### PR TITLE
dev: Create configTargets to allow sorted config changes

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -54,8 +54,8 @@
     ],
     "languageSettings": [
         {
-            "languageId": "markdown",
-            "dictionaries": []
+            "languageId": "*",
+            "allowCompoundWords": false
         }
     ]
 }

--- a/packages/_server/jest.config.js
+++ b/packages/_server/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
         '^.+\\.tsx?$': 'ts-jest'
     },
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec|perf))\\.tsx?$',
+    // collectCoverageFrom: ['src/**/*.ts'],
     moduleFileExtensions: [
         'ts',
         'tsx',

--- a/packages/_server/src/__snapshots__/commands.test.ts.snap
+++ b/packages/_server/src/__snapshots__/commands.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validate Commands clientCommands.addWordsToConfigFileFromServer 1`] = `
+Object {
+  "arguments": Array [
+    Array [
+      "one",
+      "two",
+    ],
+    "file:///document.ts",
+    Object {
+      "name": "Workspace Config",
+      "uri": "file:///cspell.json",
+    },
+  ],
+  "command": "cSpell.addWordsToConfigFileFromServer",
+  "title": "Add to CSpell",
+}
+`;
+
+exports[`Validate Commands clientCommands.addWordsToDictionaryFileFromServer 1`] = `
+Object {
+  "arguments": Array [
+    Array [
+      "one",
+      "two",
+    ],
+    "file:///document.ts",
+    Object {
+      "name": "Custom Terms",
+      "uri": "file:///dictionary.txt",
+    },
+  ],
+  "command": "cSpell.addWordsToDictionaryFileFromServer",
+  "title": "Add to dictionary",
+}
+`;
+
+exports[`Validate Commands clientCommands.addWordsToVSCodeSettingsFromServer 1`] = `
+Object {
+  "arguments": Array [
+    Array [
+      "one",
+      "two",
+    ],
+    "file:///document.ts",
+    "workspace",
+  ],
+  "command": "cSpell.addWordsToVSCodeSettingsFromServer",
+  "title": "Add to VS Code",
+}
+`;

--- a/packages/_server/src/api.ts
+++ b/packages/_server/src/api.ts
@@ -1,4 +1,5 @@
 import type * as config from './config/cspellConfig';
+import type { ConfigTarget } from './config/configTargets';
 
 export type {
     LanguageSetting,
@@ -106,6 +107,7 @@ export interface GetConfigurationForDocumentResult {
     docSettings: config.CSpellUserSettings | undefined;
     excludedBy: ExcludeRef[] | undefined;
     configFiles: UriString[];
+    configTargets: ConfigTarget[];
 }
 
 export interface ExcludeRef {

--- a/packages/_server/src/clientApi.test.ts
+++ b/packages/_server/src/clientApi.test.ts
@@ -1,0 +1,53 @@
+import { createClientApi } from './clientApi';
+import { mocked } from 'ts-jest/utils';
+import { Connection } from 'vscode-languageserver';
+import { OnSpellCheckDocumentStep, WorkspaceConfigForDocumentRequest } from './api';
+
+const stub: any = {
+    sendNotification: jest.fn(),
+    sendRequest: jest.fn(),
+};
+const connection = stub as Connection;
+
+const mockConnection = mocked(connection, true);
+
+describe('Validate Client Api', () => {
+    beforeEach(() => {
+        mockConnection.sendNotification.mockClear();
+        mockConnection.sendRequest.mockClear();
+    });
+
+    test('sendOnSpellCheckDocument', () => {
+        const api = createClientApi(connection);
+        const p: OnSpellCheckDocumentStep = {
+            uri: 'uri',
+            seq: 1,
+            step: 'step',
+            ts: 1,
+            version: 1,
+        };
+        api.sendOnSpellCheckDocument(p);
+        expect(mockConnection.sendNotification).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                method: 'onSpellCheckDocument',
+                numberOfParams: 1,
+            }),
+            p
+        );
+    });
+
+    test('sendOnWorkspaceConfigForDocumentRequest', () => {
+        const api = createClientApi(connection);
+        const req: WorkspaceConfigForDocumentRequest = {
+            uri: 'uri',
+        };
+        api.sendOnWorkspaceConfigForDocumentRequest(req);
+        expect(mockConnection.sendRequest).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                method: 'onWorkspaceConfigForDocumentRequest',
+                numberOfParams: 1,
+            }),
+            req
+        );
+    });
+});

--- a/packages/_server/src/codeAction.test.ts
+++ b/packages/_server/src/codeAction.test.ts
@@ -1,0 +1,8 @@
+import { onCodeActionHandler } from './codeActions';
+
+describe('Validate CodeAction', () => {
+    test('onCodeActionHandler', () => {
+        // Place holder test.
+        expect(typeof onCodeActionHandler).toBe('function');
+    });
+});

--- a/packages/_server/src/commands.test.ts
+++ b/packages/_server/src/commands.test.ts
@@ -1,0 +1,32 @@
+import { clientCommands } from './commands';
+
+describe('Validate Commands', () => {
+    test('clientCommands', () => {
+        // Place holder test.
+        expect(clientCommands).toBeDefined();
+    });
+
+    test('clientCommands.addWordsToConfigFileFromServer', () => {
+        expect(
+            clientCommands.addWordsToConfigFileFromServer('Add to CSpell', ['one', 'two'], 'file:///document.ts', {
+                uri: 'file:///cspell.json',
+                name: 'Workspace Config',
+            })
+        ).toMatchSnapshot();
+    });
+
+    test('clientCommands.addWordsToDictionaryFileFromServer', () => {
+        expect(
+            clientCommands.addWordsToDictionaryFileFromServer('Add to dictionary', ['one', 'two'], 'file:///document.ts', {
+                uri: 'file:///dictionary.txt',
+                name: 'Custom Terms',
+            })
+        ).toMatchSnapshot();
+    });
+
+    test('clientCommands.addWordsToVSCodeSettingsFromServer', () => {
+        expect(
+            clientCommands.addWordsToVSCodeSettingsFromServer('Add to VS Code', ['one', 'two'], 'file:///document.ts', 'workspace')
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/_server/src/commands.ts
+++ b/packages/_server/src/commands.ts
@@ -17,6 +17,9 @@ const clientCommandsKeys: CreateClientSideCommandKeys = {
     addWordsToVSCodeSettingsFromServer: 'addWordsToVSCodeSettingsFromServer',
 };
 
+/**
+ * API to create commands to be sent to the Client
+ */
 export const clientCommands: CreateClientSideCommand = {
     addWordsToConfigFileFromServer: (title: string, ...params) =>
         Command.create(title, prefix + clientCommandsKeys.addWordsToConfigFileFromServer, ...params),

--- a/packages/_server/src/config/configTargets.test.ts
+++ b/packages/_server/src/config/configTargets.test.ts
@@ -1,0 +1,142 @@
+import {
+    ConfigKind,
+    ConfigKinds,
+    ConfigScope,
+    ConfigScopes,
+    ConfigTarget,
+    ConfigTargetCSpell,
+    ConfigTargetDictionary,
+    ConfigTargetVSCode,
+    isConfigTargetOfKind,
+    isConfigTargetCSpell,
+    isConfigTargetDictionary,
+    isConfigTargetVSCode,
+    weight,
+} from './configTargets';
+
+describe('Validate ConfigTarget', () => {
+    const targetDict = t(ConfigKinds.Dictionary, ConfigScopes.Unknown);
+    const targetCSpell = t(ConfigKinds.Cspell, ConfigScopes.Unknown);
+    const targetVSCode = t(ConfigKinds.Vscode, ConfigScopes.Unknown);
+
+    test.each`
+        target          | kind                      | expected
+        ${{}}           | ${ConfigKinds.Dictionary} | ${false}
+        ${{}}           | ${ConfigKinds.Cspell}     | ${false}
+        ${{}}           | ${ConfigKinds.Vscode}     | ${false}
+        ${targetDict}   | ${ConfigKinds.Dictionary} | ${true}
+        ${targetDict}   | ${ConfigKinds.Cspell}     | ${false}
+        ${targetDict}   | ${ConfigKinds.Vscode}     | ${false}
+        ${targetCSpell} | ${ConfigKinds.Dictionary} | ${false}
+        ${targetCSpell} | ${ConfigKinds.Cspell}     | ${true}
+        ${targetCSpell} | ${ConfigKinds.Vscode}     | ${false}
+        ${targetVSCode} | ${ConfigKinds.Dictionary} | ${false}
+        ${targetVSCode} | ${ConfigKinds.Cspell}     | ${false}
+        ${targetVSCode} | ${ConfigKinds.Vscode}     | ${true}
+    `('isA $kind $target ', ({ target, expected, kind }) => {
+        const isA = fnIsA(kind);
+        expect(isA(target)).toBe(expected);
+    });
+
+    test.each`
+        target          | kind                      | expected
+        ${{}}           | ${ConfigKinds.Dictionary} | ${false}
+        ${{}}           | ${ConfigKinds.Cspell}     | ${false}
+        ${{}}           | ${ConfigKinds.Vscode}     | ${false}
+        ${targetDict}   | ${ConfigKinds.Dictionary} | ${true}
+        ${targetDict}   | ${ConfigKinds.Cspell}     | ${false}
+        ${targetDict}   | ${ConfigKinds.Vscode}     | ${false}
+        ${targetCSpell} | ${ConfigKinds.Dictionary} | ${false}
+        ${targetCSpell} | ${ConfigKinds.Cspell}     | ${true}
+        ${targetCSpell} | ${ConfigKinds.Vscode}     | ${false}
+        ${targetVSCode} | ${ConfigKinds.Dictionary} | ${false}
+        ${targetVSCode} | ${ConfigKinds.Cspell}     | ${false}
+        ${targetVSCode} | ${ConfigKinds.Vscode}     | ${true}
+    `('isConfigTargetOfKind $kind $target ', ({ target, expected, kind }) => {
+        expect(isConfigTargetOfKind(target, kind)).toBe(expected);
+    });
+
+    test.each`
+        kindA                     | scopeA                  | kindB                     | scopeB                  | comment
+        ${ConfigKinds.Dictionary} | ${ConfigScopes.Unknown} | ${ConfigKinds.Vscode}     | ${ConfigScopes.User}    | ${'User scope is lowest'}
+        ${ConfigKinds.Dictionary} | ${ConfigScopes.User}    | ${ConfigKinds.Vscode}     | ${ConfigScopes.User}    | ${'User scope is lowest'}
+        ${ConfigKinds.Dictionary} | ${ConfigScopes.Folder}  | ${ConfigKinds.Dictionary} | ${ConfigScopes.User}    | ${'User scope is lowest'}
+        ${ConfigKinds.Vscode}     | ${ConfigScopes.Folder}  | ${ConfigKinds.Dictionary} | ${ConfigScopes.User}    | ${'User scope is lowest'}
+        ${ConfigKinds.Cspell}     | ${ConfigScopes.Unknown} | ${ConfigKinds.Dictionary} | ${ConfigScopes.User}    | ${'User scope is lowest'}
+        ${ConfigKinds.Dictionary} | ${ConfigScopes.Folder}  | ${ConfigKinds.Cspell}     | ${ConfigScopes.Unknown} | ${'Prefer dictionary over cspell'}
+    `('weight of $kindA/$scopeA is greater than $kindB/$scopeB', ({ kindA, scopeA, kindB, scopeB }) => {
+        const a = t(kindA, scopeA);
+        const b = t(kindB, scopeB);
+        expect(weight(a)).toBeGreaterThan(weight(b));
+    });
+
+    test.each`
+        kind
+        ${ConfigKinds.Dictionary}
+        ${ConfigKinds.Vscode}
+        ${ConfigKinds.Cspell}
+    `('weight of $kind vs scope is correct', ({ kind }) => {
+        expect(weight(t(kind, ConfigScopes.Unknown))).toBeGreaterThanOrEqual(weight(t(kind, ConfigScopes.Folder)));
+        expect(weight(t(kind, ConfigScopes.Folder))).toBeGreaterThan(weight(t(kind, ConfigScopes.Workspace)));
+        expect(weight(t(kind, ConfigScopes.Workspace))).toBeGreaterThan(weight(t(kind, ConfigScopes.User)));
+    });
+
+    test.each`
+        scope
+        ${ConfigScopes.Unknown}
+        ${ConfigScopes.Folder}
+        ${ConfigScopes.Workspace}
+        ${ConfigScopes.User}
+    `('weight of $scope vs kind is correct', ({ scope }) => {
+        expect(weight(t(ConfigKinds.Dictionary, scope))).toBeGreaterThan(weight(t(ConfigKinds.Cspell, scope)));
+        expect(weight(t(ConfigKinds.Cspell, scope))).toBeGreaterThan(weight(t(ConfigKinds.Vscode, scope)));
+    });
+});
+
+function t(kind: ConfigKind, scope: ConfigScope): ConfigTarget {
+    switch (kind) {
+        case ConfigKinds.Dictionary:
+            return tDict(scope);
+        case ConfigKinds.Cspell:
+            return tCspell(scope);
+        case ConfigKinds.Vscode:
+            return tVSCode(scope);
+    }
+}
+
+function fnIsA(kind: ConfigKind): (t: ConfigTarget) => boolean {
+    switch (kind) {
+        case ConfigKinds.Dictionary:
+            return isConfigTargetDictionary;
+        case ConfigKinds.Cspell:
+            return isConfigTargetCSpell;
+        case ConfigKinds.Vscode:
+            return isConfigTargetVSCode;
+    }
+}
+
+function tDict(scope: ConfigScope): ConfigTargetDictionary {
+    return {
+        kind: 'dictionary',
+        scope,
+        name: 'Custom Words',
+        dictionaryUri: '',
+    };
+}
+
+function tCspell(scope: ConfigScope): ConfigTargetCSpell {
+    return {
+        kind: 'cspell',
+        scope,
+        name: 'Custom Words',
+        configUri: '',
+    };
+}
+
+function tVSCode(scope: ConfigScope): ConfigTargetVSCode {
+    return {
+        kind: 'vscode',
+        scope,
+        docUri: '',
+    };
+}

--- a/packages/_server/src/config/configTargets.ts
+++ b/packages/_server/src/config/configTargets.ts
@@ -1,0 +1,101 @@
+export type ConfigKind = 'cspell' | 'dictionary' | 'vscode';
+export type ConfigScope = 'user' | 'workspace' | 'folder' | 'unknown';
+
+type CombineWithScope<T extends string> = {
+    [key in ConfigScope as `${T}_${key}`]: number;
+};
+
+type ConfigWeights = CombineWithScope<ConfigKind>;
+
+const configWeights: ConfigWeights = {
+    dictionary_unknown: 330,
+    dictionary_folder: 330,
+    dictionary_workspace: 320,
+    dictionary_user: 130,
+    cspell_unknown: 220,
+    cspell_folder: 219,
+    cspell_workspace: 218,
+    cspell_user: 120,
+    vscode_unknown: 210,
+    vscode_folder: 210,
+    vscode_workspace: 200,
+    vscode_user: 110,
+};
+
+type UriString = string;
+
+interface ConfigTargetBase {
+    kind: ConfigKind;
+    scope: ConfigScope;
+    docUri?: UriString;
+}
+
+export interface ConfigTargetDictionary extends ConfigTargetBase {
+    kind: 'dictionary';
+    name: string;
+    dictionaryUri: UriString;
+}
+
+export interface ConfigTargetCSpell extends ConfigTargetBase {
+    kind: 'cspell';
+    name: string;
+    configUri: UriString;
+}
+
+export interface ConfigTargetVSCode extends ConfigTargetBase {
+    kind: 'vscode';
+    docUri: UriString;
+}
+
+export type ConfigTarget = ConfigTargetDictionary | ConfigTargetCSpell | ConfigTargetVSCode;
+
+type ConfigKinds = {
+    [key in ConfigKind as `${Capitalize<key>}`]: key;
+};
+
+type ConfigScopes = {
+    [key in ConfigScope as `${Capitalize<key>}`]: key;
+};
+
+type ConfigKindToTarget = {
+    [key in ConfigTarget['kind']]: key extends ConfigTargetDictionary['kind']
+        ? ConfigTargetDictionary
+        : key extends ConfigTargetCSpell['kind']
+        ? ConfigTargetCSpell
+        : key extends ConfigTargetVSCode['kind']
+        ? ConfigTargetVSCode
+        : never;
+};
+
+export const ConfigKinds: ConfigKinds = {
+    Dictionary: 'dictionary',
+    Cspell: 'cspell',
+    Vscode: 'vscode',
+};
+
+export const ConfigScopes: ConfigScopes = {
+    Unknown: 'unknown',
+    User: 'user',
+    Workspace: 'workspace',
+    Folder: 'folder',
+};
+
+function isA<T extends ConfigTarget>(kind: T['kind']) {
+    return (t: T | ConfigTarget): t is T => typeof t === 'object' && t.kind === kind;
+}
+
+export function isConfigTargetOfKind<K extends ConfigKind>(t: ConfigKindToTarget[K] | ConfigTarget, kind: K): t is ConfigKindToTarget[K] {
+    return typeof t === 'object' && t.kind === kind;
+}
+
+export const isConfigTargetDictionary = isA<ConfigTargetDictionary>(ConfigKinds.Dictionary);
+export const isConfigTargetCSpell = isA<ConfigTargetCSpell>(ConfigKinds.Cspell);
+export const isConfigTargetVSCode = isA<ConfigTargetVSCode>(ConfigKinds.Vscode);
+
+export function weight(target: ConfigTarget): number {
+    return configWeights[toWeightKey(target)];
+}
+
+function toWeightKey(target: ConfigTarget): keyof ConfigWeights {
+    return `${target.kind}_${target.scope}`;
+}

--- a/packages/_server/src/config/vscode.config.test.ts
+++ b/packages/_server/src/config/vscode.config.test.ts
@@ -1,0 +1,8 @@
+import { getConfiguration } from './vscode.config';
+
+describe('Validate vscode config', () => {
+    test('getConfiguration', () => {
+        // Placeholder test.
+        expect(getConfiguration).toBeDefined();
+    });
+});

--- a/packages/_server/src/progressNotifier.test.ts
+++ b/packages/_server/src/progressNotifier.test.ts
@@ -1,0 +1,44 @@
+import { mocked } from 'ts-jest/utils';
+import { Connection } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { createProgressNotifier } from './progressNotifier';
+import { createClientApi } from './clientApi';
+
+jest.mock('./clientApi');
+
+const mockedCreateClientApi = mocked(createClientApi);
+// const mockedCreateConnection = mocked(createConnection);
+
+mockedCreateClientApi.mockImplementation(() => {
+    return {
+        sendOnSpellCheckDocument: jest.fn(),
+        sendOnWorkspaceConfigForDocumentRequest: jest.fn(),
+    };
+});
+
+const stub: any = {};
+const connection = stub as Connection;
+
+describe('Validate Progress Notifier', () => {
+    test('createProgressNotifier', async () => {
+        const clientApi = createClientApi(connection);
+        const notifier = createProgressNotifier(clientApi);
+        const mockSendOnSpellCheckDocument = mocked(clientApi.sendOnSpellCheckDocument);
+
+        expect(notifier.emitSpellCheckDocumentStep).toBeDefined();
+
+        const doc = TextDocument.create('file:///doc.txt', 'plaintext', 1, 'Some text');
+        await notifier.emitSpellCheckDocumentStep(doc, 'test 1');
+        expect(mockSendOnSpellCheckDocument).toBeCalledWith(
+            expect.objectContaining({
+                done: false,
+                numIssues: undefined,
+                // seq: 1,
+                step: 'test 1',
+                // ts: 1626082854948,
+                uri: 'file:///doc.txt',
+                version: 1,
+            })
+        );
+    });
+});

--- a/packages/_server/src/server.test.ts
+++ b/packages/_server/src/server.test.ts
@@ -1,0 +1,8 @@
+import { run } from './server';
+
+describe('Validate Server', () => {
+    test('run', () => {
+        // place holder
+        expect(run).toBeDefined();
+    });
+});

--- a/packages/_server/src/server.ts
+++ b/packages/_server/src/server.ts
@@ -225,6 +225,7 @@ export function run(): void {
             docSettings,
             excludedBy,
             configFiles,
+            configTargets: [],
         };
     }
 


### PR DESCRIPTION
ConfigTarget is a structure that allows configuration change destinations to be sorted in preferred order.

The idea is to move the logic to the server, having it in one place.