### PR TITLE
Ignore only git object files by default

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -294,7 +294,7 @@
                         "**/package-lock.json",
                         "**/node_modules/**",
                         "**/vscode-extension/**",
-                        "**/.git/**",
+                        "**/.git/objects/**",
                         ".vscode"
                     ],
                     "description": "Specify paths/files to ignore. (Supports Globs)"


### PR DESCRIPTION
Fixes #342.

This makes it so by default, only files under `.git/objects` are ignored instead of everything under `.git`.

I don't know if this is the best fix for the issue so I'd appreciate your feedback.