### PR TITLE
fix: Make sure the VS Code instance of Uri is used

### DIFF
--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -1,4 +1,3 @@
-import { toUri } from 'common-utils/uriHelper.js';
 import {
     CodeAction,
     commands,
@@ -65,6 +64,7 @@ import {
 import { catchErrors, handleErrors, ignoreError, OnErrorResolver } from './util/errors';
 import { performance, toMilliseconds } from './util/perf';
 import { scrollToText } from './util/textEditor';
+import { toUri } from './util/uriHelper';
 import { findMatchingDocument } from './vscode/findDocument';
 
 const commandsFromServer: ClientSideCommandHandlerApi = {

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -1,9 +1,8 @@
 import { commands, TextDocument, workspace } from 'vscode';
-import { toUri } from 'common-utils/uriHelper.js';
-import { CSpellClient } from './client';
+import { ConfigKind, ConfigScope, ConfigTarget, CSpellClient } from './client';
 import { extensionId } from './constants';
 import { getCSpellDiags } from './diags';
-import { ConfigKind, ConfigScope, ConfigTarget } from './client';
+import { toUri } from './util/uriHelper';
 
 const prefix = extensionId;
 

--- a/packages/client/src/infoViewer/infoHelper.ts
+++ b/packages/client/src/infoViewer/infoHelper.ts
@@ -1,4 +1,4 @@
-import { toUri, uriToName } from 'common-utils/uriHelper';
+import { uriToName } from 'common-utils/uriHelper';
 import * as vscode from 'vscode';
 import { Uri } from 'vscode';
 import {
@@ -13,7 +13,6 @@ import {
     Workspace,
     WorkspaceFolder,
 } from '../../settingsViewer/api/settings';
-import { CSpellClient } from '../client';
 import type {
     ConfigTarget,
     ConfigTargetCSpell,
@@ -21,9 +20,11 @@ import type {
     DictionaryDefinition,
     GetConfigurationForDocumentResult,
 } from '../client';
+import { CSpellClient } from '../client';
 import { Inspect, inspectConfig, InspectValues } from '../settings';
 import { Maybe, uniqueFilter } from '../util';
 import { defaultTo, map, pipe } from '../util/pipe';
+import { toUri } from '../util/uriHelper';
 
 type Logger = typeof console.log;
 

--- a/packages/client/src/infoViewer/infoView.ts
+++ b/packages/client/src/infoViewer/infoView.ts
@@ -1,4 +1,3 @@
-import { toUri } from 'common-utils/uriHelper';
 import * as Kefir from 'kefir';
 import { format } from 'util';
 import * as vscode from 'vscode';
@@ -18,6 +17,7 @@ import { CSpellClient } from '../client';
 import { enableDisableLanguageId, enableDisableLocale } from '../commands';
 import { getSettingFromVSConfig } from '../settings';
 import { Maybe } from '../util';
+import { toUri } from '../util/uriHelper';
 import { findMatchingDocument } from '../vscode/findDocument';
 import { commandDisplayCSpellInfo } from './commands';
 import { calcSettings } from './infoHelper';

--- a/packages/client/src/settings/DictionaryHelper.ts
+++ b/packages/client/src/settings/DictionaryHelper.ts
@@ -80,7 +80,7 @@ export class DictionaryHelper {
         try {
             await dictTarget.addWords(words);
         } catch (e) {
-            throw new UnableToAddWordError(`Unable to add "${words}"`, dictTarget, words);
+            throw new UnableToAddWordError(`Unable to add "${words}"`, dictTarget, words, e);
         }
     }
 
@@ -135,7 +135,7 @@ export class DictionaryHelper {
         try {
             await dictTarget.addWords(words);
         } catch (e) {
-            throw new DictionaryTargetError(`Unable to remove "${words}" from "${dictTarget.name}"`, dictTarget);
+            throw new DictionaryTargetError(`Unable to remove "${words}" from "${dictTarget.name}"`, dictTarget, e);
         }
     }
 
@@ -375,14 +375,14 @@ function combineDictionaryEntry(c: CustomDictionaries, entry: CustomDictionaryEn
 }
 
 export class DictionaryTargetError extends Error {
-    constructor(msg: string, readonly dictTarget: DictionaryTarget) {
+    constructor(msg: string, readonly dictTarget: DictionaryTarget, readonly cause: Error | unknown) {
         super(msg);
     }
 }
 
 export class UnableToAddWordError extends DictionaryTargetError {
-    constructor(msg: string, dictTarget: DictionaryTarget, readonly words: string | string[]) {
-        super(msg, dictTarget);
+    constructor(msg: string, dictTarget: DictionaryTarget, readonly words: string | string[], readonly cause: Error | unknown) {
+        super(msg, dictTarget, cause);
     }
 }
 

--- a/packages/client/src/settings/configRepositoryHelper.ts
+++ b/packages/client/src/settings/configRepositoryHelper.ts
@@ -1,4 +1,5 @@
-import { toUri } from 'common-utils/uriHelper.js';
+import { CSpellUserSettings } from '../client';
+import { toUri } from '../util/uriHelper';
 import {
     ClientConfigKind,
     ClientConfigTarget,
@@ -15,7 +16,6 @@ import {
 } from './configRepository';
 import { ConfigKeys, ConfigUpdater } from './configUpdater';
 import { dictionaryScopeToConfigurationTarget } from './targetAndScope';
-import { CSpellUserSettings } from '../client';
 
 const KnownTargetKinds = new Set<ClientConfigKind>(['dictionary', 'cspell', 'vscode']);
 

--- a/packages/client/src/settings/configTargetHelper.ts
+++ b/packages/client/src/settings/configTargetHelper.ts
@@ -2,8 +2,9 @@
  * This helper is to help with matching possible configuration targets to configuration fields.
  */
 
-import { toUri, uriToName } from 'common-utils/uriHelper.js';
+import { uriToName } from 'common-utils/uriHelper.js';
 import * as vscode from 'vscode';
+import { toUri } from '../util/uriHelper';
 import {
     ClientConfigKind,
     ClientConfigScope,

--- a/packages/client/src/settings/mappers/configTarget.ts
+++ b/packages/client/src/settings/mappers/configTarget.ts
@@ -1,4 +1,4 @@
-import { toUri } from '../../../../__utils/dist/uriHelper';
+import { toUri } from '../../util/uriHelper';
 import { ConfigTarget, ConfigTargetCSpell, ConfigTargetDictionary, ConfigTargetVSCode } from '../../client';
 import {
     ClientConfigTarget,

--- a/packages/client/src/util/uriHelper.ts
+++ b/packages/client/src/util/uriHelper.ts
@@ -1,0 +1,10 @@
+import { Uri } from 'vscode';
+
+export function toUri(uri: string | Uri): Uri;
+export function toUri(uri: string | Uri | undefined | null): Uri | undefined;
+export function toUri(uri: string | Uri | undefined | null): Uri | undefined {
+    if (typeof uri === 'string') {
+        return Uri.parse(uri);
+    }
+    return uri || undefined;
+}


### PR DESCRIPTION
Fix: #1341

VS Code seems to be very sensitive to the class instance that created a
URI when accessing the Configuration.