### PR TITLE
fix: Fix adding words in Notebooks

### DIFF
--- a/packages/_server/src/config/documentSettings.ts
+++ b/packages/_server/src/config/documentSettings.ts
@@ -69,6 +69,12 @@ const defaultRootUri = Uri.file('').toString();
 
 const _defaultSettings: CSpellUserSettings = Object.freeze({});
 
+const _schemaMapToFile = {
+    'vscode-notebook-cell': true,
+} as const;
+
+const schemeMapToFile: Record<string, true> = Object.freeze(_schemaMapToFile);
+
 interface Clearable {
     clear: () => any;
 }
@@ -216,6 +222,9 @@ export class DocumentSettings {
     private async _fetchSettingsForUri(docUri: string): Promise<ExtSettings> {
         log(`fetchFolderSettings: URI ${docUri}`);
         const uri = Uri.parse(docUri);
+        if (uri.scheme in schemeMapToFile) {
+            return this.fetchSettingsForUri(mapToFileUri(uri).toString());
+        }
         const fsPath = path.normalize(uri.fsPath);
         const cSpellConfigSettingsRel = await this.fetchSettingsFromVSCode(docUri);
         const cSpellConfigSettings = await this.resolveWorkspacePaths(cSpellConfigSettingsRel, docUri);
@@ -563,6 +572,14 @@ export function isIncluded(settings: ExtSettings, uri: Uri): boolean {
 
 export function isExcluded(settings: ExtSettings, uri: Uri): boolean {
     return settings.excludeGlobMatcher.match(uri.fsPath);
+}
+
+function mapToFileUri(uri: Uri): Uri {
+    return uri.with({
+        scheme: 'file',
+        query: '',
+        fragment: '',
+    });
 }
 
 export const __testing__ = {

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -24,6 +24,7 @@ import { Inspect, inspectConfigKeys, sectionCSpell } from '../settings';
 import * as LanguageIds from '../settings/languageIds';
 import { Maybe } from '../util';
 import { createBroadcaster } from '../util/broadcaster';
+import { findConicalDocumentScope } from '../util/documentUri';
 import { logErrors, silenceErrors } from '../util/errors';
 import {
     createServerApi,
@@ -247,9 +248,10 @@ function handleOnWorkspaceConfigForDocumentRequest(req: WorkspaceConfigForDocume
 }
 
 function calculateWorkspaceConfigForDocument(docUri: Uri | undefined): WorkspaceConfigForDocument {
-    const cfg = inspectConfigKeys(docUri, ['words', 'userWords', 'ignoreWords']);
+    const scope = findConicalDocumentScope(docUri);
+    const cfg = inspectConfigKeys(scope, ['words', 'userWords', 'ignoreWords']);
     const workspaceFile = workspace.workspaceFile?.toString();
-    const workspaceFolder = docUri && workspace.getWorkspaceFolder(docUri)?.uri.toString();
+    const workspaceFolder = scope && workspace.getWorkspaceFolder(scope)?.uri.toString();
 
     const allowFolder = workspaceFile !== undefined;
 

--- a/packages/client/src/settings/vsConfig.ts
+++ b/packages/client/src/settings/vsConfig.ts
@@ -1,6 +1,7 @@
 import { workspace, Uri, ConfigurationTarget, TextDocument, WorkspaceConfiguration, ConfigurationScope } from 'vscode';
 import { extensionId } from '../constants';
 import { CSpellUserSettings } from '../client';
+import { findConicalDocumentScope } from '../util/documentUri';
 
 export { CSpellUserSettings } from '../client';
 export { ConfigurationTarget } from 'vscode';
@@ -460,7 +461,7 @@ interface HasUri {
 }
 
 function normalizeConfigurationScope(scope: GetConfigurationScope): GetConfigurationScope {
-    if (isUriLike(scope)) return fixUri(scope);
+    if (isUriLike(scope)) return findConicalDocumentScope(fixUri(scope));
     if (isHasUri(scope)) {
         if (isUri(scope.uri)) return scope;
         return {

--- a/packages/client/src/util/documentUri.ts
+++ b/packages/client/src/util/documentUri.ts
@@ -1,0 +1,44 @@
+import { Uri, workspace } from 'vscode';
+
+const _schemaFile = {
+    file: true,
+    untitled: true,
+} as const;
+
+const _schemaMapToFile = {
+    'vscode-notebook-cell': true,
+} as const;
+
+const _schemeBlocked = {
+    git: true,
+    output: true,
+    debug: true,
+    vscode: true,
+} as const;
+
+const schemeFile: Record<string, true> = Object.freeze(_schemaFile);
+const schemeBlocked: Record<string, true> = Object.freeze(_schemeBlocked);
+const schemeMapToFile: Record<string, true> = Object.freeze(_schemaMapToFile);
+
+export function findConicalDocumentScope(docUri: Uri | undefined): Uri | undefined {
+    if (docUri === undefined) return undefined;
+    if (docUri.scheme in schemeBlocked) return undefined;
+    if (docUri.scheme in schemeFile) return docUri;
+
+    const path = docUri.path;
+
+    // Search the open documents for a match.
+    for (const doc of workspace.textDocuments) {
+        const uri = doc.uri;
+        if (uri.path === path && uri.scheme === 'file') {
+            return uri;
+        }
+    }
+
+    if (docUri.scheme in schemeMapToFile) {
+        return docUri.with({ scheme: 'file', query: '', fragment: '' });
+    }
+
+    // Hope for the best.
+    return docUri;
+}


### PR DESCRIPTION
fix: #1353

Add a workaround to address the issue that VS Code Config cannot cope with Notebook documents. See: [WorkspaceConfiguration update fails if TextDocument is a Notebook · Issue #134103 · microsoft/vscode](https://github.com/microsoft/vscode/issues/134103)