### PR TITLE
fix: replaced call to fs.pathExists() with fs.existsSync()

### DIFF
--- a/packages/client/src/settings/settings.ts
+++ b/packages/client/src/settings/settings.ts
@@ -70,7 +70,7 @@ function findSettingsFiles(docUri?: Uri, isUpdatable?: boolean): Promise<Uri[]> 
         .map((root) => configFileLocations.map((rel) => path.join(root, rel)))
         .reduce((a, b) => a.concat(b), []);
 
-    const found = possibleLocations.map(async (filename) => ({ filename, exists: await fs.pathExists(filename) }));
+    const found = possibleLocations.map(async (filename) => ({ filename, exists: fs.existsSync(filename) }));
 
     return Promise.all(found).then((found) =>
         found


### PR DESCRIPTION
Replaced call to fs.pathExists() with fs.existsSync().

Reasons:
1. pathExists() has been deprecated
2. My team writes an extension for VS Code.  I sometimes need to turn on caught exceptions and uncaught exceptions, but this is impossible to do with the cspell extension installed, since `findSettingsFiles()` looks for a dozen different config files and thrown an exception for every file it can't find (and it does this every 10 seconds)
