### PR TITLE
fix: Make sure to listen for all settings changes.

### DIFF
--- a/packages/_server/src/server.ts
+++ b/packages/_server/src/server.ts
@@ -156,8 +156,9 @@ function run() {
         const { uri, languageId } = params;
         const fileEnabled = uri ? !await isUriExcluded(uri) : undefined;
         const settings = await getActiveUriSettings(uri);
+        const languageEnabled = languageId && uri ? await isLanguageEnabled({ uri, languageId }, settings) : undefined;
         return {
-            languageEnabled: languageId && uri ? await isLanguageEnabled({ uri, languageId }, settings) : undefined,
+            languageEnabled,
             fileEnabled,
         };
     }

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -20,7 +20,7 @@ export function handlerApplyTextEdits(client: LanguageClient) {
                 window.showInformationMessage('Spelling changes are outdated and cannot be applied to the document.');
             }
             const propertyFixSpellingWithRenameProvider: SpellCheckerSettingsProperties = 'fixSpellingWithRenameProvider';
-            const cfg = workspace.getConfiguration(CSpellSettings.sectionCSpell);
+            const cfg = workspace.getConfiguration(Settings.sectionCSpell);
             if (cfg.get(propertyFixSpellingWithRenameProvider) && edits.length === 1) {
                 console.log(`${propertyFixSpellingWithRenameProvider} Enabled`);
                 const edit = edits[0];

--- a/packages/client/src/settings/CSpellSettings.ts
+++ b/packages/client/src/settings/CSpellSettings.ts
@@ -6,8 +6,6 @@ import { unique, uniqueFilter } from '../util';
 
 const currentSettingsFileVersion = '0.1';
 
-export const sectionCSpell = 'cSpell';
-
 export const defaultFileName = 'cSpell.json';
 
 export interface CSpellSettings extends CSpellUserSettingsWithComments {

--- a/packages/client/src/statusbar.ts
+++ b/packages/client/src/statusbar.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { CSpellClient } from './client';
 import * as infoViewer from './infoViewer';
 import { isSupportedUri, isSupportedDoc } from './util';
-import { sectionCSpell } from './settings/CSpellSettings';
+import { sectionCSpell } from './settings';
 
 
 export function initStatusBar(context: ExtensionContext, client: CSpellClient) {


### PR DESCRIPTION
This is to hand a bug in the language-server that will not trigger settings changes if the value didn't exist when the server was started.
