### PR TITLE
fix: Adjust the workspace resolver paths

### DIFF
--- a/packages/_server/src/WorkspacePathResolver.test.ts
+++ b/packages/_server/src/WorkspacePathResolver.test.ts
@@ -220,31 +220,27 @@ describe('Validate workspace substitution resolver', () => {
     test('resolveSettings languageSettings', () => {
         const resolver = createWorkspaceNamesResolver(workspaces[1], workspaces, undefined);
         const result = resolveSettings(settingsLanguageSettings, resolver);
-        expect(result?.languageSettings?.[0]).toEqual({
-            languageId: 'typescript',
-            dictionaryDefinitions: [
-                { name: 'My Dictionary',      path: (`${rootUri.fsPath}/words.txt`)},
-                { name: 'Company Dictionary', path: (`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
-                { name: 'Project Dictionary', path: (`${rootUri.fsPath}/terms/terms.txt` )},
-            ]
-        });
+        expect(result?.languageSettings?.[0].languageId).toEqual('typescript');
+        expect(normalizePath(result?.languageSettings?.[0].dictionaryDefinitions)).toEqual([
+            { name: 'My Dictionary',      path: p(`${rootUri.fsPath}/words.txt`)},
+            { name: 'Company Dictionary', path: p(`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
+            { name: 'Project Dictionary', path: p(`${rootUri.fsPath}/terms/terms.txt` )},
+        ]);
     });
 
     test('resolveSettings overrides', () => {
         const resolver = createWorkspaceNamesResolver(workspaces[1], workspaces, undefined);
         const result = resolveSettings(settingsOverride, resolver);
-        expect(result?.overrides?.[0]?.languageSettings?.[0]).toEqual({
-            languageId: 'typescript',
-            dictionaryDefinitions: [
-                { name: 'My Dictionary',      path: (`${rootUri.fsPath}/words.txt`)},
-                { name: 'Company Dictionary', path: (`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
-                { name: 'Project Dictionary', path: (`${rootUri.fsPath}/terms/terms.txt`)},
-            ]
-        });
-        expect(result?.overrides?.[0]?.dictionaryDefinitions).toEqual([
-            { name: 'My Dictionary',      path: (`${rootUri.fsPath}/words.txt`)},
-            { name: 'Company Dictionary', path: (`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
-            { name: 'Project Dictionary', path: (`${rootUri.fsPath}/terms/terms.txt`)},
+        expect(result?.overrides?.[0]?.languageSettings?.[0].languageId).toEqual('typescript');
+        expect(normalizePath(result?.overrides?.[0].dictionaryDefinitions)).toEqual([
+            { name: 'My Dictionary',      path: p(`${rootUri.fsPath}/words.txt`)},
+            { name: 'Company Dictionary', path: p(`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
+            { name: 'Project Dictionary', path: p(`${rootUri.fsPath}/terms/terms.txt` )},
+        ]);
+        expect(normalizePath(result?.overrides?.[0]?.dictionaryDefinitions)).toEqual([
+            { name: 'My Dictionary',      path: p(`${rootUri.fsPath}/words.txt`)},
+            { name: 'Company Dictionary', path: p(`${rootUri.fsPath}/node_modules/@company/terms/terms.txt`)},
+            { name: 'Project Dictionary', path: p(`${rootUri.fsPath}/terms/terms.txt`)},
         ]);
         expect(result?.overrides?.[0]?.ignorePaths).toEqual([
             '**/node_modules/**',

--- a/packages/_server/src/WorkspacePathResolver.test.ts
+++ b/packages/_server/src/WorkspacePathResolver.test.ts
@@ -82,9 +82,9 @@ describe('Validate WorkspacePathResolver', () => {
 
 describe('Validate workspace substitution resolver', () => {
     const rootPath = '/path to root/root';
-    const clientPath = Path.normalize(Path.join(rootPath, 'client'));
-    const serverPath = Path.normalize(Path.join(rootPath, '_server'));
-    const clientTestPath = Path.normalize(Path.join(clientPath, 'test'));
+    const clientPath = Path.join(rootPath, 'client');
+    const serverPath = Path.join(rootPath, '_server');
+    const clientTestPath = Path.join(clientPath, 'test');
     const rootUri = Uri.file(rootPath);
     const clientUri = Uri.file(clientPath);
     const serverUri = Uri.file(serverPath);
@@ -230,14 +230,14 @@ describe('Validate workspace substitution resolver', () => {
             languageId: 'typescript',
             dictionaryDefinitions: [
                 { name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`},
-                { name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`},
-                { name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt` },
+                { name: 'Company Dictionary', path: `${rootUri.fsPath}/node_modules/@company/terms/terms.txt`},
+                { name: 'Project Dictionary', path: `${rootUri.fsPath}/terms/terms.txt` },
             ]
         });
         expect(result?.overrides?.[0]?.dictionaryDefinitions).toEqual([
             { name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`},
-            { name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`},
-            { name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt` },
+            { name: 'Company Dictionary', path: `${rootUri.fsPath}/node_modules/@company/terms/terms.txt`},
+            { name: 'Project Dictionary', path: `${rootUri.fsPath}/terms/terms.txt` },
         ]);
         expect(result?.overrides?.[0]?.ignorePaths).toEqual([
             '**/node_modules/**',
@@ -278,7 +278,7 @@ describe('Validate workspace substitution resolver', () => {
         expect(result.dictionaryDefinitions).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 name: 'Folder Dictionary',
-                path: expect.stringMatching(/^[/\\]path to root[/\\]root[/\\]client[/\\]packages[/\\]_server[/\\]words\.txt$/),
+                path: `${clientUri.fsPath}/packages/_server/words.txt`,
             }),
             expect.objectContaining({
                 name: 'Folder Dictionary 2',

--- a/packages/_server/src/WorkspacePathResolver.test.ts
+++ b/packages/_server/src/WorkspacePathResolver.test.ts
@@ -123,7 +123,7 @@ describe('Validate workspace substitution resolver', () => {
             '${workspaceFolder}/cspell.json',
             '${workspaceFolder:Client}/cspell.json',
             '${workspaceFolder:Server}/cspell.json',
-            '${workspaceFolder:Root}/cspell.json',
+            '${workspaceRoot}/cspell.json',
             '${workspaceFolder:Failed}/cspell.json',
             'path/${workspaceFolder:Client}/cspell.json',
         ]
@@ -146,7 +146,7 @@ describe('Validate workspace substitution resolver', () => {
             },
             {
                 name: 'Company Dictionary',
-                path: '${workspaceFolder}/node_modules/@company/terms/terms.txt'
+                path: '${root}/node_modules/@company/terms/terms.txt'
             },
             {
                 name: 'Project Dictionary',
@@ -180,7 +180,7 @@ describe('Validate workspace substitution resolver', () => {
         const result = resolveSettings(settingsImports, resolver);
         expect(result.import).toEqual([
             'cspell.json',
-            `${clientUri.fsPath}/cspell.json`,
+            `${rootUri.fsPath}/cspell.json`,
             `${clientUri.fsPath}/cspell.json`,
             `${serverUri.fsPath}/cspell.json`,
             `${rootUri.fsPath}/cspell.json`,
@@ -205,7 +205,7 @@ describe('Validate workspace substitution resolver', () => {
         const result = resolveSettings(settingsDictionaryDefinitions, resolver);
         expect(result.dictionaryDefinitions).toEqual([
             expect.objectContaining({ name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`}),
-            expect.objectContaining({ name: 'Company Dictionary', path: `${clientUri.fsPath}/node_modules/@company/terms/terms.txt`}),
+            expect.objectContaining({ name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`}),
             expect.objectContaining({ name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt`}),
         ]);
     });
@@ -217,7 +217,7 @@ describe('Validate workspace substitution resolver', () => {
             languageId: 'typescript',
             dictionaryDefinitions: [
                 { name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`},
-                { name: 'Company Dictionary', path: `${clientUri.fsPath}/node_modules/@company/terms/terms.txt`},
+                { name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`},
                 { name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt` },
             ]
         });
@@ -230,13 +230,13 @@ describe('Validate workspace substitution resolver', () => {
             languageId: 'typescript',
             dictionaryDefinitions: [
                 { name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`},
-                { name: 'Company Dictionary', path: `${clientUri.fsPath}/node_modules/@company/terms/terms.txt`},
+                { name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`},
                 { name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt` },
             ]
         });
         expect(result?.overrides?.[0]?.dictionaryDefinitions).toEqual([
             { name: 'My Dictionary', path: `${rootUri.fsPath}/words.txt`},
-            { name: 'Company Dictionary', path: `${clientUri.fsPath}/node_modules/@company/terms/terms.txt`},
+            { name: 'Company Dictionary', path: `${rootPath}/node_modules/@company/terms/terms.txt`},
             { name: 'Project Dictionary', path: `${rootPath}/terms/terms.txt` },
         ]);
         expect(result?.overrides?.[0]?.ignorePaths).toEqual([
@@ -278,11 +278,11 @@ describe('Validate workspace substitution resolver', () => {
         expect(result.dictionaryDefinitions).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 name: 'Folder Dictionary',
-                path: 'custom root/packages/_server/words.txt',
+                path: expect.stringMatching(/^[/\\]path to root[/\\]root[/\\]client[/\\]packages[/\\]_server[/\\]words\.txt$/),
             }),
             expect.objectContaining({
                 name: 'Folder Dictionary 2',
-                path: expect.stringMatching(/^[/\\]path to root[/\\]root[/\\]client[/\\]words2\.txt$/),
+                path: 'custom root/words2.txt',
             }),
         ]));
     });

--- a/packages/_server/src/WorkspacePathResolver.ts
+++ b/packages/_server/src/WorkspacePathResolver.ts
@@ -168,7 +168,7 @@ function createWorkspaceNameToPathResolver(
         return match;
     }
 
-    return (path: string) => {
+    return (path: string): string => {
         return path.replace(regEx, replacer);
     };
 }

--- a/packages/_server/src/WorkspacePathResolver.ts
+++ b/packages/_server/src/WorkspacePathResolver.ts
@@ -136,20 +136,29 @@ function createWorkspaceNameToGlobResolver(folder: FolderPath, folders: FolderPa
     };
 }
 
+/**
+ *
+ * @param currentFolder
+ * @param folders
+ * @param root
+ */
 function createWorkspaceNameToPathResolver(
-    folder: FolderPath,
+    currentFolder: FolderPath,
     folders: FolderPath[],
     root: string | undefined
 ): WorkspacePathResolverFn {
-    const folderPairs = [['${workspaceFolder}', folder.path] as [string, string]]
+    const folderPairs = ([] as [string, string][])
         .concat([
-            ['.', root || folders[0]?.path || folder.path],
+            ['.', currentFolder.path ],
             ['~', os.homedir()],
+            ['${workspaceFolder}', root || folders[0]?.path || currentFolder.path],
+            ['${root}', root || folders[0]?.path || currentFolder.path],
+            ['${workspaceRoot}', root || folders[0]?.path || currentFolder.path],
         ])
         .concat(folders.map(folder => [`\${workspaceFolder:${ folder.name }}`, folder.path]
         ));
     const map = new Map(folderPairs);
-    const regEx = /^(?:\.|~|\$\{workspaceFolder(?:[^}]*)\})/i;
+    const regEx = /^(?:\.|~|\$\{(?:workspaceFolder|workspaceRoot|root)(?:[^}]*)\})/i;
 
     function replacer(match: string): string {
         const r = map.get(match);


### PR DESCRIPTION
New Resolver
- `.` => current workspace folder
- `~` => User Home
- `${root}` | `${workspaceRoot}` => workspace root
- `${workspaceFolder[:folder name]}` => workspace folder matching name.