### PR TITLE
fix: Put cspell autocompletion behind a configuration setting.

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -41,6 +41,7 @@
 | [`cSpell.numSuggestions`](#cspellnumsuggestions)                                                   | resource             | Controls the number of suggestions shown.                                                                |
 | [`cSpell.overrides`](#cspelloverrides)                                                             | resource             | Overrides to apply based upon the file path.                                                             |
 | [`cSpell.patterns`](#cspellpatterns)                                                               | resource             | Defines a list of patterns that can be used in ignoreRegExpList and includeRegExpList                    |
+| [`cSpell.showAutocompleteSuggestions`](#cspellshowautocompletesuggestions)                         | language-overridable | Show CSpell in-document directives as you type.                                                          |
 | [`cSpell.showCommandsInEditorContextMenu`](#cspellshowcommandsineditorcontextmenu)                 | application          | Show Spell Checker actions in Editor Context Menu                                                        |
 | [`cSpell.showStatus`](#cspellshowstatus)                                                           | application          | Display the spell checker status on the status bar.                                                      |
 | [`cSpell.showStatusAlignment`](#cspellshowstatusalignment)                                         | application          | The side of the status bar to display the spell checker status.                                          |
@@ -864,6 +865,26 @@ Description
 
 Default
 : _- none -_
+
+---
+
+### `cSpell.showAutocompleteSuggestions`
+
+Name
+: `cSpell.showAutocompleteSuggestions`
+
+Type
+: boolean
+
+Scope
+: language-overridable
+
+Description
+: Show CSpell in-document directives as you type.
+**Note:** VS Code must be restarted for this setting to take effect.
+
+Default
+: _`false`_
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2526,6 +2526,13 @@
           "description": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
           "scope": "window",
           "type": "boolean"
+        },
+        "cSpell.showAutocompleteSuggestions": {
+          "default": false,
+          "description": "Show CSpell in-document directives as you type.",
+          "scope": "language-overridable",
+          "type": "boolean",
+          "markdownDescription": "Show CSpell in-document directives as you type.\n**Note:** VS Code must be restarted for this setting to take effect."
         }
       }
     }

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -2060,6 +2060,13 @@
       "scope": "resource",
       "type": "array"
     },
+    "showAutocompleteSuggestions": {
+      "default": false,
+      "description": "Show CSpell in-document directives as you type.",
+      "markdownDescription": "Show CSpell in-document directives as you type.\n**Note:** VS Code must be restarted for this setting to take effect.",
+      "scope": "language-overridable",
+      "type": "boolean"
+    },
     "showCommandsInEditorContextMenu": {
       "default": true,
       "description": "Show Spell Checker actions in Editor Context Menu",

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -74,6 +74,16 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     showStatusAlignment?: 'Left' | 'Right';
 
     /**
+     * Show CSpell in-document directives as you type.
+     * @markdownDescription
+     * Show CSpell in-document directives as you type.
+     * **Note:** VS Code must be restarted for this setting to take effect.
+     * @scope language-overridable
+     * @default false
+     */
+    showAutocompleteSuggestions?: boolean;
+
+    /**
      * Delay in ms after a document has changed before checking it for spelling errors.
      * @scope application
      * @default 50

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -52,6 +52,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     pnpFiles: 'pnpFiles',
     readonly: 'readonly',
     reporters: 'reporters',
+    showAutocompleteSuggestions: 'showAutocompleteSuggestions',
     showCommandsInEditorContextMenu: 'showCommandsInEditorContextMenu',
     showStatus: 'showStatus',
     showStatusAlignment: 'showStatusAlignment',


### PR DESCRIPTION
fix: #1536 
There is no real fix, this fix allows the option to be turned off.
The real fix would need to take place in VS Code.