### PR TITLE
dev: Have the general toggle command change nearest setting

### DIFF
--- a/docs/_includes/generated-docs/commands.md
+++ b/docs/_includes/generated-docs/commands.md
@@ -35,5 +35,6 @@
 | `cSpell.removeWordFromUserDictionary`        | Remove Words from the Global Dictionary                                                                |
 | `cSpell.removeWordFromWorkspaceDictionary`   | Remove Words from the Workspace Dictionaries                                                           |
 | `cSpell.suggestSpellingCorrections`          | Spelling Suggestions...<br>**When:**<br> `editorTextFocus && cSpell.editorMenuContext.showSuggestions` |
-| `cSpell.toggleEnableForGlobal`               | Toggle Spell Checking                                                                                  |
-| `cSpell.toggleEnableSpellChecker`            | Toggle Spell Checking For the Current Workspace                                                        |
+| `cSpell.toggleEnableForGlobal`               | Toggle Spell Checking in User Settings                                                                 |
+| `cSpell.toggleEnableForWorkspace`            | Toggle Spell Checking for Workspace                                                                    |
+| `cSpell.toggleEnableSpellChecker`            | Toggle Spell Checking                                                                                  |

--- a/package.json
+++ b/package.json
@@ -202,11 +202,6 @@
         "title": "Disable Spell Checking by Default"
       },
       {
-        "command": "cSpell.toggleEnableForGlobal",
-        "category": "Spell",
-        "title": "Toggle Spell Checking"
-      },
-      {
         "command": "cSpell.enableCurrentLanguage",
         "category": "Spell",
         "title": "Enable Spell Checking Document Language"
@@ -222,9 +217,19 @@
         "title": "Show Spell Checker Configuration Info"
       },
       {
+        "command": "cSpell.toggleEnableForGlobal",
+        "category": "Spell",
+        "title": "Toggle Spell Checking in User Settings"
+      },
+      {
+        "command": "cSpell.toggleEnableForWorkspace",
+        "category": "Spell",
+        "title": "Toggle Spell Checking for Workspace"
+      },
+      {
         "command": "cSpell.toggleEnableSpellChecker",
         "category": "Spell",
-        "title": "Toggle Spell Checking For the Current Workspace"
+        "title": "Toggle Spell Checking"
       },
       {
         "command": "cSpell.removeWordFromFolderDictionary",

--- a/packages/client/src/commands.ts
+++ b/packages/client/src/commands.ts
@@ -58,6 +58,7 @@ import { normalizeWords } from './settings/CSpellSettings';
 import { createDictionaryTargetForFile, DictionaryTarget } from './settings/DictionaryTarget';
 import { mapConfigTargetToClientConfigTarget } from './settings/mappers/configTarget';
 import {
+    configurationTargetToClientConfigScope,
     configurationTargetToClientConfigScopeInfluenceRange,
     configurationTargetToDictionaryScope,
     dictionaryScopeToConfigurationTarget,
@@ -86,8 +87,8 @@ type CommandHandler = {
 };
 
 const prompt = onCommandUseDiagsSelectionOrPrompt;
-const tfCfg = targetsFromConfigurationTarget;
-const tsFCfg = targetsAndScopeFromConfigurationTarget;
+const tsFCfg = (configTarget: ConfigurationTarget, limitToTarget = false) =>
+    targetsAndScopeFromConfigurationTarget(configTarget, undefined, undefined, limitToTarget);
 const actionAddWordToFolder = prompt('Add Words to Folder Dictionary', addWordToFolderDictionary);
 const actionAddWordToWorkspace = prompt('Add Words to Workspace Dictionaries', addWordToWorkspaceDictionary);
 const actionAddWordToUser = prompt('Add Words to User Dictionary', addWordToUserDictionary);
@@ -140,10 +141,11 @@ const commandHandlers: CommandHandler = {
     'cSpell.disableLanguage': disableLanguageIdCmd,
     'cSpell.enableForGlobal': async () => setEnableSpellChecking(await tsFCfg(ConfigurationTarget.Global), true),
     'cSpell.disableForGlobal': async () => setEnableSpellChecking(await tsFCfg(ConfigurationTarget.Global), false),
-    'cSpell.toggleEnableForGlobal': async () => toggleEnableSpellChecker(await tsFCfg(ConfigurationTarget.Global)),
+    'cSpell.toggleEnableForGlobal': async () => toggleEnableSpellChecker(await tsFCfg(ConfigurationTarget.Global, true)),
     'cSpell.enableForWorkspace': async () => setEnableSpellChecking(await tsFCfg(ConfigurationTarget.Workspace), true),
     'cSpell.disableForWorkspace': async () => setEnableSpellChecking(await tsFCfg(ConfigurationTarget.Workspace), false),
-    'cSpell.toggleEnableSpellChecker': async () => toggleEnableSpellChecker(await tsFCfg(ConfigurationTarget.Workspace)),
+    'cSpell.toggleEnableForWorkspace': async () => toggleEnableSpellChecker(await tsFCfg(ConfigurationTarget.Workspace)),
+    'cSpell.toggleEnableSpellChecker': async () => toggleEnableSpellChecker(await tsFCfg(ConfigurationTarget.Global)),
     'cSpell.enableCurrentLanguage': enableCurrentLanguage,
     'cSpell.disableCurrentLanguage': disableCurrentLanguage,
 
@@ -339,7 +341,7 @@ export function enableDisableLanguageId(
     enable: boolean
 ): Promise<void> {
     return handleErrors(async () => {
-        const t = await (configTarget ? tfCfg(configTarget, uri) : targetsForUri(uri));
+        const t = await (configTarget ? targetsFromConfigurationTarget(configTarget, uri) : targetsForUri(uri));
         return Settings.enableLanguageIdForTarget(languageId, enable, t);
     }, ctx(`enableDisableLanguageId enable: ${enable}`, configTarget, uri));
 }
@@ -388,9 +390,12 @@ export function disableCurrentLanguage(): Promise<void> {
 async function targetsAndScopeFromConfigurationTarget(
     cfgTarget: ConfigurationTarget,
     docUri?: string | null | Uri | undefined,
-    configScope?: ConfigurationScope
+    configScope?: ConfigurationScope,
+    cfgTargetIsExact?: boolean
 ): Promise<TargetsAndScopes> {
-    const scopes = configurationTargetToClientConfigScopeInfluenceRange(cfgTarget);
+    const scopes = cfgTargetIsExact
+        ? [configurationTargetToClientConfigScope(cfgTarget)]
+        : configurationTargetToClientConfigScopeInfluenceRange(cfgTarget);
     const pattern = createConfigTargetMatchPattern(matchKindAll, matchScopeAll, { dictionary: false });
 
     docUri = toUri(docUri);

--- a/packages/client/src/statusbar.ts
+++ b/packages/client/src/statusbar.ts
@@ -89,7 +89,7 @@ export function initStatusBar(context: ExtensionContext, client: CSpellClient): 
         } else {
             sbCheck.text = `$(stop) ${cspellStatusBarIcon}`;
             sbCheck.tooltip = 'Enable spell checking';
-            sbCheck.command = 'cSpell.enableForWorkspace';
+            sbCheck.command = 'cSpell.enableForGlobal';
             sbCheck.show();
         }
     }


### PR DESCRIPTION
Have the status bar `enable` spelling use `cSpell.enableForGlobal`.

Fix #1289 