### PR TITLE
Emit warning for failure in updateSettingInConfig.

### DIFF
--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -404,7 +404,21 @@ export async function updateSettingInConfig<K extends keyof CSpellUserSettings>(
     const cspellResult = await updateCSpellFile(settingsFilename, orig.value);
     // Only update VS Code config if we do not have `cspell.json` file or is it a forceUpdate.
     const configResult = (!cspellResult || forceUpdateVSCode) && await updateConfig();
-    return !!configResult;
+    const success = cspellResult || !!configResult;
+
+    const extractedTarget = config.extractTarget(target);
+    const targetName = ConfigurationTarget[extractedTarget];
+
+    if (!cspellResult) {
+        if (configResult) {
+            vscode.window.showWarningMessage(`cSpell: Failed to update cSpell configuration for target ${targetName}; updated VSCode configuration instead.`);
+        }
+        else {
+            vscode.window.showErrorMessage(`cSpell: Failed to update cSpell or VSCode configuration for target ${targetName}.`);
+        }
+    }
+
+    return success;
 }
 
 performance.mark('settings.ts done');


### PR DESCRIPTION
This change introduces warning and error messages for failures in updateSettingInConfig. This function first tries to update the cSpell config file and then the VSCode settings. In case the first fails but the second succeeds, a warning message is emitted. In case both fail an error message is emitted.

This change is meant to fix #463, implementing the first of the proposed resolutions from that issue.