### PR TITLE
Fix: enabled languages

### DIFF
--- a/packages/_server/src/documentSettings.ts
+++ b/packages/_server/src/documentSettings.ts
@@ -309,7 +309,7 @@ function applyEnableFiletypes(enableFiletypes: string[], settings: CSpellUserSet
             enabled.add(lang)
         }
     });
-    return enabled.size ? { ...rest, enabledLanguageIds: [...enabled] } : { ...rest };
+    return  enabled.size || settings.enabledLanguageIds !== undefined ? { ...rest, enabledLanguageIds: [...enabled] } : { ...rest };
 }
 
 const correctRegExMap = new Map([

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -253,8 +253,8 @@
                         "yaml",
                         "yml"
                     ],
-                    "deprecationMessage": "Deprecated, use `cSpell.enableFiletypes` to Enable / Disable checking files types.",
-                    "description": "Specify file types to spell check.",
+                    "description": "Specify file types to spell check. Use `cSpell.enableFiletypes` to Enable / Disable checking files types.",
+                    "markdownDescription": "Specify a list of file types to spell check. It is better to use `cSpell.enableFiletypes` to Enable / Disable checking files types.",
                     "uniqueItems": true
                 },
                 "cSpell.import": {


### PR DESCRIPTION
Indicate that `enableLanguageIds` is not deprecated.