### PR TITLE
Add julia to languageIds.ts

### DIFF
--- a/packages/client/src/settings/languageIds.ts
+++ b/packages/client/src/settings/languageIds.ts
@@ -22,6 +22,7 @@ export const languageIds: string[] = [
     'javascript',
     'javascriptreact',
     'json',
+    'julia',
     'less',
     'lua',
     'makefile',


### PR DESCRIPTION
Hi, this plugin is really helpful to me.

But it really took me a while to figure out why it didn't work in the julia programming language files. So I'd propose to add `julia` in the settings.

Thanks for your awesome work!