### PR TITLE
fix: Make suggestions menu consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -2324,17 +2324,17 @@
         },
         "cSpell.suggestionMenuType": {
           "default": "quickPick",
-          "description": "Which menu type is used for suggestions.",
           "enum": [
             "quickPick",
             "quickFix"
           ],
           "enumDescriptions": [
-            "Suggestions will appear in the suggestion bar at the IDE top",
-            "Suggestions will appear near the word, inside the text editor"
+            "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
+            "Suggestions will appear inline near the word, inside the text editor."
           ],
           "scope": "resource",
-          "type": "string"
+          "type": "string",
+          "markdownDescription": "The type of menu used to display spelling suggestions."
         }
       }
     }

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1934,15 +1934,15 @@
     },
     "suggestionMenuType": {
       "default": "quickPick",
-      "description": "Which menu type is used for suggestions.",
       "enum": [
         "quickPick",
         "quickFix"
       ],
       "enumDescriptions": [
-        "Suggestions will appear in the suggestion bar at the IDE top",
-        "Suggestions will appear near the word, inside the text editor"
+        "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
+        "Suggestions will appear inline near the word, inside the text editor."
       ],
+      "markdownDescription": "The type of menu used to display spelling suggestions.",
       "scope": "resource",
       "type": "string"
     },

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -201,6 +201,17 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     spellCheckOnlyWorkspaceFiles?: boolean;
 
     /**
+     * @scope resource
+     * @markdownDescription
+     * The type of menu used to display spelling suggestions.
+     * @default "quickPick"
+     * @enumDescriptions [
+     *  "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
+     *  "Suggestions will appear inline near the word, inside the text editor."]
+     */
+    suggestionMenuType?: 'quickPick' | 'quickFix';
+
+    /**
      * Show Regular Expression Explorer
      * @scope application
      * @default false
@@ -599,16 +610,6 @@ interface CSpellSettingsPackageProperties extends CSpellSettings {
      * @scope resource
      */
     noSuggestDictionaries?: CSpellSettings['noSuggestDictionaries'];
-
-    /**
-     * @scope resource
-     * @description Which menu type is used for suggestions.
-     * @default "quickPick"
-     * @enumDescriptions [
-     *  "Suggestions will appear in the suggestion bar at the IDE top",
-     *  "Suggestions will appear near the word, inside the text editor"]
-     */
-    suggestionMenuType?: 'quickPick' | 'quickFix';
 }
 
 /**

--- a/packages/client/src/settings/DictionaryHelper.ts
+++ b/packages/client/src/settings/DictionaryHelper.ts
@@ -16,7 +16,7 @@ import type {
 } from '../client';
 import { scrollToText } from '../util/textEditor';
 import { ClientConfigTarget } from './clientConfigTarget';
-import { ConfigKeysByField } from './configFields';
+import { ConfigFields } from './configFields';
 import { ConfigRepository, CSpellConfigRepository, VSCodeRepository } from './configRepository';
 import { dictionaryTargetBestMatches, MatchTargetsFn } from './configTargetHelper';
 import { configUpdaterForKeys } from './configUpdater';
@@ -294,7 +294,7 @@ async function addCustomDictionaryToConfig(cfgRep: ConfigRepository, def: Dictio
 
 function updaterForCustomDictionaryToConfigCSpell(def: DictionaryDefinitionCustom) {
     const name = def.name;
-    return configUpdaterForKeys([ConfigKeysByField.dictionaries, ConfigKeysByField.dictionaryDefinitions], (cfg) => {
+    return configUpdaterForKeys([ConfigFields.dictionaries, ConfigFields.dictionaryDefinitions], (cfg) => {
         const { dictionaries = [], dictionaryDefinitions = [] } = cfg;
         const defsByName = new Map(dictionaryDefinitions.map((d) => [d.name, d]));
         const dictNames = new Set(dictionaries);
@@ -313,10 +313,10 @@ function updaterForCustomDictionaryToConfigVSCode(def: DictionaryDefinitionCusto
     const name = def.name;
     return configUpdaterForKeys(
         [
-            ConfigKeysByField.customDictionaries,
-            ConfigKeysByField.customFolderDictionaries,
-            ConfigKeysByField.customWorkspaceDictionaries,
-            ConfigKeysByField.customUserDictionaries,
+            ConfigFields.customDictionaries,
+            ConfigFields.customFolderDictionaries,
+            ConfigFields.customWorkspaceDictionaries,
+            ConfigFields.customUserDictionaries,
         ],
         (cfg) => {
             const { customDictionaries, ...rest } = combineCustomDictionaries(cfg);

--- a/packages/client/src/settings/configFields.test.ts
+++ b/packages/client/src/settings/configFields.test.ts
@@ -1,8 +1,8 @@
-import { ConfigKeysByField } from './configFields';
+import { ConfigFields } from './configFields';
 
 describe('Validate configFields', () => {
     test('ConfigKeysByField', () => {
-        const entries = Object.entries(ConfigKeysByField);
+        const entries = Object.entries(ConfigFields);
         expect(entries.length).toBeGreaterThan(0);
         for (const [key, value] of entries) {
             expect(value).toBe(key);

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -6,7 +6,7 @@ type CSpellUserSettingsFields = {
     [key in ConfigKeys]: key;
 };
 
-export const ConfigKeysByField: CSpellUserSettingsFields = {
+export const ConfigFields: CSpellUserSettingsFields = {
     allowCompoundWords: 'allowCompoundWords',
     allowedSchemas: 'allowedSchemas',
     blockCheckingWhenAverageChunkSizeGreatherThan: 'blockCheckingWhenAverageChunkSizeGreatherThan',

--- a/packages/client/src/settings/configRepository.ts
+++ b/packages/client/src/settings/configRepository.ts
@@ -2,7 +2,7 @@ import { uriToName } from 'common-utils/uriHelper.js';
 import { pick } from 'common-utils/util.js';
 import { ConfigurationTarget, Uri, workspace, WorkspaceFolder } from 'vscode';
 import { CSpellUserSettings, CustomDictionaryScope } from '../client';
-import { ConfigKeysByField } from './configFields';
+import { ConfigFields } from './configFields';
 import { ConfigFileReaderWriter, createConfigFileReaderWriter } from './configFileReadWrite';
 import { ConfigUpdater, configUpdaterForKey } from './configUpdater';
 import { configurationTargetToDictionaryScope } from './targetAndScope';
@@ -154,14 +154,14 @@ export class VSCodeRepository extends ConfigRepositoryBase {
         if (this.target !== ConfigurationTarget.Global) return { fn, keys: neededKeys };
 
         const keys = new Set(neededKeys);
-        if (keys.has(ConfigKeysByField.words)) {
-            keys.add(ConfigKeysByField.userWords);
+        if (keys.has(ConfigFields.words)) {
+            keys.add(ConfigFields.userWords);
         }
 
         function userWordsToWords(cfg: CSpellUserSettings): CSpellUserSettings {
             const { userWords, words, ...rest } = cfg;
             const c: CSpellUserSettings = { ...rest };
-            if (keys.has(ConfigKeysByField.userWords) || userWords || words) {
+            if (keys.has(ConfigFields.userWords) || userWords || words) {
                 c.words = userWords?.concat(words ?? []) ?? words;
             }
             return c;
@@ -170,7 +170,7 @@ export class VSCodeRepository extends ConfigRepositoryBase {
         function wordsToUserWords(cfg: CSpellUserSettings): CSpellUserSettings {
             const { words, userWords, ...cfgResult } = cfg;
             const r: CSpellUserSettings = { ...cfgResult };
-            if (Object.keys(cfg).includes(ConfigKeysByField.words)) {
+            if (Object.keys(cfg).includes(ConfigFields.words)) {
                 r.words = undefined;
                 r.userWords = words?.concat(userWords || []);
             }

--- a/packages/client/src/settings/index.ts
+++ b/packages/client/src/settings/index.ts
@@ -1,3 +1,4 @@
 export * from './settings';
 export * from './vsConfig';
 export { CSpellSettings, configFilesToWatch } from './CSpellSettings';
+export { ConfigFields } from './configFields';


### PR DESCRIPTION
Have the right click spelling suggestions menu option and the Find Next/Previous Issue use the same suggestions menu.

@elazarcoh, Thank you for the help. I made a minor change.