### PR TITLE
Adds missing file extension to main entry point

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -36,7 +36,7 @@
     "activationEvents": [
         "*"
     ],
-    "main": "./dist/extension",
+    "main": "./dist/extension.js",
     "contributes": {
         "menus": {
             "editor/context": [


### PR DESCRIPTION
Fixes:
- streetsidesoftware/vscode-cspell-dict-extensions#21
- streetsidesoftware/vscode-cspell-dict-extensions#35
- streetsidesoftware/vscode-cspell-dict-extensions#46
- streetsidesoftware/vscode-cspell-dict-extensions#50
