### PR TITLE
fix: Configuration changes should be responsive

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -637,6 +637,7 @@ Default
 | Setting                                                                      | Scope    | Description                                                                                    |
 | ---------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | [`cSpell.allowedSchemas`](#cspellallowedschemas)                             | window   | Control which file schemas will be checked for spelling (VS Code must be restarted for this…   |
+| [`cSpell.enableFiletypes`](#cspellenablefiletypes)                           | resource | File Types to Check                                                                            |
 | [`cSpell.files`](#cspellfiles)                                               | resource | Glob patterns of files to be checked.                                                          |
 | [`cSpell.globRoot`](#cspellglobroot)                                         | resource | The root to use for glop patterns found in this configuration.                                 |
 | [`cSpell.ignorePaths`](#cspellignorepaths)                                   | resource | Glob patterns of files to be ignored                                                           |
@@ -669,6 +670,34 @@ Description
 
 Default
 : [ _`"file"`_, _`"gist"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_ ]
+
+---
+
+### `cSpell.enableFiletypes`
+
+Name
+: `cSpell.enableFiletypes` -- File Types to Check
+
+Type
+: string[]
+
+Scope
+: resource
+
+Description
+: Enable / Disable checking file types (languageIds).
+These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
+To disable a language, prefix with `!` as in `!json`,
+
+    Example:
+    ```
+    jsonc       // enable checking for jsonc
+    !json       // disable checking for json
+    kotlin      // enable checking for kotlin
+    ```
+
+Default
+: _- none -_
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1062,6 +1062,19 @@
             "scope": "window",
             "type": "array"
           },
+          "cSpell.enableFiletypes": {
+            "items": {
+              "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+              "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
+              "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
+              "type": "string"
+            },
+            "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+            "scope": "resource",
+            "title": "File Types to Check",
+            "type": "array",
+            "uniqueItems": true
+          },
           "cSpell.files": {
             "description": "",
             "items": {

--- a/packages/__utils/src/util.test.ts
+++ b/packages/__utils/src/util.test.ts
@@ -1,4 +1,4 @@
-import { unique, uniqueFilter, freqCount, mustBeDefined, isDefined, textToWords, pick } from './util';
+import { unique, uniqueFilter, freqCount, mustBeDefined, isDefined, textToWords, pick, setIfDefined } from './util';
 
 describe('Util', () => {
     test('unique', () => {
@@ -74,6 +74,18 @@ describe('Validate Util Functions', () => {
 
         const r = pick(Object.freeze(src), ['a', 'b']);
         expect(r).toEqual({ a: src.a, b: src.b });
+    });
+
+    test('setIfDefined', () => {
+        interface Person {
+            name: string;
+            dob?: string;
+        }
+
+        const p0: Person = { name: 'tester' };
+        setIfDefined(p0, 'dob', 'today');
+        setIfDefined(p0, 'name', undefined);
+        expect(p0).toEqual({ name: 'tester', dob: 'today' });
     });
 
     // cspell:ignore spéciale geschäft aåáâäñãæ

--- a/packages/__utils/src/util.ts
+++ b/packages/__utils/src/util.ts
@@ -72,3 +72,10 @@ export function pick<T, K extends keyof T>(src: T, keys: readonly K[]): Pick<T, 
     }
     return r as Pick<T, K>;
 }
+
+export function setIfDefined<T, K extends keyof T>(record: T, key: K, value: T[K] | undefined): T {
+    if (value !== undefined) {
+        record[key] = value;
+    }
+    return record;
+}

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -693,6 +693,19 @@
           "scope": "window",
           "type": "array"
         },
+        "cSpell.enableFiletypes": {
+          "items": {
+            "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+            "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
+            "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
+            "type": "string"
+          },
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+          "scope": "resource",
+          "title": "File Types to Check",
+          "type": "array",
+          "uniqueItems": true
+        },
         "cSpell.files": {
           "description": "",
           "items": {

--- a/packages/_server/src/config/configTargetsHelper.ts
+++ b/packages/_server/src/config/configTargetsHelper.ts
@@ -20,7 +20,7 @@ import { CSpellSettingsWithFileSource, extractCSpellFileConfigurations, extractT
 
 export function calculateConfigTargets(settings: CSpellUserSettings, workspaceConfig: WorkspaceConfigForDocument): ConfigTarget[] {
     const targets: ConfigTarget[] = [];
-    const sources = extractCSpellFileConfigurations(settings);
+    const sources = extractCSpellFileConfigurations(settings).filter((cfg) => !cfg.readonly);
     const dictionaries = extractTargetDictionaries(settings);
 
     targets.push(...workspaceConfigToTargets(workspaceConfig));

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -891,6 +891,7 @@ type VSConfigFilesAndFolders = PrefixWithCspell<_VSConfigFilesAndFolders>;
 type _VSConfigFilesAndFolders = Pick<
     SpellCheckerSettingsVSCodeBase,
     | 'allowedSchemas'
+    | 'enableFiletypes'
     | 'files'
     | 'globRoot'
     | 'ignorePaths'

--- a/packages/client/src/extension.ts
+++ b/packages/client/src/extension.ts
@@ -34,16 +34,22 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi>
 
     // Start the client.
     context.subscriptions.push(client.start());
+    const statusBar = initStatusBar(context, client);
 
     function triggerGetSettings(delayInMs = 0) {
-        setTimeout(() => silenceErrors(client.triggerSettingsRefresh(), 'triggerGetSettings'), delayInMs);
+        setTimeout(triggerGetSettingsNow, delayInMs);
+    }
+
+    function triggerGetSettingsNow() {
+        silenceErrors(client.triggerSettingsRefresh(), 'triggerGetSettings').then(() => {
+            settingsViewer.update();
+            statusBar.refresh();
+        });
     }
 
     function triggerConfigChange() {
         triggerGetSettings();
     }
-
-    initStatusBar(context, client);
 
     const configWatcher = vscode.workspace.createFileSystemWatcher(settings.configFileLocationGlob);
 

--- a/packages/client/src/infoViewer/infoHelper.ts
+++ b/packages/client/src/infoViewer/infoHelper.ts
@@ -171,7 +171,7 @@ function extractFileConfig(
         configFiles: extractConfigFiles(docConfig),
         fileIsExcluded,
         fileIsIncluded,
-        fileIsInWorkspace: !!folder,
+        fileIsInWorkspace: !!folder || isUntitled,
         excludedBy: mapExcludedBy(excludedBy),
         gitignoreInfo: extractGitignoreInfo(),
         blockedReason: docConfig.blockedReason,

--- a/packages/client/src/infoViewer/infoView.ts
+++ b/packages/client/src/infoViewer/infoView.ts
@@ -21,9 +21,12 @@ import { toUri } from '../util/uriHelper';
 import { findMatchingDocument } from '../vscode/findDocument';
 import { commandDisplayCSpellInfo } from './commands';
 import { calcSettings } from './infoHelper';
+import { promisify } from 'util';
 
 const viewerPath = 'packages/client/settingsViewer/webapp';
 const title = 'Spell Checker Preferences';
+
+const wait = promisify(setTimeout);
 
 type RefreshEmitter = Kefir.Emitter<void, Error> | undefined;
 
@@ -101,6 +104,7 @@ async function createView(context: vscode.ExtensionContext, column: vscode.ViewC
 
     async function refreshState() {
         log(`refreshState: uri "${state.activeDocumentUri}"`);
+        await wait(500);
         state.settings = await calcStateSettings(state.activeDocumentUri, state.activeFolderUri);
     }
 
@@ -333,6 +337,10 @@ function log(...params: Parameters<typeof console.log>) {
     const msg = format(...params);
     const now = new Date();
     console.log(`${now.toISOString()} InfoView -- ${msg}`);
+}
+
+export function update(): void {
+    currentPanel?.updateView();
 }
 
 export const __testing__ = {


### PR DESCRIPTION
Make sure the status bar and the configuration page
reflects changes to the configuration.
- Do not show `readonly` configurations.
- Move enableFileTypes