### PR TITLE
fix: Fix References to version "0.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
 ```javascript
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct

--- a/docs/index.md
+++ b/docs/index.md
@@ -354,8 +354,8 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
 ```javascript
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -331,8 +331,8 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
 ```javascript
 // cSpell Settings
 {
-    // Version of the setting file.  Always 0.1
-    "version": "0.1",
+    // Version of the setting file.  Always 0.2
+    "version": "0.2",
     // language - current active spelling language
     "language": "en",
     // words - list of words to be always considered correct


### PR DESCRIPTION
Related to [cspell documentation lists version as always 0.1 · Issue #1638](https://github.com/streetsidesoftware/cspell/issues/1638)