### PR TITLE
fix: Block checking of minified documents to prevent high-cpu usage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2303,6 +2303,24 @@
           },
           "type": "array",
           "scope": "resource"
+        },
+        "cSpell.blockCheckingWhenAverageChunkSizeGreatherThan": {
+          "default": 40,
+          "description": "The maximum average chunk of text size. A chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.blockCheckingWhenLineLengthGreaterThan": {
+          "default": 1000,
+          "description": "The maximum line length",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
+          "default": 200,
+          "description": "The maximum size of text chunks",
+          "scope": "resource",
+          "type": "number"
         }
       }
     }

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -25,6 +25,24 @@
       "scope": "window",
       "type": "array"
     },
+    "blockCheckingWhenAverageChunkSizeGreatherThan": {
+      "default": 40,
+      "description": "The maximum average chunk of text size. A chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`",
+      "scope": "resource",
+      "type": "number"
+    },
+    "blockCheckingWhenLineLengthGreaterThan": {
+      "default": 1000,
+      "description": "The maximum line length",
+      "scope": "resource",
+      "type": "number"
+    },
+    "blockCheckingWhenTextChunkSizeGreaterThan": {
+      "default": 200,
+      "description": "The maximum size of text chunks",
+      "scope": "resource",
+      "type": "number"
+    },
     "caseSensitive": {
       "description": "Words must match case rules.",
       "markdownDescription": "Turns on case sensitive checking by default",

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -19,7 +19,7 @@ export type {
     LanguageSetting,
 } from '@cspell/cspell-types';
 
-export interface SpellCheckerSettings {
+export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings {
     /**
      * The limit in K-Characters to be checked in a file.
      * @scope resource
@@ -231,6 +231,29 @@ type EnableCustomDictionary = boolean;
  * @patternErrorMessage "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space."
  */
 type EnableFileTypeId = string;
+
+interface SpellCheckerShouldCheckDocSettings {
+    /**
+     * The maximum line length
+     * @scope resource
+     * @default 1000
+     */
+    blockCheckingWhenLineLengthGreaterThan?: number;
+    /**
+     * The maximum size of text chunks
+     * @scope resource
+     * @default 200
+     */
+    blockCheckingWhenTextChunkSizeGreaterThan?: number;
+    /**
+     * The maximum average chunk of text size.
+     * A chunk is the characters between absolute word breaks.
+     * Absolute word breaks match: `/[\s,{}[\]]/`
+     * @scope resource
+     * @default 40
+     */
+    blockCheckingWhenAverageChunkSizeGreatherThan?: number;
+}
 
 export type CustomDictionaries = {
     [Name in DictionaryId]: EnableCustomDictionary | CustomDictionariesDictionary;

--- a/packages/_server/src/utils/analysis.test.ts
+++ b/packages/_server/src/utils/analysis.test.ts
@@ -1,0 +1,93 @@
+import {
+    isTextLikelyMinified,
+    IsTextLikelyMinifiedOptions,
+    ReasonAverageWordsSize,
+    ReasonLineLength,
+    ReasonMaxWordsSize,
+} from './analysis';
+import * as FS from 'fs';
+import * as Path from 'path';
+
+const sampleWebpack = FS.readFileSync(Path.join(__dirname, '../../dist/main.js'), 'utf8');
+
+const defaultOptions: IsTextLikelyMinifiedOptions = {
+    blockCheckingWhenLineLengthGreaterThan: 1000,
+    blockCheckingWhenAverageChunkSizeGreatherThan: 40,
+    blockCheckingWhenTextChunkSizeGreaterThan: 180,
+};
+
+//cspell:dictionaries lorem-ipsum
+
+const lines = [
+    'Commodo ex ex sit ad. Ex esse aliqua excepteur in aliqua amet sunt. Culpa non non esse est incididunt ullamco est Lorem',
+    'est pariatur. Ullamco ex est nisi id veniam laboris consectetur velit. Eu tempor deserunt tempor anim. Aute culpa id dolor',
+    'ea commodo labore enim. Pariatur sit consequat qui nostrud ullamco adipisicing dolore consequat ad mollit culpa excepteur',
+    'est pariatur. Ullamco ex est nisi id veniam laboris consectetur velit. Eu tempor deserunt tempor anim. Aute culpa id dolor',
+    'reprehenderit. eu nulla do Lorem mollit ut incididunt excepteur. Labore voluptate ex est occaecat. Proident laborum incididunt',
+    'ad officia ea sint commodo pariatur. Adipisicing in cupidatat laboris excepteur tempor exercitation amet reprehenderit ipsum ad qui.',
+    'reprehenderit. eu nulla do Lorem mollit ut incididunt excepteur. Labore voluptate ex est occaecat. Proident laborum incididunt',
+    'Adipisicing irure nisi enim ipsum mollit culpa officia do pariatur adipisicing. In sint esse quis do velit sint commodo sit labore',
+    'commodo quis. Dolore Lorem quis ullamco incididunt cupidatat ex duis dolore officia.',
+];
+
+const longLine = lines.slice(0, 5).join(' ');
+
+function sampleText50() {
+    return genSampleParagraphs(50);
+}
+function sampleText200() {
+    return genSampleParagraphs(200);
+}
+function sampleLongLine() {
+    return genSampleLongLine().replace(/\s/g, '-');
+}
+function sampleLines200() {
+    return genLines(200);
+}
+
+function genSampleParagraphs(count: number) {
+    const paragraph1 = lines.slice(0, 3).join(' ');
+    const paragraph2 = lines.slice(3, 8).join(' ');
+    const paragraph3 = lines.slice(7).join(' ');
+    return joinSamples(count, [paragraph1, paragraph2, paragraph3, paragraph2, paragraph3, paragraph1]);
+}
+
+function genLines(count: number) {
+    return joinSamples(count, lines);
+}
+
+function joinSamples(count: number, samples: string[]): string {
+    const parts: string[] = [];
+
+    for (let i = 0, j = 0; i < count; ++i, j = (j + 1) % samples.length) {
+        parts.push(samples[j]);
+    }
+
+    return parts.join('\n');
+}
+
+function genSampleLongLine() {
+    return longLine;
+}
+
+describe('analysis', () => {
+    test.each`
+        text                                                             | opts  | expected
+        ${''}                                                            | ${{}} | ${false}
+        ${'\n\n'}                                                        | ${{}} | ${false}
+        ${'{}'}                                                          | ${{}} | ${false}
+        ${'{}\n'}                                                        | ${{}} | ${false}
+        ${sampleText50()}                                                | ${{}} | ${false}
+        ${sampleLines200()}                                              | ${{}} | ${false}
+        ${sampleText50().replace(/ /g, '-')}                             | ${{}} | ${ReasonAverageWordsSize}
+        ${sampleText50().replace(/\s/g, ',')}                            | ${{}} | ${ReasonLineLength}
+        ${sampleText200()}                                               | ${{}} | ${false}
+        ${sampleText200().replace(/ /g, '-')}                            | ${{}} | ${ReasonAverageWordsSize}
+        ${sampleText200().replace(/\s/g, ',')}                           | ${{}} | ${ReasonLineLength}
+        ${sampleWebpack}                                                 | ${{}} | ${ReasonLineLength}
+        ${[sampleText50(), sampleLongLine(), sampleText50()].join('\n')} | ${{}} | ${ReasonMaxWordsSize}
+    `('isTextLikelyMinified $#', ({ text, opts, expected }) => {
+        const options = Object.assign({}, defaultOptions, opts);
+        expect(isTextLikelyMinified(text, options)).toBe(expected);
+    });
+});

--- a/packages/_server/src/utils/analysis.ts
+++ b/packages/_server/src/utils/analysis.ts
@@ -1,0 +1,63 @@
+import { genSequence } from 'gensequence';
+
+export const ReasonLineLength = 'Lines are too long.' as const;
+export const ReasonAverageWordsSize = 'Average Word Size is Too High' as const;
+export const ReasonMaxWordsSize = 'Maximum Word Length is Too High' as const;
+
+type MinifiedReasons = typeof ReasonLineLength | typeof ReasonAverageWordsSize | typeof ReasonMaxWordsSize;
+
+export interface IsTextLikelyMinifiedOptions {
+    /** The maximum line length */
+    blockCheckingWhenLineLengthGreaterThan: number;
+    /** The maximum size of text chunks */
+    blockCheckingWhenTextChunkSizeGreaterThan: number;
+    /**
+     * The maximum average chunk size.
+     * A chunk is the characters between absolute word breaks.
+     * Absolute word breaks match: `/[\s,{}[\]]/`
+     */
+    blockCheckingWhenAverageChunkSizeGreatherThan: number;
+}
+
+export const defaultIsTextLikelyMinifiedOptions: IsTextLikelyMinifiedOptions = {
+    blockCheckingWhenLineLengthGreaterThan: 1000,
+    blockCheckingWhenTextChunkSizeGreaterThan: 200,
+    blockCheckingWhenAverageChunkSizeGreatherThan: 40,
+};
+
+/**
+ * Check if a document is minified making spell checking difficult and slow.
+ *
+ * @param doc - document to check.
+ * @returns true - if the file might be minified.
+ */
+export function isTextLikelyMinified(text: string, options: IsTextLikelyMinifiedOptions): MinifiedReasons | false {
+    const lineBreaks = [0].concat(
+        genSequence(text.matchAll(/\n/g))
+            .map((a) => a.index || 0)
+            .take(100)
+            .toArray()
+    );
+    if (lineBreaks.length < 100) lineBreaks.push(text.length);
+
+    const first100 = genSequence(lineBreaks)
+        .scan((a, b) => [a[1], b], [0, 0])
+        .map(([a, b]) => text.slice(a, b).trim())
+        .filter((a) => !!a)
+        .toArray();
+
+    const over1k = genSequence(first100).first((a) => a.length > options.blockCheckingWhenLineLengthGreaterThan);
+    if (over1k) return ReasonLineLength;
+
+    const sampleText = first100.join('\n');
+    const chunks = [...sampleText.matchAll(/[\s,{}[\]]+/g)].map((a) => a.index || 0);
+    chunks.push(sampleText.length);
+    const wordCount = chunks.length;
+    const avgChunkSize = sampleText.length / wordCount;
+    if (avgChunkSize > options.blockCheckingWhenAverageChunkSizeGreatherThan) return ReasonAverageWordsSize;
+
+    const maxChunkSize = chunks.reduce((a, b) => [b, Math.max(a[1], b - a[0])], [0, 0])[1];
+    if (maxChunkSize > options.blockCheckingWhenTextChunkSizeGreaterThan) return ReasonMaxWordsSize;
+
+    return false;
+}

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -9,6 +9,9 @@ type CSpellUserSettingsFields = {
 export const ConfigKeysByField: CSpellUserSettingsFields = {
     allowCompoundWords: 'allowCompoundWords',
     allowedSchemas: 'allowedSchemas',
+    blockCheckingWhenAverageChunkSizeGreatherThan: 'blockCheckingWhenAverageChunkSizeGreatherThan',
+    blockCheckingWhenLineLengthGreaterThan: 'blockCheckingWhenLineLengthGreaterThan',
+    blockCheckingWhenTextChunkSizeGreaterThan: 'blockCheckingWhenTextChunkSizeGreaterThan',
     caseSensitive: 'caseSensitive',
     checkLimit: 'checkLimit',
     customDictionaries: 'customDictionaries',


### PR DESCRIPTION
Adds the following settings:

```typescript
interface SpellCheckerShouldCheckDocSettings {
    /**
     * The maximum line length
     * @scope resource
     * @default 1000
     */
    blockCheckingWhenLineLengthGreaterThan?: number;
    /**
     * The maximum size of text chunks
     * @scope resource
     * @default 200
     */
    blockCheckingWhenTextChunkSizeGreaterThan?: number;
    /**
     * The maximum average chunk of text size.
     * A chunk is the characters between absolute word breaks.
     * Absolute word breaks match: `/[\s,{}[\]]/`
     * @scope resource
     * @default 40
     */
    blockCheckingWhenAverageChunkSizeGreatherThan?: number;
}
```