### PR TITLE
fix: remove HexDigit from predefined patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,6 @@ def sum_it(self, seq):
 ### Exclude patterns
 
 -   `Urls`<sup>1</sup> -- Matches urls
--   `HexDigits` -- Matches hex digits: `/^x?[0-1a-f]+$/i`
 -   `HexValues` -- Matches common hex format like #aaa, 0xfeef, \\u0134
 -   `EscapeCharacters`<sup>1</sup> -- matches special characters: '\\n', '\\t' etc.
 -   `Base64`<sup>1</sup> -- matches base64 blocks of text longer than 40 characters.


### PR DESCRIPTION
The current definition of HexDigit is not very useful, since it will not match anything except at the beginning of a document.