### PR TITLE
fix: Turn off `virtualWorkspaces` and `untrustedWorkspaces`

### DIFF
--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -83,6 +83,7 @@ tslib
 typechecking
 unelevated
 untracked
+untrusted
 uri's
 visualstudio
 vsce

--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
   ],
   "main": "./packages/client/dist/extension.js",
   "contributes": {
+    "virtualWorkspaces": false,
+    "untrustedWorkspaces": {
+      "supported": false
+    },
     "menus": {
       "editor/context": [
         {


### PR DESCRIPTION
Explicitly turn off support for `virtualWorkspaces` and `untrustedWorkspaces` until further investigation is possible.
See #846 and #839.