### PR TITLE
fix: remove duplicate definition of `enableFiletypes`

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -46,7 +46,6 @@ Default
 | [`cSpell.customDictionaries`](#cspellcustomdictionaries)       | resource | Custom Dictionaries                                                                               |
 | [`cSpell.dictionaries`](#cspelldictionaries)                   | resource | Optional list of dictionaries to use.                                                             |
 | [`cSpell.dictionaryDefinitions`](#cspelldictionarydefinitions) | resource | Define additional available dictionaries.                                                         |
-| [`cSpell.enableFiletypes`](#cspellenablefiletypes)             | resource | File Types to Check                                                                               |
 | [`cSpell.flagWords`](#cspellflagwords)                         | resource | List of words to always be considered incorrect.                                                  |
 | [`cSpell.ignoreWords`](#cspellignorewords)                     | resource | A list of words to be ignored by the spell checker.                                               |
 | [`cSpell.language`](#cspelllanguage)                           | resource | Current active spelling language.                                                                 |
@@ -152,34 +151,6 @@ Scope
 
 Description
 : Define additional available dictionaries.
-
-Default
-: _- none -_
-
----
-
-### `cSpell.enableFiletypes`
-
-Name
-: `cSpell.enableFiletypes` -- File Types to Check
-
-Type
-: string[]
-
-Scope
-: resource
-
-Description
-: Enable / Disable checking file types (languageIds).
-These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
-To disable a language, prefix with `!` as in `!json`,
-
-    Example:
-    ```
-    jsonc       // enable checking for jsonc
-    !json       // disable checking for json
-    kotlin      // enable checking for kotlin
-    ```
 
 Default
 : _- none -_

--- a/package.json
+++ b/package.json
@@ -1339,19 +1339,6 @@
             "scope": "resource",
             "type": "array"
           },
-          "cSpell.enableFiletypes": {
-            "items": {
-              "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-              "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
-              "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
-              "type": "string"
-            },
-            "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-            "scope": "resource",
-            "title": "File Types to Check",
-            "type": "array",
-            "uniqueItems": true
-          },
           "cSpell.flagWords": {
             "description": "List of words to always be considered incorrect.",
             "items": {

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -970,19 +970,6 @@
           "scope": "resource",
           "type": "array"
         },
-        "cSpell.enableFiletypes": {
-          "items": {
-            "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-            "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
-            "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
-            "type": "string"
-          },
-          "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-          "scope": "resource",
-          "title": "File Types to Check",
-          "type": "array",
-          "uniqueItems": true
-        },
         "cSpell.flagWords": {
           "description": "List of words to always be considered incorrect.",
           "items": {

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -820,7 +820,6 @@ type _VSConfigLanguageAndDictionaries = Pick<
     | 'customDictionaries'
     | 'dictionaries'
     | 'dictionaryDefinitions'
-    | 'enableFiletypes'
     | 'flagWords'
     | 'ignoreWords'
     | 'language'


### PR DESCRIPTION
fix: #1929