### PR TITLE
Add link to cspell's dictionaries package [README]

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If anything shows up, then the port is still locked.
 Improvements to existing word lists and new word lists are welcome.
 
 All dictionaries are being migrated to [cspell-dicts](https://github.com/Jason3S/cspell-dicts).
-Some dictionaries are still located at [cspell](https://github.com/Jason3S/cspell)/dictionaries.
+Some dictionaries are still located at [cspell](https://github.com/Jason3S/cspell)/[dictionaries](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell-lib/dictionaries).
 
 ### Format for Dictionary Word lists
 


### PR DESCRIPTION
While opening a pull request to add a term to the software terms dictionary, it took me a while to figure out which package does it belong to. So, I've updated the README file to include a link to the dictionaries package of cspell.

Thanks!