### PR TITLE
Add .cspell.json to paths checked for config file

### DIFF
--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -23,6 +23,7 @@ export const baseConfigName        = CSpellSettings.defaultFileName;
 export const configFileLocations = [
     baseConfigName,
     baseConfigName.toLowerCase(),
+    `.${baseConfigName.toLowerCase()}`,
     `.vscode/${baseConfigName}`,
     `.vscode/${baseConfigName.toLowerCase()}`,
 ];


### PR DESCRIPTION
Hi!

The main cSpell package lists `.cspell.json` as one of the paths checked for the configuration file[0]. However the vscode plugin omits that filename, so sending this PR to add it.

Please let me know if anything else should be done here.

Thanks!

[0]: https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell#customization