### PR TITLE
Adding Gist/SFTP support

### DIFF
--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -6,7 +6,9 @@
   "properties": {
     "allowedSchemas": {
       "default": [
+        "gist",
         "file",
+        "sftp",
         "untitled"
       ],
       "description": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).",

--- a/packages/_server/src/documentSettings.ts
+++ b/packages/_server/src/documentSettings.ts
@@ -52,7 +52,7 @@ const defaultExclude: Glob[] = [
     '__pycache__/**',   // ignore cache files.
 ];
 
-const defaultAllowedSchemes = ['file', 'untitled'];
+const defaultAllowedSchemes = ['gist', 'file', 'sftp', 'untitled'];
 const schemeBlackList = ['git', 'output', 'debug', 'vscode'];
 
 const defaultRootUri = Uri.file('').toString();

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -440,7 +440,9 @@
                         "type": "string"
                     },
                     "default": [
+                        "gist",
                         "file",
+                        "sftp",
                         "untitled"
                     ]
                 },

--- a/packages/client/src/util/uriHelper.ts
+++ b/packages/client/src/util/uriHelper.ts
@@ -1,7 +1,7 @@
 
 import * as vscode from 'vscode';
 
-export const supportedSchemes = ['file', 'untitled'];
+export const supportedSchemes = ['gist', 'file', 'sftp', 'untitled'];
 export const setOfSupportedSchemes = new Set(supportedSchemes);
 
 export function isSupportedUri(uri?: vscode.Uri): boolean {


### PR DESCRIPTION
This PR simply adds support for the spell checker to run on files that are provided by the `gist` and `sftp` virtual file systems.

// CC @Jason3S 