### PR TITLE
fix: #541 - Only split the selection on word boundaries

### DIFF
--- a/fixtures/workspaces/yarn2/yarn2-test-med/custom-terms.txt
+++ b/fixtures/workspaces/yarn2/yarn2-test-med/custom-terms.txt
@@ -1,2 +1,4 @@
 # Contains custom terms for this project.
+geschäft
 medicalterms
+spéciale

--- a/packages/_server/src/server.ts
+++ b/packages/_server/src/server.ts
@@ -20,7 +20,7 @@ import * as Validator from './validator';
 import { ReplaySubject, Subscription, timer } from 'rxjs';
 import { filter, tap, debounce, debounceTime, mergeMap, take } from 'rxjs/operators';
 import { onCodeActionHandler } from './codeActions';
-import { Glob, Text } from 'cspell-lib';
+import { Glob } from 'cspell-lib';
 
 import * as CSpell from 'cspell-lib';
 import { CSpellUserSettings } from './config/cspellConfig';
@@ -38,6 +38,7 @@ import { log, logError, logger, logInfo, LogLevel, setWorkspaceBase, setWorkspac
 import { PatternMatcher, MatchResult, RegExpMatches } from './PatternMatcher';
 import { DictionaryWatcher } from './config/dictionaryWatcher';
 import { ConfigWatcher } from './config/configWatcher';
+import { textToWords } from './utils';
 
 log('Starting Spell Checker Server');
 
@@ -236,15 +237,6 @@ export function run(): void {
             id: ex.settings.id,
             name: ex.settings.name,
         }));
-    }
-
-    function textToWords(text: string): string[] {
-        const setOfWords = new Set(
-            Text.extractWordsFromCode(text)
-                .map((t) => t.text)
-                .map((t) => t.toLowerCase())
-        );
-        return [...setOfWords];
     }
 
     function handleSplitTextIntoWords(text: string): Api.SplitTextIntoWordsResult {

--- a/packages/_server/src/utils/index.ts
+++ b/packages/_server/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { uniqueFilter, isDefined } from './util';
+export { uniqueFilter, isDefined, textToWords } from './util';

--- a/packages/_server/src/utils/util.test.ts
+++ b/packages/_server/src/utils/util.test.ts
@@ -31,6 +31,7 @@ describe('Validate Util Functions', () => {
         ${'My $trip to the café was 4un!'} | ${['My', 'trip', 'to', 'the', 'café', 'was', '4un']}
         ${"winter's...weather"}            | ${["winter's", 'weather']}
         ${'one\ntwo\nthree\n'}             | ${['one', 'two', 'three']}
+        ${'one-two-three\n'}               | ${['one-two-three']}
         ${'spéciale geschäft'}             | ${['spéciale', 'geschäft']}
         ${'aåáâäñãæ'}                      | ${['aåáâäñãæ']}
     `('textToWords "$line"', ({ line, expected }: TestTextToWords) => {

--- a/packages/_server/src/utils/util.test.ts
+++ b/packages/_server/src/utils/util.test.ts
@@ -1,4 +1,4 @@
-import { uniqueFilter, isDefined } from './util';
+import { uniqueFilter, isDefined, textToWords } from './util';
 
 describe('Validate Util Functions', () => {
     test('Unique filter', () => {
@@ -9,13 +9,36 @@ describe('Validate Util Functions', () => {
         const b = { id: 'b', v: 1 };
         const aa = { id: 'a', v: 2 };
         expect([a, a, b, aa, b].filter(uniqueFilter())).toEqual([a, b, aa]);
-        expect([a, a, b, aa, b, aa].filter(uniqueFilter(a => a.id))).toEqual([a, b]);
+        expect([a, a, b, aa, b, aa].filter(uniqueFilter((a) => a.id))).toEqual([a, b]);
     });
 
     test('isDefined', () => {
         const values = ['hello', 'how', undefined, 'are', 'you', null, '?'];
         const strings: string[] = values.filter(isDefined);
-        expect(values).toEqual(expect.arrayContaining([undefined, null, 'you']))
+        expect(values).toEqual(expect.arrayContaining([undefined, null, 'you']));
         expect(strings).toEqual(expect.not.arrayContaining([undefined, null]));
     });
+
+    interface TestTextToWords {
+        line: string;
+        expected: string[];
+    }
+    test.each`
+        line                               | expected
+        ${'hello'}                         | ${['hello']}
+        ${'hello|there'}                   | ${'hello|there'.split('|')}
+        ${'coffee|at|the|café'}            | ${'coffee|at|the|café'.split('|')}
+        ${'My $trip to the café was 4un!'} | ${['My', 'trip', 'to', 'the', 'café', 'was', '4un']}
+        ${"winter's...weather"}            | ${["winter's", 'weather']}
+        ${'one\ntwo\nthree\n'}             | ${['one', 'two', 'three']}
+        ${'spéciale geschäft'}             | ${['spéciale', 'geschäft']}
+        ${'aåáâäñãæ'}                      | ${['aåáâäñãæ']}
+    `('textToWords "$line"', ({ line, expected }: TestTextToWords) => {
+        const r = textToWords(line);
+        expect(r).toEqual(expected);
+        const r2 = textToWords(line.normalize('NFD'));
+        expect(r2).toEqual(expected);
+    });
+
+    // cspell:ignore spéciale geschäft aåáâäñãæ
 });

--- a/packages/_server/src/utils/util.ts
+++ b/packages/_server/src/utils/util.ts
@@ -22,3 +22,16 @@ export function isDefined<T>(v: T | undefined | null): v is T {
 export function escapeRegExp(s: string): string {
     return s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
 }
+
+/**
+ * Breaks a string along word boundaries and removes an non-words.
+ * @param text - text to split
+ * @returns array of words
+ */
+export function textToWords(text: string): string[] {
+    const isWord = /^[\p{L}\w']+$/u;
+    const regExpWordBreaks = /(?<![\p{L}\w'])(?=[\p{L}\w'])|(?<=[\p{L}\w'])(?![\p{L}\w'])/gu;
+    const split = text.normalize('NFC').split(regExpWordBreaks);
+    const words = split.filter((w) => isWord.test(w));
+    return words;
+}

--- a/packages/_server/src/utils/util.ts
+++ b/packages/_server/src/utils/util.ts
@@ -29,8 +29,8 @@ export function escapeRegExp(s: string): string {
  * @returns array of words
  */
 export function textToWords(text: string): string[] {
-    const isWord = /^[\p{L}\w']+$/u;
-    const regExpWordBreaks = /(?<![\p{L}\w'])(?=[\p{L}\w'])|(?<=[\p{L}\w'])(?![\p{L}\w'])/gu;
+    const isWord = /^[\p{L}\w'-]+$/u;
+    const regExpWordBreaks = /(?<![\p{L}\w'-])(?=[\p{L}\w'-])|(?<=[\p{L}\w'-])(?![\p{L}\w'-])/gu;
     const split = text.normalize('NFC').split(regExpWordBreaks);
     const words = split.filter((w) => isWord.test(w));
     return words;

--- a/packages/client/src/settings/CSpellSettings.ts
+++ b/packages/client/src/settings/CSpellSettings.ts
@@ -77,7 +77,7 @@ export function writeSettings(filename: Uri, settings: CSpellSettings): Promise<
 }
 
 export function addWordToSettingsAndUpdate(filename: Uri, word: string): Promise<CSpellSettings> {
-    return readSettingsFileAndApplyUpdate(filename, (settings) => addWordsToSettings(settings, normalizeWord(word)));
+    return readSettingsFileAndApplyUpdate(filename, (settings) => addWordsToSettings(settings, normalizeWords(word)));
 }
 
 export function addWordsToSettings(settings: CSpellSettings, wordsToAdd: string[]): CSpellSettings {
@@ -86,7 +86,7 @@ export function addWordsToSettings(settings: CSpellSettings, wordsToAdd: string[
 }
 
 export function addIgnoreWordToSettingsAndUpdate(filename: Uri, word: string): Promise<CSpellSettings> {
-    return readSettingsFileAndApplyUpdate(filename, (settings) => addIgnoreWordsToSettings(settings, normalizeWord(word)));
+    return readSettingsFileAndApplyUpdate(filename, (settings) => addIgnoreWordsToSettings(settings, normalizeWords(word)));
 }
 
 export function addIgnoreWordsToSettings(settings: CSpellSettings, wordsToAdd: string[]): CSpellSettings {
@@ -116,7 +116,7 @@ export function filterOutWords(words: string[], wordsToRemove: string[]): string
 }
 
 export function removeWordFromSettingsAndUpdate(filename: Uri, word: string): Promise<CSpellSettings> {
-    return readSettingsFileAndApplyUpdate(filename, (settings) => removeWordsFromSettings(settings, normalizeWord(word)));
+    return readSettingsFileAndApplyUpdate(filename, (settings) => removeWordsFromSettings(settings, normalizeWords(word)));
 }
 
 export function addLanguageIdsToSettings(settings: CSpellSettings, languageIds: string[], onlyIfExits: boolean): CSpellSettings {
@@ -162,8 +162,11 @@ export async function readSettingsFileAndApplyUpdate(
     return writeSettings(cspellConfigUri, newSettings);
 }
 
-export function normalizeWord(word: string): string[] {
-    return [word].map((a) => a.trim()).filter((a) => !!a);
+export function normalizeWords(words: string): string[] {
+    return words
+        .split(' ')
+        .map((a) => a.trim())
+        .filter((a) => !!a);
 }
 
 export function isUpdateSupportedForConfigFileFormat(uri: Uri): boolean {

--- a/packages/client/src/settings/DictionaryHelper.ts
+++ b/packages/client/src/settings/DictionaryHelper.ts
@@ -4,7 +4,7 @@ import * as config from './config';
 import { resolveTarget, addWordToSettings, determineSettingsPaths } from './settings';
 import { Uri } from 'vscode';
 import * as vscode from 'vscode';
-import { addWordToSettingsAndUpdate } from './CSpellSettings';
+import { addWordToSettingsAndUpdate, normalizeWords } from './CSpellSettings';
 import type {
     CSpellUserSettings,
     CustomDictionaryScope,
@@ -25,6 +25,13 @@ interface CustomDictionaryWithPath {
 export class DictionaryHelper {
     constructor(public client: CSpellClient) {}
 
+    /**
+     * Add word or words to the configuration
+     * @param word - a single word or multiple words separated with a space.
+     * @param target - where the word should be written: Folder, Workspace, User
+     * @param docUri - the related document (helps to determine the configuration location)
+     * @returns the promise resolves upon completion.
+     */
     public async addWordToTarget(word: string, target: Target, docUri: Uri | undefined): Promise<void> {
         const actualTarget = resolveTarget(target, docUri);
         const docConfig = await this.getDocConfig(docUri);
@@ -34,7 +41,7 @@ export class DictionaryHelper {
             return this.addWordsToConfig(word, actualTarget, docConfig);
         }
 
-        await this.addWordsToCustomDictionaries([word], customDicts);
+        await this.addWordsToCustomDictionaries(normalizeWords(word), customDicts);
         return this.client.notifySettingsChanged();
     }
 

--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -2,7 +2,7 @@ import { performance } from '../util/perf';
 performance.mark('settings.ts');
 import { CSpellUserSettings, normalizeLocale as normalizeLocale } from '../server';
 import {
-    normalizeWord,
+    normalizeWords,
     configFileLocations,
     defaultFileName as baseConfigName,
     readSettings,
@@ -133,20 +133,20 @@ export async function disableLanguage(target: config.ConfigTarget, languageId: s
 
 export function addWordToSettings(target: config.ConfigTarget, word: string): Promise<boolean> {
     const useGlobal = config.isGlobalTarget(target) || !hasWorkspaceLocation();
-    const addWords = normalizeWord(word);
+    const addWords = normalizeWords(word);
     const section: 'userWords' | 'words' = useGlobal ? 'userWords' : 'words';
     return updateSettingInConfig(section, target, (words) => unique(addWords.concat(words || []).sort()), true);
 }
 
 export function addIgnoreWordToSettings(target: config.ConfigTarget, word: string): Promise<boolean> {
-    const addWords = normalizeWord(word);
+    const addWords = normalizeWords(word);
     return updateSettingInConfig('ignoreWords', target, (words) => unique(addWords.concat(words || []).sort()), true);
 }
 
 export async function removeWordFromSettings(target: config.ConfigTarget, word: string): Promise<boolean> {
     const useGlobal = config.isGlobalTarget(target);
     const section: 'userWords' | 'words' = useGlobal ? 'userWords' : 'words';
-    const toRemove = normalizeWord(word);
+    const toRemove = normalizeWords(word);
     return updateSettingInConfig(section, target, (words) => filterOutWords(words || [], toRemove), true);
 }
 


### PR DESCRIPTION
Make sure words are only split along word boundaries.

