### PR TITLE
Don't link to outdated extension

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -61,7 +61,6 @@ Open up VS Code and hit `F1` and type `ext` select install and type `code-spell-
 ## Add-On Specialized Dictionaries
 
 - [Medical Terms](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker-medical-terms)
-- [Fullstack](https://marketplace.visualstudio.com/items?itemName=rbalet.code-spell-checker-fullstack)
 
 ## Enabled File Types
 


### PR DESCRIPTION
See https://github.com/streetsidesoftware/cspell-dicts/issues/271

Or, if this is still desired, maybe the extension should be updated and ownership transferred to `streetsidesoftware`