### PR TITLE
fix: Fix Toggle Enable Spell Checker 

### DIFF
--- a/packages/client/docs/settings.md
+++ b/packages/client/docs/settings.md
@@ -43,3 +43,20 @@ Workspaces - means it is possible to adjust any configuration that is not Global
 1. Only present targets that will have an impact.
 1. If no targets will have an impact, do nothing.
 1. If there is only 1 target, then perform action without asking.
+
+# Toggle Enable Spell Checker
+
+## Logic
+
+There are currently two different target scopes (Workspace and Global). These are really max level of influence.
+
+The goal of the Toggle is to turn on / off the spell checker in a intuitive and predictable way. In other words:
+
+> If the spell checker is currently off for the file I have open, I want it on and vice versa.
+
+The logic to the Toggler is as follows:
+
+-   Find the most local configuration with the `enable` value set.
+-   Remove it if it will become the same as the inherited value otherwise set it to the negation.
+
+Having a scope of Workspace prevents the Global value from being updated, but the rest of the logic is the same.

--- a/packages/client/src/settings/index.test.ts
+++ b/packages/client/src/settings/index.test.ts
@@ -1,0 +1,7 @@
+import * as index from './index';
+
+describe('settings/index', () => {
+    test('', () => {
+        expect(typeof index.enableLocaleForTarget).toBe('function');
+    });
+});

--- a/packages/client/src/settings/index.ts
+++ b/packages/client/src/settings/index.ts
@@ -7,11 +7,11 @@ export {
     disableLanguageId,
     enableLanguageId,
     enableLanguageIdForTarget,
+    enableLocaleForTarget,
     setEnableSpellChecking,
     toggleEnableSpellChecker,
     watchSettingsFiles,
 } from './settings';
-export { enableLocaleForTarget } from './settings.locale';
 export {
     ConfigurationTarget,
     getScopedSettingFromVSConfig,

--- a/packages/client/src/settings/index.ts
+++ b/packages/client/src/settings/index.ts
@@ -7,11 +7,11 @@ export {
     disableLanguageId,
     enableLanguageId,
     enableLanguageIdForTarget,
-    enableLocaleForTarget,
     setEnableSpellChecking,
     toggleEnableSpellChecker,
     watchSettingsFiles,
 } from './settings';
+export { enableLocaleForTarget } from './settings.locale';
 export {
     ConfigurationTarget,
     getScopedSettingFromVSConfig,

--- a/packages/client/src/settings/index.ts
+++ b/packages/client/src/settings/index.ts
@@ -9,6 +9,7 @@ export {
     enableLanguageIdForTarget,
     enableLocaleForTarget,
     setEnableSpellChecking,
+    TargetsAndScopes,
     toggleEnableSpellChecker,
     watchSettingsFiles,
 } from './settings';

--- a/packages/client/src/settings/settings.base.ts
+++ b/packages/client/src/settings/settings.base.ts
@@ -1,0 +1,39 @@
+/**
+ * This file contains settings related functions, but are not exported out of the folder.
+ */
+
+import { CSpellUserSettings } from '../client';
+import { ClientConfigTarget, orderScope } from './clientConfigTarget';
+import { applyUpdateToConfigTargets, readFromConfigTargets } from './configRepositoryHelper';
+import { ConfigTargetMatchPattern, filterClientConfigTargets } from './configTargetHelper';
+import { configUpdaterForKey } from './configUpdater';
+
+export function readConfigTargetValues<K extends keyof CSpellUserSettings>(
+    targets: ClientConfigTarget[],
+    key: K
+): Promise<[ClientConfigTarget, Pick<CSpellUserSettings, K>][]> {
+    return readFromConfigTargets(key, targets);
+}
+
+export type ApplyValueOrFn<K extends keyof CSpellUserSettings> =
+    | CSpellUserSettings[K]
+    | ((v: CSpellUserSettings[K]) => CSpellUserSettings[K]);
+
+export function applyToConfig<K extends keyof CSpellUserSettings>(
+    targets: ClientConfigTarget[],
+    key: K,
+    value: ApplyValueOrFn<K>,
+    filter?: ConfigTargetMatchPattern
+): Promise<void> {
+    targets = filter ? filterClientConfigTargets(targets, filter) : targets;
+    const updater = configUpdaterForKey<K>(key, value);
+    return applyUpdateToConfigTargets(updater, targets);
+}
+
+export function orderTargetsLocalToGlobal(targets: ClientConfigTarget[]): ClientConfigTarget[] {
+    const scopes = targets.map((t) => t.scope);
+    const orderedScopes = orderScope(scopes, true);
+    const orderedTargets: ClientConfigTarget[] = [];
+    orderedScopes.map((scope) => targets.filter((t) => t.scope === scope)).forEach((t) => t.forEach((t) => orderedTargets.push(t)));
+    return orderedTargets;
+}

--- a/packages/client/src/settings/settings.base.ts
+++ b/packages/client/src/settings/settings.base.ts
@@ -5,7 +5,13 @@
 import { CSpellUserSettings } from '../client';
 import { ClientConfigTarget, orderScope } from './clientConfigTarget';
 import { applyUpdateToConfigTargets, readFromConfigTargets } from './configRepositoryHelper';
-import { ConfigTargetMatchPattern, filterClientConfigTargets } from './configTargetHelper';
+import {
+    ConfigTargetMatchPattern,
+    filterClientConfigTargets,
+    patternMatchNoDictionaries,
+    quickPickBestMatchTarget,
+    quickPickTargets,
+} from './configTargetHelper';
 import { configUpdaterForKey } from './configUpdater';
 
 export function readConfigTargetValues<K extends keyof CSpellUserSettings>(
@@ -36,4 +42,24 @@ export function orderTargetsLocalToGlobal(targets: ClientConfigTarget[]): Client
     const orderedTargets: ClientConfigTarget[] = [];
     orderedScopes.map((scope) => targets.filter((t) => t.scope === scope)).forEach((t) => t.forEach((t) => orderedTargets.push(t)));
     return orderedTargets;
+}
+
+export async function setConfigFieldQuickPickBestTarget<K extends keyof CSpellUserSettings>(
+    targets: ClientConfigTarget[],
+    key: K,
+    value: ApplyValueOrFn<K>
+): Promise<void> {
+    const t = await quickPickBestMatchTarget(targets, patternMatchNoDictionaries);
+    if (!t || !t.length) return;
+    return applyToConfig(t, key, value);
+}
+
+export async function setConfigFieldQuickPick<K extends keyof CSpellUserSettings>(
+    targets: ClientConfigTarget[],
+    key: K,
+    value: ApplyValueOrFn<K>
+): Promise<void> {
+    const t = await quickPickTargets(targets);
+    if (!t || !t.length) return;
+    return applyToConfig(t, key, value);
 }

--- a/packages/client/src/settings/settings.enable.test.ts
+++ b/packages/client/src/settings/settings.enable.test.ts
@@ -1,0 +1,13 @@
+import { toggleEnableSpellChecker, setEnableSpellChecking } from './settings.enable';
+
+describe('settings.enable', () => {
+    test('toggleEnableSpellChecker empty', async () => {
+        await expect(toggleEnableSpellChecker({ targets: [], scopes: [] })).resolves.toBe(undefined);
+    });
+
+    test('setEnableSpellChecking empty', async () => {
+        await expect(setEnableSpellChecking({ targets: [], scopes: [] }, true)).rejects.toEqual(
+            new Error('No matching configuration found.')
+        );
+    });
+});

--- a/packages/client/src/settings/settings.enable.ts
+++ b/packages/client/src/settings/settings.enable.ts
@@ -1,0 +1,10 @@
+import { ClientConfigTarget } from './clientConfigTarget';
+import { setConfigFieldQuickPick } from './settings.base';
+
+export function setEnableSpellChecking(targets: ClientConfigTarget[], enabled: boolean): Promise<void> {
+    return setConfigFieldQuickPick(targets, 'enabled', enabled);
+}
+
+export function toggleEnableSpellChecker(targets: ClientConfigTarget[]): Promise<void> {
+    return setConfigFieldQuickPick(targets, 'enabled', (enabled) => !enabled);
+}

--- a/packages/client/src/settings/settings.enable.ts
+++ b/packages/client/src/settings/settings.enable.ts
@@ -1,10 +1,35 @@
-import { ClientConfigTarget } from './clientConfigTarget';
-import { setConfigFieldQuickPick } from './settings.base';
+import type { CSpellUserSettings } from './settings.base';
+import {
+    applyToConfig,
+    calcRelevantTargetInfo,
+    findInheritedTargetValue,
+    readConfigTargetValues,
+    setConfigFieldQuickPick,
+} from './settings.base';
+import { TargetsAndScopes } from './settings.types';
 
-export function setEnableSpellChecking(targets: ClientConfigTarget[], enabled: boolean): Promise<void> {
-    return setConfigFieldQuickPick(targets, 'enabled', enabled);
+const enableKey: keyof CSpellUserSettings = 'enabled';
+
+export function setEnableSpellChecking(targetsAndScopes: TargetsAndScopes, enabled: boolean): Promise<void> {
+    const { possibleTargets } = calcRelevantTargetInfo(targetsAndScopes);
+    return setConfigFieldQuickPick(possibleTargets, enableKey, enabled);
 }
 
-export function toggleEnableSpellChecker(targets: ClientConfigTarget[]): Promise<void> {
-    return setConfigFieldQuickPick(targets, 'enabled', (enabled) => !enabled);
+export async function toggleEnableSpellChecker(targetsAndScopes: TargetsAndScopes): Promise<void> {
+    const { possibleTargets, orderedTargets } = calcRelevantTargetInfo(targetsAndScopes);
+    const mapTargetsToValue = new Map(await readConfigTargetValues(orderedTargets, enableKey));
+    const possibleTargetsWithValues = possibleTargets.filter((t) => mapTargetsToValue.get(t)?.[enableKey] !== undefined);
+
+    if (!possibleTargets.length) {
+        // Nothing to do.
+        return;
+    }
+
+    const closestTarget = possibleTargetsWithValues[possibleTargetsWithValues.length - 1] ?? possibleTargets[possibleTargets.length - 1];
+    const targetCurrentValue = mapTargetsToValue.get(closestTarget)?.[enableKey];
+    const found = findInheritedTargetValue(mapTargetsToValue, closestTarget, enableKey);
+    const defaultValue = found ?? true; // Global default is true/
+    const currentValue = targetCurrentValue ?? defaultValue;
+    const newValue = defaultValue !== currentValue ? undefined : !currentValue;
+    return applyToConfig([closestTarget], enableKey, () => newValue);
 }

--- a/packages/client/src/settings/settings.locale.test.ts
+++ b/packages/client/src/settings/settings.locale.test.ts
@@ -1,0 +1,51 @@
+import { __testing__ } from './settings.locale';
+
+const { addLocaleToCurrentLocale, removeLocaleFromCurrentLocale, doLocalesIntersect, isLocaleSubsetOf } = __testing__;
+
+describe('Validate settings.ts', () => {
+    test.each`
+        locale              | current | expected
+        ${'en'}             | ${'en'} | ${'en'}
+        ${'nl_nl'}          | ${'en'} | ${'en,nl-NL'}
+        ${'nl,nl_nl,nl-Nl'} | ${'en'} | ${'en,nl,nl-NL'}
+    `('addLocaleToCurrentLocale $locale + $current => $expected', ({ locale, current, expected }) => {
+        expect(addLocaleToCurrentLocale(locale, current)).toBe(expected);
+    });
+
+    test.each`
+        locale        | current       | expected
+        ${'en'}       | ${'en'}       | ${undefined}
+        ${'nl_nl'}    | ${'en'}       | ${'en'}
+        ${'nl_nl'}    | ${'en,nl-NL'} | ${'en'}
+        ${'nl,nl_nl'} | ${'en,nl'}    | ${'en'}
+        ${'en;nl_nl'} | ${'en,nl'}    | ${'nl'}
+        ${'en;nl_nl'} | ${'en, nl'}   | ${'nl'}
+    `('removeLocaleFromCurrentLocale $current - $locale => $expected', ({ locale, current, expected }) => {
+        expect(removeLocaleFromCurrentLocale(locale, current)).toBe(expected);
+    });
+
+    test.each`
+        locale        | current       | expected
+        ${'en'}       | ${'en'}       | ${true}
+        ${'nl_nl'}    | ${'en'}       | ${false}
+        ${'nl_nl'}    | ${'en,nl-NL'} | ${true}
+        ${'nl,nl_nl'} | ${'en,nl'}    | ${true}
+        ${'en;nl_nl'} | ${'en,nl'}    | ${true}
+        ${'en;nl_nl'} | ${'en, nl'}   | ${true}
+    `('doLocalesIntersect $current ⋂ $locale => $expected', ({ locale, current, expected }) => {
+        expect(doLocalesIntersect(locale, current)).toBe(expected);
+    });
+
+    test.each`
+        locale        | current        | expected
+        ${'en'}       | ${'en'}        | ${true}
+        ${'nl_nl'}    | ${'en'}        | ${false}
+        ${'nl_nl'}    | ${'en,nl-NL'}  | ${true}
+        ${'nl,nl_nl'} | ${'en,nl'}     | ${false}
+        ${'en;nl_nl'} | ${'en,nl'}     | ${false}
+        ${'en;nl_nl'} | ${'nl-nl, en'} | ${true}
+        ${'en;nl_nl'} | ${'en, nl'}    | ${false}
+    `('doLocalesIntersect $locale ⊆ $current => $expected', ({ locale, current, expected }) => {
+        expect(isLocaleSubsetOf(locale, current)).toBe(expected);
+    });
+});

--- a/packages/client/src/settings/settings.locale.ts
+++ b/packages/client/src/settings/settings.locale.ts
@@ -1,7 +1,7 @@
-import { CSpellUserSettings, normalizeLocale } from '../client';
 import { ClientConfigScope, ClientConfigTarget, orderScope } from './clientConfigTarget';
 import { quickPickTarget } from './configTargetHelper';
-import { applyToConfig, readConfigTargetValues, orderTargetsLocalToGlobal } from './settings.base';
+import type { CSpellUserSettings } from './settings.base';
+import { applyToConfig, normalizeLocale, orderTargetsLocalToGlobal, readConfigTargetValues } from './settings.base';
 
 /**
  * Try to add or remove a locale from the nearest configuration.

--- a/packages/client/src/settings/settings.locale.ts
+++ b/packages/client/src/settings/settings.locale.ts
@@ -3,14 +3,6 @@ import { ClientConfigScope, ClientConfigTarget, orderScope } from './clientConfi
 import { quickPickTarget } from './configTargetHelper';
 import { applyToConfig, readConfigTargetValues, orderTargetsLocalToGlobal } from './settings.base';
 
-export function enableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
-    return enableLocaleForTarget(locale, true, targets, possibleScopes);
-}
-
-export function disableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
-    return enableLocaleForTarget(locale, false, targets, possibleScopes);
-}
-
 /**
  * Try to add or remove a locale from the nearest configuration.
  * Present the user with the option to pick a target if more than one viable target is available.

--- a/packages/client/src/settings/settings.locale.ts
+++ b/packages/client/src/settings/settings.locale.ts
@@ -1,0 +1,139 @@
+import { CSpellUserSettings, normalizeLocale } from '../client';
+import { ClientConfigScope, ClientConfigTarget, orderScope } from './clientConfigTarget';
+import { quickPickTarget } from './configTargetHelper';
+import { applyToConfig, readConfigTargetValues, orderTargetsLocalToGlobal } from './settings.base';
+
+export function enableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
+    return enableLocaleForTarget(locale, true, targets, possibleScopes);
+}
+
+export function disableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
+    return enableLocaleForTarget(locale, false, targets, possibleScopes);
+}
+
+/**
+ * Try to add or remove a locale from the nearest configuration.
+ * Present the user with the option to pick a target if more than one viable target is available.
+ *
+ * @param locale - locale to add or remove
+ * @param enable - true = add
+ * @param targets - all known targets
+ * @param possibleScopes - possible scopes
+ * @returns resolves when finished - rejects if an error was encountered.
+ */
+export async function enableLocaleForTarget(
+    locale: string,
+    enable: boolean,
+    targets: ClientConfigTarget[],
+    possibleScopes: ClientConfigScope[]
+): Promise<void> {
+    // Have targets inherit values.
+    targets = targets.map((t) => ({ ...t, useMerge: t.useMerge ?? t.kind === 'vscode' }));
+
+    const allowedScopes = new Set(orderScope(possibleScopes));
+    const orderedTargets = new Set(orderTargetsLocalToGlobal(targets));
+    const mapTargetsToValue = new Map(await readConfigTargetValues([...orderedTargets], 'language'));
+    const possibleTargets = new Set([...orderedTargets].filter((t) => allowedScopes.has(t.scope)));
+
+    if (!enable) {
+        // remove all non-overlapping targets.
+        [...mapTargetsToValue].filter(([_, v]) => !doLocalesIntersect(locale, v.language)).forEach(([t]) => possibleTargets.delete(t));
+    } else {
+        const keep = [...possibleTargets];
+        const targetsWithLocale = new Set([...mapTargetsToValue].filter(([_, v]) => isLocaleSubsetOf(locale, v.language)).map(([t]) => t));
+        let clear = false;
+        for (const t of possibleTargets) {
+            clear = clear || targetsWithLocale.has(t);
+            if (clear) possibleTargets.delete(t);
+        }
+        // If nothing is left, let the user pick from any of the possible set.
+        if (!possibleTargets.size) {
+            // Add back any that have not already been set.
+            keep.filter((t) => !targetsWithLocale.has(t)).forEach((t) => possibleTargets.add(t));
+        }
+    }
+
+    const t = possibleTargets.size > 1 ? await quickPickTarget([...possibleTargets]) : [...possibleTargets][0];
+    if (!t) return;
+
+    const defaultValue = calcInheritedDefault('language', t, mapTargetsToValue);
+
+    const applyFn: (src: string | undefined) => string | undefined = enable
+        ? (currentLanguage) => addLocaleToCurrentLocale(locale, currentLanguage || defaultValue)
+        : (currentLanguage) => removeLocaleFromCurrentLocale(locale, currentLanguage);
+
+    return applyToConfig([t], 'language', applyFn);
+}
+
+function normalize(locale: string) {
+    return normalizeLocale(locale)
+        .split(',')
+        .filter((a) => !!a);
+}
+
+function addLocaleToCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
+    const toAdd = normalize(locale);
+    const currentSet = new Set(normalize(currentLocale || ''));
+
+    toAdd.forEach((locale) => currentSet.add(locale));
+
+    return [...currentSet].join(',') || undefined;
+}
+
+function removeLocaleFromCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
+    const toRemove = normalize(locale);
+    const currentSet = new Set(normalize(currentLocale || ''));
+
+    toRemove.forEach((locale) => currentSet.delete(locale));
+
+    return [...currentSet].join(',') || undefined;
+}
+
+function doLocalesIntersect(localeA: string, localeB: string): boolean;
+function doLocalesIntersect(localeA: string, localeB: undefined): false;
+function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean;
+function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean {
+    if (!localeA || !localeB) return false;
+
+    const a = new Set(normalize(localeA));
+    const b = normalize(localeB);
+    for (const locale of b) {
+        if (a.has(locale)) return true;
+    }
+    return false;
+}
+
+function isLocaleSubsetOf(localeA: string, localeB: string): boolean;
+function isLocaleSubsetOf(localeA: string, localeB: undefined): false;
+function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean;
+function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean {
+    if (!localeA || !localeB) return false;
+
+    const largerSet = new Set(normalize(localeB));
+    const smallerSet = normalize(localeA);
+    for (const locale of smallerSet) {
+        if (!largerSet.has(locale)) return false;
+    }
+    return true;
+}
+
+function calcInheritedDefault<K extends keyof CSpellUserSettings>(
+    key: K,
+    target: ClientConfigTarget,
+    targetsWithValue: Iterable<[ClientConfigTarget, CSpellUserSettings]>
+): CSpellUserSettings[K] {
+    const tv = [...targetsWithValue].reverse();
+    let value: CSpellUserSettings[K] = undefined;
+    for (const [t, v] of tv) {
+        value = v[key] ?? value;
+        if (t === target) break;
+    }
+    return value;
+}
+
+export const __testing__ = {
+    addLocaleToCurrentLocale,
+    removeLocaleFromCurrentLocale,
+    doLocalesIntersect,
+    isLocaleSubsetOf,
+};

--- a/packages/client/src/settings/settings.test.ts
+++ b/packages/client/src/settings/settings.test.ts
@@ -1,55 +1,7 @@
-import { hasWorkspaceLocation, __testing__ } from './settings';
-
-const { addLocaleToCurrentLocale, removeLocaleFromCurrentLocale, doLocalesIntersect, isLocaleSubsetOf } = __testing__;
+import { hasWorkspaceLocation } from './settings';
 
 describe('Validate settings.ts', () => {
     test('hasWorkspaceLocation', () => {
         expect(hasWorkspaceLocation()).toBe(false);
-    });
-
-    test.each`
-        locale              | current | expected
-        ${'en'}             | ${'en'} | ${'en'}
-        ${'nl_nl'}          | ${'en'} | ${'en,nl-NL'}
-        ${'nl,nl_nl,nl-Nl'} | ${'en'} | ${'en,nl,nl-NL'}
-    `('addLocaleToCurrentLocale $locale + $current => $expected', ({ locale, current, expected }) => {
-        expect(addLocaleToCurrentLocale(locale, current)).toBe(expected);
-    });
-
-    test.each`
-        locale        | current       | expected
-        ${'en'}       | ${'en'}       | ${undefined}
-        ${'nl_nl'}    | ${'en'}       | ${'en'}
-        ${'nl_nl'}    | ${'en,nl-NL'} | ${'en'}
-        ${'nl,nl_nl'} | ${'en,nl'}    | ${'en'}
-        ${'en;nl_nl'} | ${'en,nl'}    | ${'nl'}
-        ${'en;nl_nl'} | ${'en, nl'}   | ${'nl'}
-    `('removeLocaleFromCurrentLocale $current - $locale => $expected', ({ locale, current, expected }) => {
-        expect(removeLocaleFromCurrentLocale(locale, current)).toBe(expected);
-    });
-
-    test.each`
-        locale        | current       | expected
-        ${'en'}       | ${'en'}       | ${true}
-        ${'nl_nl'}    | ${'en'}       | ${false}
-        ${'nl_nl'}    | ${'en,nl-NL'} | ${true}
-        ${'nl,nl_nl'} | ${'en,nl'}    | ${true}
-        ${'en;nl_nl'} | ${'en,nl'}    | ${true}
-        ${'en;nl_nl'} | ${'en, nl'}   | ${true}
-    `('doLocalesIntersect $current ⋂ $locale => $expected', ({ locale, current, expected }) => {
-        expect(doLocalesIntersect(locale, current)).toBe(expected);
-    });
-
-    test.each`
-        locale        | current        | expected
-        ${'en'}       | ${'en'}        | ${true}
-        ${'nl_nl'}    | ${'en'}        | ${false}
-        ${'nl_nl'}    | ${'en,nl-NL'}  | ${true}
-        ${'nl,nl_nl'} | ${'en,nl'}     | ${false}
-        ${'en;nl_nl'} | ${'en,nl'}     | ${false}
-        ${'en;nl_nl'} | ${'nl-nl, en'} | ${true}
-        ${'en;nl_nl'} | ${'en, nl'}    | ${false}
-    `('doLocalesIntersect $locale ⊆ $current => $expected', ({ locale, current, expected }) => {
-        expect(isLocaleSubsetOf(locale, current)).toBe(expected);
     });
 });

--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -18,6 +18,7 @@ export interface SettingsInfo {
     path: Uri;
     settings: CSpellUserSettings;
 }
+export type { TargetsAndScopes } from './settings.types';
 
 export function watchSettingsFiles(callback: () => void): vscode.Disposable {
     // Every 10 seconds see if we have new files to watch.

--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -3,22 +3,15 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { Uri, workspace } from 'vscode';
-import { CSpellUserSettings, normalizeLocale as normalizeLocale } from '../client';
+import { CSpellUserSettings } from '../client';
 import { isDefined, unique } from '../util';
 import * as watcher from '../util/watcher';
-import { ClientConfigScope, ClientConfigTarget, orderScope } from './clientConfigTarget';
+import { ClientConfigTarget } from './clientConfigTarget';
 import { readConfigFile, writeConfigFile } from './configFileReadWrite';
-import { applyUpdateToConfigTargets, readFromConfigTargets } from './configRepositoryHelper';
-import {
-    ConfigTargetMatchPattern,
-    filterClientConfigTargets,
-    patternMatchNoDictionaries,
-    quickPickBestMatchTarget,
-    quickPickTarget,
-    quickPickTargets,
-} from './configTargetHelper';
-import { configUpdaterForKey } from './configUpdater';
+import { patternMatchNoDictionaries, quickPickBestMatchTarget, quickPickTargets } from './configTargetHelper';
 import { configFileLocations, isUpdateSupportedForConfigFileFormat, normalizeWords, preferredConfigFiles } from './CSpellSettings';
+import { applyToConfig, ApplyValueOrFn } from './settings.base';
+
 export { ConfigTargetLegacy, InspectScope, Scope } from './vsConfig';
 export interface SettingsInfo {
     path: Uri;
@@ -132,93 +125,6 @@ async function setConfigFieldQuickPick<K extends keyof CSpellUserSettings>(
     return applyToConfig(t, key, value);
 }
 
-type ApplyValueOrFn<K extends keyof CSpellUserSettings> = CSpellUserSettings[K] | ((v: CSpellUserSettings[K]) => CSpellUserSettings[K]);
-
-function applyToConfig<K extends keyof CSpellUserSettings>(
-    targets: ClientConfigTarget[],
-    key: K,
-    value: ApplyValueOrFn<K>,
-    filter?: ConfigTargetMatchPattern
-) {
-    targets = filter ? filterClientConfigTargets(targets, filter) : targets;
-    const updater = configUpdaterForKey<K>(key, value);
-    return applyUpdateToConfigTargets(updater, targets);
-}
-
-function readConfigTargetValues<K extends keyof CSpellUserSettings>(targets: ClientConfigTarget[], key: K) {
-    return readFromConfigTargets(key, targets);
-}
-
-export function enableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
-    return enableLocaleForTarget(locale, true, targets, possibleScopes);
-}
-
-export function disableLocale(targets: ClientConfigTarget[], locale: string, possibleScopes: ClientConfigScope[]): Promise<void> {
-    return enableLocaleForTarget(locale, false, targets, possibleScopes);
-}
-
-/**
- * Try to add or remove a locale from the nearest configuration.
- * Present the user with the option to pick a target if more than one viable target is available.
- *
- * @param locale - locale to add or remove
- * @param enable - true = add
- * @param targets - all known targets
- * @param possibleScopes - possible scopes
- * @returns resolves when finished - rejects if an error was encountered.
- */
-export async function enableLocaleForTarget(
-    locale: string,
-    enable: boolean,
-    targets: ClientConfigTarget[],
-    possibleScopes: ClientConfigScope[]
-): Promise<void> {
-    // Have targets inherit values.
-    targets = targets.map((t) => ({ ...t, useMerge: t.useMerge ?? t.kind === 'vscode' }));
-
-    const allowedScopes = new Set(orderScope(possibleScopes));
-    const orderedTargets = new Set(orderTargetsLocalToGlobal(targets));
-    const mapTargetsToValue = new Map(await readConfigTargetValues([...orderedTargets], 'language'));
-    const possibleTargets = new Set([...orderedTargets].filter((t) => allowedScopes.has(t.scope)));
-
-    if (!enable) {
-        // remove all non-overlapping targets.
-        [...mapTargetsToValue].filter(([_, v]) => !doLocalesIntersect(locale, v.language)).forEach(([t]) => possibleTargets.delete(t));
-    } else {
-        const keep = [...possibleTargets];
-        const targetsWithLocale = new Set([...mapTargetsToValue].filter(([_, v]) => isLocaleSubsetOf(locale, v.language)).map(([t]) => t));
-        let clear = false;
-        for (const t of possibleTargets) {
-            clear = clear || targetsWithLocale.has(t);
-            if (clear) possibleTargets.delete(t);
-        }
-        // If nothing is left, let the user pick from any of the possible set.
-        if (!possibleTargets.size) {
-            // Add back any that have not already been set.
-            keep.filter((t) => !targetsWithLocale.has(t)).forEach((t) => possibleTargets.add(t));
-        }
-    }
-
-    const t = possibleTargets.size > 1 ? await quickPickTarget([...possibleTargets]) : [...possibleTargets][0];
-    if (!t) return;
-
-    const defaultValue = calcInheritedDefault('language', t, mapTargetsToValue);
-
-    const applyFn: (src: string | undefined) => string | undefined = enable
-        ? (currentLanguage) => addLocaleToCurrentLocale(locale, currentLanguage || defaultValue)
-        : (currentLanguage) => removeLocaleFromCurrentLocale(locale, currentLanguage);
-
-    return applyToConfig([t], 'language', applyFn);
-}
-
-function orderTargetsLocalToGlobal(targets: ClientConfigTarget[]): ClientConfigTarget[] {
-    const scopes = targets.map((t) => t.scope);
-    const orderedScopes = orderScope(scopes, true);
-    const orderedTargets: ClientConfigTarget[] = [];
-    orderedScopes.map((scope) => targets.filter((t) => t.scope === scope)).forEach((t) => t.forEach((t) => orderedTargets.push(t)));
-    return orderedTargets;
-}
-
 /**
  * It is a two step logic to minimize a build up of values in the configuration.
  * The idea is to use defaults whenever possible.
@@ -311,76 +217,3 @@ export async function createConfigFileRelativeToDocumentUri(referenceDocUri?: Ur
     await createConfigFile(configFile, overwrite);
     return configFile;
 }
-
-function normalize(locale: string) {
-    return normalizeLocale(locale)
-        .split(',')
-        .filter((a) => !!a);
-}
-
-function addLocaleToCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
-    const toAdd = normalize(locale);
-    const currentSet = new Set(normalize(currentLocale || ''));
-
-    toAdd.forEach((locale) => currentSet.add(locale));
-
-    return [...currentSet].join(',') || undefined;
-}
-
-function removeLocaleFromCurrentLocale(locale: string, currentLocale: string | undefined): string | undefined {
-    const toRemove = normalize(locale);
-    const currentSet = new Set(normalize(currentLocale || ''));
-
-    toRemove.forEach((locale) => currentSet.delete(locale));
-
-    return [...currentSet].join(',') || undefined;
-}
-
-function doLocalesIntersect(localeA: string, localeB: string): boolean;
-function doLocalesIntersect(localeA: string, localeB: undefined): false;
-function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean;
-function doLocalesIntersect(localeA: string, localeB: string | undefined): boolean {
-    if (!localeA || !localeB) return false;
-
-    const a = new Set(normalize(localeA));
-    const b = normalize(localeB);
-    for (const locale of b) {
-        if (a.has(locale)) return true;
-    }
-    return false;
-}
-
-function isLocaleSubsetOf(localeA: string, localeB: string): boolean;
-function isLocaleSubsetOf(localeA: string, localeB: undefined): false;
-function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean;
-function isLocaleSubsetOf(localeA: string, localeB: string | undefined): boolean {
-    if (!localeA || !localeB) return false;
-
-    const largerSet = new Set(normalize(localeB));
-    const smallerSet = normalize(localeA);
-    for (const locale of smallerSet) {
-        if (!largerSet.has(locale)) return false;
-    }
-    return true;
-}
-
-function calcInheritedDefault<K extends keyof CSpellUserSettings>(
-    key: K,
-    target: ClientConfigTarget,
-    targetsWithValue: Iterable<[ClientConfigTarget, CSpellUserSettings]>
-): CSpellUserSettings[K] {
-    const tv = [...targetsWithValue].reverse();
-    let value: CSpellUserSettings[K] = undefined;
-    for (const [t, v] of tv) {
-        value = v[key] ?? value;
-        if (t === target) break;
-    }
-    return value;
-}
-
-export const __testing__ = {
-    addLocaleToCurrentLocale,
-    removeLocaleFromCurrentLocale,
-    doLocalesIntersect,
-    isLocaleSubsetOf,
-};

--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -8,10 +8,11 @@ import { isDefined, unique } from '../util';
 import * as watcher from '../util/watcher';
 import { ClientConfigTarget } from './clientConfigTarget';
 import { readConfigFile, writeConfigFile } from './configFileReadWrite';
-import { patternMatchNoDictionaries, quickPickBestMatchTarget, quickPickTargets } from './configTargetHelper';
 import { configFileLocations, isUpdateSupportedForConfigFileFormat, normalizeWords, preferredConfigFiles } from './CSpellSettings';
-import { applyToConfig, ApplyValueOrFn } from './settings.base';
+import { setConfigFieldQuickPick } from './settings.base';
 
+export { setEnableSpellChecking, toggleEnableSpellChecker } from './settings.enable';
+export { enableLocaleForTarget } from './settings.locale';
 export { ConfigTargetLegacy, InspectScope, Scope } from './vsConfig';
 export interface SettingsInfo {
     path: Uri;
@@ -79,10 +80,6 @@ function findSettingsFiles(docUri?: Uri, isUpdatable?: boolean): Promise<Uri[]> 
     );
 }
 
-export function setEnableSpellChecking(targets: ClientConfigTarget[], enabled: boolean): Promise<void> {
-    return setConfigFieldQuickPick(targets, 'enabled', enabled);
-}
-
 /**
  * @description Enable a programming language
  * @param target - which level of setting to set
@@ -99,30 +96,6 @@ export async function disableLanguageId(targets: ClientConfigTarget[], languageI
 export function addIgnoreWordsToSettings(targets: ClientConfigTarget[], words: string | string[]): Promise<void> {
     const addWords = normalizeWords(words);
     return setConfigFieldQuickPick(targets, 'ignoreWords', (words) => unique(addWords.concat(words || []).sort()));
-}
-
-export function toggleEnableSpellChecker(targets: ClientConfigTarget[]): Promise<void> {
-    return setConfigFieldQuickPick(targets, 'enabled', (enabled) => !enabled);
-}
-
-export async function setConfigFieldQuickPickBestTarget<K extends keyof CSpellUserSettings>(
-    targets: ClientConfigTarget[],
-    key: K,
-    value: ApplyValueOrFn<K>
-): Promise<void> {
-    const t = await quickPickBestMatchTarget(targets, patternMatchNoDictionaries);
-    if (!t || !t.length) return;
-    return applyToConfig(t, key, value);
-}
-
-async function setConfigFieldQuickPick<K extends keyof CSpellUserSettings>(
-    targets: ClientConfigTarget[],
-    key: K,
-    value: ApplyValueOrFn<K>
-) {
-    const t = await quickPickTargets(targets);
-    if (!t || !t.length) return;
-    return applyToConfig(t, key, value);
 }
 
 /**

--- a/packages/client/src/settings/settings.types.ts
+++ b/packages/client/src/settings/settings.types.ts
@@ -1,0 +1,8 @@
+import { ClientConfigScope, ClientConfigTarget } from './clientConfigTarget';
+
+export interface TargetsAndScopes {
+    /** all targets that have an influence on changing a setting */
+    targets: ClientConfigTarget[];
+    /** possible scopes to apply the setting. */
+    scopes: ClientConfigScope[];
+}


### PR DESCRIPTION
Fix: #1289 

## Toggle Enable Spell Checker

### Logic

There are currently two different target scopes (Workspace and Global). These are really max level of influence.

The goal of the Toggle is to turn on / off the spell checker in a intuitive and predictable way. In other words:

> If the spell checker is currently off for the file I have open, I want it on and vice versa.

The logic to the Toggler is as follows:

-   Find the most local configuration with the `enable` value set.
-   Remove it if it will become the same as the inherited value otherwise set it to the negation.

Having a scope of Workspace prevents the Global value from being updated, but the rest of the logic is the same.
