### PR TITLE
fix: Fix add / remove locale from configuration

### DIFF
--- a/packages/client/docs/settings.md
+++ b/packages/client/docs/settings.md
@@ -18,3 +18,28 @@ A resource level setting that specifies the location of the `cspell.json` file.
         -   `+` indicates compound required
         -   `*` indicates optional compound
         -   ` ` (don't know yet) indicates do not suggest.
+
+# Add Remove Locale
+
+## Logic
+
+### Scope
+
+When adding / removing locales, the scope is either Global or Workspace.
+Global - means it is possible to adjust any configuration.
+Workspaces - means it is possible to adjust any configuration that is not Global.
+
+-   Targets are presented from Locale to Global.
+-   Targets _Inherit_ their values from Global to Local.
+
+### Adding Locale
+
+1. Only present targets that will have an impact.
+1. If no targets will have an impact, then present any target that can be changed.
+1. If there is only 1 target, then perform action without asking.
+
+### Removing Locale
+
+1. Only present targets that will have an impact.
+1. If no targets will have an impact, do nothing.
+1. If there is only 1 target, then perform action without asking.

--- a/packages/client/src/settings/CSpellSettings.test.ts
+++ b/packages/client/src/settings/CSpellSettings.test.ts
@@ -1,6 +1,6 @@
 import { Uri } from 'vscode';
-import { CSpellUserSettings } from '.';
-import { fsRemove, getPathToTemp, getUriToSample, mkdirp, readFile, writeFile, oc } from '../test/helpers';
+import { CSpellUserSettings } from '../client';
+import { fsRemove, getPathToTemp, getUriToSample, mkdirp, oc, readFile, writeFile } from '../test/helpers';
 import { unique } from '../util';
 import * as CSS from './CSpellSettings';
 import { readSettings, writeSettings } from './CSpellSettings';

--- a/packages/client/src/settings/clientConfigTarget.ts
+++ b/packages/client/src/settings/clientConfigTarget.ts
@@ -98,3 +98,27 @@ export function isClientConfigTargetOfKind<K extends ClientConfigKind>(
 export const isClientConfigTargetDictionary = isA<ClientConfigTargetDictionary>(ConfigKinds.Dictionary);
 export const isClientConfigTargetCSpell = isA<ClientConfigTargetCSpell>(ConfigKinds.Cspell);
 export const isClientConfigTargetVSCode = isA<ClientConfigTargetVSCode>(ConfigKinds.Vscode);
+
+type ScopeToOrder = {
+    [K in ClientConfigScope]: number;
+};
+
+const scopeOrderGlobalToLocal: ScopeToOrder = {
+    user: 1,
+    workspace: 2,
+    folder: 3,
+    unknown: 4,
+};
+
+function compareClientConfigScopesGlobalToLocal(a: ClientConfigScope, b: ClientConfigScope): number {
+    return scopeOrderGlobalToLocal[a] - scopeOrderGlobalToLocal[b];
+}
+
+function compareClientConfigScopesLocalToGlobal(a: ClientConfigScope, b: ClientConfigScope): number {
+    return scopeOrderGlobalToLocal[b] - scopeOrderGlobalToLocal[a];
+}
+
+export function orderScope(scopes: ClientConfigScope[], localToGlobal = true): ClientConfigScope[] {
+    const compare = localToGlobal ? compareClientConfigScopesLocalToGlobal : compareClientConfigScopesGlobalToLocal;
+    return [...scopes].sort(compare);
+}

--- a/packages/client/src/settings/index.ts
+++ b/packages/client/src/settings/index.ts
@@ -1,4 +1,27 @@
-export * from './settings';
-export * from './vsConfig';
-export { CSpellSettings, configFilesToWatch } from './CSpellSettings';
 export { ConfigFields } from './configFields';
+export { configFilesToWatch, CSpellSettings } from './CSpellSettings';
+export {
+    addIgnoreWordsToSettings,
+    ConfigTargetLegacy,
+    createConfigFileRelativeToDocumentUri,
+    disableLanguageId,
+    enableLanguageId,
+    enableLanguageIdForTarget,
+    enableLocaleForTarget,
+    setEnableSpellChecking,
+    toggleEnableSpellChecker,
+    watchSettingsFiles,
+} from './settings';
+export {
+    ConfigurationTarget,
+    getScopedSettingFromVSConfig,
+    getSettingFromVSConfig,
+    getSettingsFromVSConfig,
+    Inspect,
+    inspectConfig,
+    inspectConfigKeys,
+    InspectValues,
+    normalizeTarget,
+    Scopes,
+    sectionCSpell,
+} from './vsConfig';

--- a/packages/client/src/settings/settings.test.ts
+++ b/packages/client/src/settings/settings.test.ts
@@ -1,4 +1,6 @@
-import { hasWorkspaceLocation, addLocaleToCurrentLocale, removeLocaleFromCurrentLocale } from './settings';
+import { hasWorkspaceLocation, __testing__ } from './settings';
+
+const { addLocaleToCurrentLocale, removeLocaleFromCurrentLocale, doLocalesIntersect, isLocaleSubsetOf } = __testing__;
 
 describe('Validate settings.ts', () => {
     test('hasWorkspaceLocation', () => {
@@ -24,5 +26,30 @@ describe('Validate settings.ts', () => {
         ${'en;nl_nl'} | ${'en, nl'}   | ${'nl'}
     `('removeLocaleFromCurrentLocale $current - $locale => $expected', ({ locale, current, expected }) => {
         expect(removeLocaleFromCurrentLocale(locale, current)).toBe(expected);
+    });
+
+    test.each`
+        locale        | current       | expected
+        ${'en'}       | ${'en'}       | ${true}
+        ${'nl_nl'}    | ${'en'}       | ${false}
+        ${'nl_nl'}    | ${'en,nl-NL'} | ${true}
+        ${'nl,nl_nl'} | ${'en,nl'}    | ${true}
+        ${'en;nl_nl'} | ${'en,nl'}    | ${true}
+        ${'en;nl_nl'} | ${'en, nl'}   | ${true}
+    `('doLocalesIntersect $current ⋂ $locale => $expected', ({ locale, current, expected }) => {
+        expect(doLocalesIntersect(locale, current)).toBe(expected);
+    });
+
+    test.each`
+        locale        | current        | expected
+        ${'en'}       | ${'en'}        | ${true}
+        ${'nl_nl'}    | ${'en'}        | ${false}
+        ${'nl_nl'}    | ${'en,nl-NL'}  | ${true}
+        ${'nl,nl_nl'} | ${'en,nl'}     | ${false}
+        ${'en;nl_nl'} | ${'en,nl'}     | ${false}
+        ${'en;nl_nl'} | ${'nl-nl, en'} | ${true}
+        ${'en;nl_nl'} | ${'en, nl'}    | ${false}
+    `('doLocalesIntersect $locale ⊆ $current => $expected', ({ locale, current, expected }) => {
+        expect(isLocaleSubsetOf(locale, current)).toBe(expected);
     });
 });

--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -6,14 +6,15 @@ import { Uri, workspace } from 'vscode';
 import { CSpellUserSettings, normalizeLocale as normalizeLocale } from '../client';
 import { isDefined, unique } from '../util';
 import * as watcher from '../util/watcher';
-import { ClientConfigTarget } from './clientConfigTarget';
+import { ClientConfigScope, ClientConfigTarget, orderScope } from './clientConfigTarget';
 import { readConfigFile, writeConfigFile } from './configFileReadWrite';
-import { applyUpdateToConfigTargets } from './configRepositoryHelper';
+import { applyUpdateToConfigTargets, readFromConfigTargets } from './configRepositoryHelper';
 import {
     ConfigTargetMatchPattern,
     filterClientConfigTargets,
     patternMatchNoDictionaries,
     quickPickBestMatchTarget,
+    quickPickTarget,
     quickPickTargets,
 } from './configTargetHelper';
 import { configUpdaterForKey } from './configUpdater';
@@ -144,19 +145,78 @@ function applyToConfig<K extends keyof CSpellUserSettings>(
     return applyUpdateToConfigTargets(updater, targets);
 }
 
-export function enableLocale(targets: ClientConfigTarget[], locale: string): Promise<void> {
-    return enableLocaleForTarget(locale, true, targets);
+function readConfigTargetValues<K extends keyof CSpellUserSettings>(targets: ClientConfigTarget[], key: K) {
+    return readFromConfigTargets(key, targets);
 }
 
-export function disableLocale(targets: ClientConfigTarget[], locale: string): Promise<void> {
-    return enableLocaleForTarget(locale, false, targets);
+export function enableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
+    return enableLocaleForTarget(locale, true, targets, possibleScopes);
 }
 
-export function enableLocaleForTarget(locale: string, enable: boolean, targets: ClientConfigTarget[]): Promise<void> {
+export function disableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
+    return enableLocaleForTarget(locale, false, targets, possibleScopes);
+}
+
+/**
+ * Try to add or remove a locale from the nearest configuration.
+ * Present the user with the option to pick a target if more than one viable target is available.
+ *
+ * @param locale - locale to add or remove
+ * @param enable - true = add
+ * @param targets - all known targets
+ * @param possibleScopes - possible scopes
+ * @returns resolves when finished - rejects if an error was encountered.
+ */
+export async function enableLocaleForTarget(
+    locale: string,
+    enable: boolean,
+    targets: ClientConfigTarget[],
+    possibleScopes: ClientConfigScope[]
+): Promise<void> {
+    // Have targets inherit values.
+    targets = targets.map((t) => ({ ...t, useMerge: t.useMerge ?? t.kind === 'vscode' }));
+
+    const allowedScopes = new Set(orderScope(possibleScopes));
+    const orderedTargets = new Set(orderTargetsLocalToGlobal(targets));
+    const mapTargetsToValue = new Map(await readConfigTargetValues([...orderedTargets], 'language'));
+    const possibleTargets = new Set([...orderedTargets].filter((t) => allowedScopes.has(t.scope)));
+
+    if (!enable) {
+        // remove all non-overlapping targets.
+        [...mapTargetsToValue].filter(([_, v]) => !doLocalesIntersect(locale, v.language)).forEach(([t]) => possibleTargets.delete(t));
+    } else {
+        const keep = [...possibleTargets];
+        const targetsWithLocale = new Set([...mapTargetsToValue].filter(([_, v]) => isLocaleSubsetOf(locale, v.language)).map(([t]) => t));
+        let clear = false;
+        for (const t of possibleTargets) {
+            clear = clear || targetsWithLocale.has(t);
+            if (clear) possibleTargets.delete(t);
+        }
+        // If nothing is left, let the user pick from any of the possible set.
+        if (!possibleTargets.size) {
+            // Add back any that have not already been set.
+            keep.filter((t) => !targetsWithLocale.has(t)).forEach((t) => possibleTargets.add(t));
+        }
+    }
+
+    const t = possibleTargets.size > 1 ? await quickPickTarget([...possibleTargets]) : [...possibleTargets][0];
+    if (!t) return;
+
+    const defaultValue = calcInheritedDefault('language', t, mapTargetsToValue);
+
     const applyFn: (src: string | undefined) => string | undefined = enable
-        ? (currentLanguage) => addLocaleToCurrentLocale(locale, currentLanguage)
+        ? (currentLanguage) => addLocaleToCurrentLocale(locale, currentLanguage || defaultValue)
         : (currentLanguage) => removeLocaleFromCurrentLocale(locale, currentLanguage);
-    return setConfigFieldQuickPick(targets, 'language', applyFn);
+
+    return applyToConfig([t], 'language', applyFn);
+}
+
+function orderTargetsLocalToGlobal(targets: ClientConfigTarget[]): ClientConfigTarget[] {
+    const scopes = targets.map((t) => t.scope);
+    const orderedScopes = orderScope(scopes, true);
+    const orderedTargets: ClientConfigTarget[] = [];
+    orderedScopes.map((scope) => targets.filter((t) => t.scope === scope)).forEach((t) => t.forEach((t) => orderedTargets.push(t)));
+    return orderedTargets;
 }
 
 /**
@@ -258,7 +318,7 @@ function normalize(locale: string) {
         .filter((a) => !!a);
 }
 
-export function addLocaleToCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
+function addLocaleToCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
     const toAdd = normalize(locale);
     const currentSet = new Set(normalize(currentLocale || ''));
 
@@ -267,7 +327,7 @@ export function addLocaleToCurrentLocale(locale: string, currentLocale: string |
     return [...currentSet].join(',') || undefined;
 }
 
-export function removeLocaleFromCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
+function removeLocaleFromCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
     const toRemove = normalize(locale);
     const currentSet = new Set(normalize(currentLocale || ''));
 
@@ -275,3 +335,52 @@ export function removeLocaleFromCurrentLocale(locale: string, currentLocale: str
 
     return [...currentSet].join(',') || undefined;
 }
+
+function doLocalesIntersect(localeA: string, localeB: string): boolean;
+function doLocalesIntersect(localeA: string, localeB: undefined): false;
+function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean;
+function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean {
+    if (!localeA || !localeB) return false;
+
+    const a = new Set(normalize(localeA));
+    const b = normalize(localeB);
+    for (const locale of b) {
+        if (a.has(locale)) return true;
+    }
+    return false;
+}
+
+function isLocaleSubsetOf(localeA: string, localeB: string): boolean;
+function isLocaleSubsetOf(localeA: string, localeB: undefined): false;
+function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean;
+function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean {
+    if (!localeA || !localeB) return false;
+
+    const largerSet = new Set(normalize(localeB));
+    const smallerSet = normalize(localeA);
+    for (const locale of smallerSet) {
+        if (!largerSet.has(locale)) return false;
+    }
+    return true;
+}
+
+function calcInheritedDefault<K extends keyof CSpellUserSettings>(
+    key: K,
+    target: ClientConfigTarget,
+    targetsWithValue: Iterable<[ClientConfigTarget, CSpellUserSettings]>
+): CSpellUserSettings[K] {
+    const tv = [...targetsWithValue].reverse();
+    let value: CSpellUserSettings[K] = undefined;
+    for (const [t, v] of tv) {
+        value = v[key] ?? value;
+        if (t === target) break;
+    }
+    return value;
+}
+
+export const __testing__ = {
+    addLocaleToCurrentLocale,
+    removeLocaleFromCurrentLocale,
+    doLocalesIntersect,
+    isLocaleSubsetOf,
+};

--- a/packages/client/src/settings/targetAndScope.test.ts
+++ b/packages/client/src/settings/targetAndScope.test.ts
@@ -18,9 +18,9 @@ describe('targetAndScope', () => {
 
     test.each`
         target                                 | expected
-        ${ConfigurationTarget.Global}          | ${['user', 'workspace', 'folder']}
-        ${ConfigurationTarget.Workspace}       | ${['workspace', 'folder']}
-        ${ConfigurationTarget.WorkspaceFolder} | ${['folder']}
+        ${ConfigurationTarget.Global}          | ${['user', 'workspace', 'folder', 'unknown']}
+        ${ConfigurationTarget.Workspace}       | ${['workspace', 'folder', 'unknown']}
+        ${ConfigurationTarget.WorkspaceFolder} | ${['folder', 'unknown']}
     `('configurationTargetToClientConfigScopeInfluenceRange', ({ target, expected }) => {
         expect(configurationTargetToClientConfigScopeInfluenceRange(target)).toEqual(expected);
     });

--- a/packages/client/src/settings/targetAndScope.test.ts
+++ b/packages/client/src/settings/targetAndScope.test.ts
@@ -1,5 +1,9 @@
 import { ConfigurationTarget } from 'vscode';
-import { configurationTargetToDictionaryScope, dictionaryScopeToConfigurationTarget } from './targetAndScope';
+import {
+    configurationTargetToClientConfigScopeInfluenceRange,
+    configurationTargetToDictionaryScope,
+    dictionaryScopeToConfigurationTarget,
+} from './targetAndScope';
 
 describe('targetAndScope', () => {
     test.each`
@@ -10,5 +14,14 @@ describe('targetAndScope', () => {
     `('dictionaryScopeToConfigurationTarget $scope $configTarget', ({ scope, configTarget }) => {
         expect(dictionaryScopeToConfigurationTarget(scope)).toBe(configTarget);
         expect(configurationTargetToDictionaryScope(configTarget)).toBe(scope);
+    });
+
+    test.each`
+        target                                 | expected
+        ${ConfigurationTarget.Global}          | ${['user', 'workspace', 'folder']}
+        ${ConfigurationTarget.Workspace}       | ${['workspace', 'folder']}
+        ${ConfigurationTarget.WorkspaceFolder} | ${['folder']}
+    `('configurationTargetToClientConfigScopeInfluenceRange', ({ target, expected }) => {
+        expect(configurationTargetToClientConfigScopeInfluenceRange(target)).toEqual(expected);
     });
 });

--- a/packages/client/src/settings/targetAndScope.ts
+++ b/packages/client/src/settings/targetAndScope.ts
@@ -1,5 +1,6 @@
 import { ConfigurationTarget } from 'vscode';
 import { CustomDictionaryScope, ConfigTargetVSCode } from '../client';
+import { ClientConfigScope } from './clientConfigTarget';
 
 type ConfigScopeVScode = ConfigTargetVSCode['scope'];
 
@@ -23,10 +24,31 @@ const ScopeToTarget: ConfigScopeToTarget = {
     folder: ConfigurationTarget.WorkspaceFolder,
 } as const;
 
+const ScopeOrder = [ConfigurationTarget.Global, ConfigurationTarget.Workspace, ConfigurationTarget.WorkspaceFolder] as const;
+
 export function configurationTargetToDictionaryScope(target: ConfigurationTarget): CustomDictionaryScope {
     return targetToScope[target];
 }
 
 export function dictionaryScopeToConfigurationTarget(scope: ConfigScopeVScode): ConfigurationTarget {
+    return clientConfigScopeToConfigurationTarget(scope);
+}
+
+export function clientConfigScopeToConfigurationTarget(scope: ConfigScopeVScode): ConfigurationTarget {
     return ScopeToTarget[scope];
+}
+
+export function configurationTargetToClientConfigScope(target: ConfigurationTarget): ClientConfigScope {
+    return targetToScope[target];
+}
+
+export function configurationTargetToClientConfigScopeInfluenceRange(target: ConfigurationTarget): ClientConfigScope[] {
+    const scopes: ClientConfigScope[] = [];
+    const start = ScopeOrder.indexOf(target);
+    if (start < 0) return scopes;
+    for (let i = start; i < ScopeOrder.length; ++i) {
+        scopes.push(configurationTargetToClientConfigScope(ScopeOrder[i]));
+    }
+    scopes.push('unknown');
+    return scopes;
 }


### PR DESCRIPTION
## Logic

### Scope

When adding / removing locales, the scope is either Global or Workspace.
Global - means it is possible to adjust any configuration.
Workspaces - means it is possible to adjust any configuration that is not Global.

-   Targets are presented from Locale to Global.
-   Targets _Inherit_ their values from Global to Local.

### Adding Locale

1. Only present targets that will have an impact.
1. If no targets will have an impact, then present any target that can be changed.
1. If there is only 1 target, then perform action without asking.

### Removing Locale

1. Only present targets that will have an impact.
1. If no targets will have an impact, do nothing.
1. If there is only 1 target, then perform action without asking.