### PR TITLE
feat: Add `checkOnlyEnabledFileTypes` option

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -491,7 +491,8 @@ Scope
 
 Description
 : Show CSpell in-document directives as you type.
-**Note:** VS Code must be restarted for this setting to take effect.
+
+    **Note:** VS Code must be restarted for this setting to take effect.
 
 Default
 : _`false`_
@@ -681,8 +682,10 @@ Scope
 
 Description
 : Enable / Disable checking file types (languageIds).
-These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
-To disable a language, prefix with `!` as in `!json`,
+
+    These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
+    To disable a language, prefix with `!` as in `!json`,
+
 
     **Example: individual file types**
     ```
@@ -690,6 +693,7 @@ To disable a language, prefix with `!` as in `!json`,
     !json       // disable checking for json
     kotlin      // enable checking for kotlin
     ```
+
 
     **Example: enable all file types**
     ```
@@ -823,7 +827,7 @@ Description
 : Only spell check files that are in the currently open workspace.
 This same effect can be achieved using the `files` setting.
 
-    ```
+    ```js
     "cSpell.files": ["**"]
     ```
 
@@ -889,7 +893,8 @@ By default it is the first folder.
 
     This is used to find the `cspell.json` file for the workspace.
 
-    Example: use the `client` folder
+
+    **Example: use the `client` folder**
     ```
     ${workspaceFolder:client}
     ```
@@ -929,7 +934,9 @@ Description
     A chunk is the characters between absolute word breaks.
     Absolute word breaks match: `/[\s,{}[\]]/`
 
+
     **Error Message:** _Average Word Size is Too High._
+
 
     If you are seeing this message, it means that the file contains mostly long lines
     without many word breaks.
@@ -956,6 +963,7 @@ Description
     Block spell checking if lines are longer than the value given.
     This is used to prevent spell checking generated files.
 
+
     **Error Message:** _Lines are too long._
 
 Default
@@ -979,10 +987,13 @@ Description
 
     It is used to prevent spell checking of generated files.
 
+
     A chunk is the characters between absolute word breaks.
     Absolute word breaks match: `/[\s,{}[\]]/`, i.e. spaces or braces.
 
+
     **Error Message:** _Maximum Word Length is Too High._
+
 
     If you are seeing this message, it means that the file contains a very long line
     without many word breaks.

--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -684,11 +684,17 @@ Description
 These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
 To disable a language, prefix with `!` as in `!json`,
 
-    Example:
+    **Example: individual file types**
     ```
     jsonc       // enable checking for jsonc
     !json       // disable checking for json
     kotlin      // enable checking for kotlin
+    ```
+
+    **Example: enable all file types**
+    ```
+    *           // enable checking for all file types
+    !json       // except for json
     ```
 
 Default

--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -608,6 +608,7 @@ Default
 | Setting                                                                      | Scope    | Description                                                                                    |
 | ---------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------- |
 | [`cSpell.allowedSchemas`](#cspellallowedschemas)                             | window   | Control which file schemas will be checked for spelling (VS Code must be restarted for this…   |
+| [`cSpell.checkOnlyEnabledFileTypes`](#cspellcheckonlyenabledfiletypes)       | resource | Check Only Enabled File Types                                                                  |
 | [`cSpell.enableFiletypes`](#cspellenablefiletypes)                           | resource | File Types to Check                                                                            |
 | [`cSpell.files`](#cspellfiles)                                               | resource | Glob patterns of files to be checked.                                                          |
 | [`cSpell.globRoot`](#cspellglobroot)                                         | resource | The root to use for glop patterns found in this configuration.                                 |
@@ -641,6 +642,29 @@ Description
 
 Default
 : [ _`"file"`_, _`"gist"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_ ]
+
+---
+
+### `cSpell.checkOnlyEnabledFileTypes`
+
+Name
+: `cSpell.checkOnlyEnabledFileTypes` -- Check Only Enabled File Types
+
+Type
+: boolean
+
+Scope
+: resource
+
+Description
+: By default, the spell checker checks only enabled file types. Use `cSpell.enableFiletypes`
+to turn on / off various file types.
+
+    When this setting is `false`, all file types are checked except for the ones disabled by `cSpell.enableFiletypes`.
+    See `cSpell.enableFiletypes` on how to disable a file type.
+
+Default
+: _`true`_
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1081,7 +1081,7 @@
               "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
               "type": "string"
             },
-            "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+            "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
             "scope": "resource",
             "title": "File Types to Check",
             "type": "array",

--- a/package.json
+++ b/package.json
@@ -1067,6 +1067,13 @@
             "scope": "window",
             "type": "array"
           },
+          "cSpell.checkOnlyEnabledFileTypes": {
+            "default": true,
+            "markdownDescription": "By default, the spell checker checks only enabled file types. Use `cSpell.enableFiletypes`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `cSpell.enableFiletypes`.\nSee `cSpell.enableFiletypes` on how to disable a file type.",
+            "scope": "resource",
+            "title": "Check Only Enabled File Types",
+            "type": "boolean"
+          },
           "cSpell.enableFiletypes": {
             "items": {
               "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",

--- a/package.json
+++ b/package.json
@@ -1063,7 +1063,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.",
+            "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.",
             "scope": "window",
             "type": "array"
           },
@@ -1076,12 +1076,12 @@
           },
           "cSpell.enableFiletypes": {
             "items": {
-              "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-              "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
+              "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+              "pattern": "(^!*(?!\\s)[\\s\\w_.\\-]+$)|(^!*[*]$)",
               "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
               "type": "string"
             },
-            "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+            "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
             "scope": "resource",
             "title": "File Types to Check",
             "type": "array",
@@ -1137,7 +1137,7 @@
           },
           "cSpell.spellCheckOnlyWorkspaceFiles": {
             "default": false,
-            "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `files` setting.\n\n```\n\"cSpell.files\": [\"**\"]\n```",
+            "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `files` setting.\n\n\n```js\n\"cSpell.files\": [\"**\"]\n```",
             "scope": "window",
             "title": "Spell Check Only Workspace Files",
             "type": "boolean"
@@ -1154,7 +1154,7 @@
             "type": "boolean"
           },
           "cSpell.workspaceRootPath": {
-            "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\nExample: use the `client` folder\n```\n${workspaceFolder:client}\n```",
+            "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder**\n```\n${workspaceFolder:client}\n```",
             "scope": "resource",
             "title": "Workspace Root Folder Path",
             "type": "string"
@@ -1197,12 +1197,12 @@
                       "type": "string"
                     },
                     "name": {
-                      "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                      "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                       "title": "Name of Dictionary",
                       "type": "string"
                     },
                     "path": {
-                      "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                      "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                       "title": "Optional Path to Dictionary Text File",
                       "type": "string"
                     },
@@ -1239,7 +1239,7 @@
                 }
               ]
             },
-            "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
+            "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
             "scope": "resource",
             "title": "Custom Dictionaries",
             "type": "object"
@@ -1695,14 +1695,14 @@
                     },
                     "name": {
                       "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                      "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                      "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                       "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                       "title": "Name of Dictionary",
                       "type": "string"
                     },
                     "path": {
                       "description": "A File System Path. Relative paths are relative to the configuration file.",
-                      "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                      "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                       "title": "Optional Path to Dictionary Text File",
                       "type": "string"
                     },
@@ -1772,14 +1772,14 @@
                     },
                     "name": {
                       "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                      "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                      "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                       "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                       "title": "Name of Dictionary",
                       "type": "string"
                     },
                     "path": {
                       "description": "A File System Path. Relative paths are relative to the configuration file.",
-                      "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                      "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                       "title": "Optional Path to Dictionary Text File",
                       "type": "string"
                     },
@@ -1849,14 +1849,14 @@
                     },
                     "name": {
                       "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                      "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                      "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                       "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                       "title": "Name of Dictionary",
                       "type": "string"
                     },
                     "path": {
                       "description": "A File System Path. Relative paths are relative to the configuration file.",
-                      "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                      "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                       "title": "Optional Path to Dictionary Text File",
                       "type": "string"
                     },
@@ -1964,19 +1964,19 @@
         "properties": {
           "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
             "default": 80,
-            "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n**Error Message:** _Average Word Size is Too High._\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.",
+            "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average Word Size is Too High._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.",
             "scope": "language-overridable",
             "type": "number"
           },
           "cSpell.blockCheckingWhenLineLengthGreaterThan": {
             "default": 10000,
-            "markdownDescription": "The maximum line length.\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n**Error Message:** _Lines are too long._",
+            "markdownDescription": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._",
             "scope": "language-overridable",
             "type": "number"
           },
           "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
             "default": 500,
-            "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\nIt is used to prevent spell checking of generated files.\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n**Error Message:** _Maximum Word Length is Too High._\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.",
+            "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum Word Length is Too High._\n\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.",
             "scope": "language-overridable",
             "type": "number"
           },
@@ -2081,8 +2081,7 @@
           },
           "cSpell.showAutocompleteSuggestions": {
             "default": false,
-            "description": "Show CSpell in-document directives as you type.",
-            "markdownDescription": "Show CSpell in-document directives as you type.\n**Note:** VS Code must be restarted for this setting to take effect.",
+            "markdownDescription": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
             "scope": "language-overridable",
             "type": "boolean"
           },

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -694,7 +694,7 @@
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.",
+          "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.",
           "scope": "window",
           "type": "array"
         },
@@ -707,12 +707,12 @@
         },
         "cSpell.enableFiletypes": {
           "items": {
-            "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-            "pattern": "^!?(?!\\s)[\\s\\w_.\\-]+$",
+            "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+            "pattern": "(^!*(?!\\s)[\\s\\w_.\\-]+$)|(^!*[*]$)",
             "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
             "type": "string"
           },
-          "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
           "scope": "resource",
           "title": "File Types to Check",
           "type": "array",
@@ -768,7 +768,7 @@
         },
         "cSpell.spellCheckOnlyWorkspaceFiles": {
           "default": false,
-          "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `files` setting.\n\n```\n\"cSpell.files\": [\"**\"]\n```",
+          "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `files` setting.\n\n\n```js\n\"cSpell.files\": [\"**\"]\n```",
           "scope": "window",
           "title": "Spell Check Only Workspace Files",
           "type": "boolean"
@@ -785,7 +785,7 @@
           "type": "boolean"
         },
         "cSpell.workspaceRootPath": {
-          "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\nExample: use the `client` folder\n```\n${workspaceFolder:client}\n```",
+          "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder**\n```\n${workspaceFolder:client}\n```",
           "scope": "resource",
           "title": "Workspace Root Folder Path",
           "type": "string"
@@ -828,12 +828,12 @@
                     "type": "string"
                   },
                   "name": {
-                    "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                     "title": "Name of Dictionary",
                     "type": "string"
                   },
                   "path": {
-                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                    "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                     "title": "Optional Path to Dictionary Text File",
                     "type": "string"
                   },
@@ -870,7 +870,7 @@
               }
             ]
           },
-          "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
+          "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
           "scope": "resource",
           "title": "Custom Dictionaries",
           "type": "object"
@@ -1326,14 +1326,14 @@
                   },
                   "name": {
                     "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                     "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                     "title": "Name of Dictionary",
                     "type": "string"
                   },
                   "path": {
                     "description": "A File System Path. Relative paths are relative to the configuration file.",
-                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                    "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                     "title": "Optional Path to Dictionary Text File",
                     "type": "string"
                   },
@@ -1403,14 +1403,14 @@
                   },
                   "name": {
                     "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                     "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                     "title": "Name of Dictionary",
                     "type": "string"
                   },
                   "path": {
                     "description": "A File System Path. Relative paths are relative to the configuration file.",
-                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                    "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                     "title": "Optional Path to Dictionary Text File",
                     "type": "string"
                   },
@@ -1480,14 +1480,14 @@
                   },
                   "name": {
                     "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "The reference name of the dictionary.\n\nExample: `My Words` or `custom`\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf they name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
                     "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                     "title": "Name of Dictionary",
                     "type": "string"
                   },
                   "path": {
                     "description": "A File System Path. Relative paths are relative to the configuration file.",
-                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
+                    "markdownDescription": "Define the path to the dictionary text file.\n\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\n\nFile Format: Each line in the file is considered a dictionary entry.\n\n\nCase is preserved while leading and trailing space is removed.\n\n\nThe path should be absolute, or relative to the workspace.\n\n\n**Example:** relative to User's folder\n\n```\n~/dictionaries/custom_dictionary.txt\n```\n\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```\n${workspaceFolder:client}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might no as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```\n${workspaceFolder}/build/custom_dictionary.txt\n```\n\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```\n./build/custom_dictionary.txt\n```",
                     "title": "Optional Path to Dictionary Text File",
                     "type": "string"
                   },
@@ -1595,19 +1595,19 @@
       "properties": {
         "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
           "default": 80,
-          "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n**Error Message:** _Average Word Size is Too High._\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.",
+          "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average Word Size is Too High._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.",
           "scope": "language-overridable",
           "type": "number"
         },
         "cSpell.blockCheckingWhenLineLengthGreaterThan": {
           "default": 10000,
-          "markdownDescription": "The maximum line length.\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n**Error Message:** _Lines are too long._",
+          "markdownDescription": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._",
           "scope": "language-overridable",
           "type": "number"
         },
         "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
           "default": 500,
-          "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\nIt is used to prevent spell checking of generated files.\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n**Error Message:** _Maximum Word Length is Too High._\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.",
+          "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum Word Length is Too High._\n\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.",
           "scope": "language-overridable",
           "type": "number"
         },
@@ -1712,8 +1712,7 @@
         },
         "cSpell.showAutocompleteSuggestions": {
           "default": false,
-          "description": "Show CSpell in-document directives as you type.",
-          "markdownDescription": "Show CSpell in-document directives as you type.\n**Note:** VS Code must be restarted for this setting to take effect.",
+          "markdownDescription": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
           "scope": "language-overridable",
           "type": "boolean"
         },

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -698,6 +698,13 @@
           "scope": "window",
           "type": "array"
         },
+        "cSpell.checkOnlyEnabledFileTypes": {
+          "default": true,
+          "markdownDescription": "By default, the spell checker checks only enabled file types. Use `cSpell.enableFiletypes`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `cSpell.enableFiletypes`.\nSee `cSpell.enableFiletypes` on how to disable a file type.",
+          "scope": "resource",
+          "title": "Check Only Enabled File Types",
+          "type": "boolean"
+        },
         "cSpell.enableFiletypes": {
           "items": {
             "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -712,7 +712,7 @@
             "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
             "type": "string"
           },
-          "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\nThese are in additional to the file types specified by `cSpell.enabledLanguageIds`.\nTo disable a language, prefix with `!` as in `!json`,\n\n**Example: individual file types**\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
           "scope": "resource",
           "title": "File Types to Check",
           "type": "array",

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -45,6 +45,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * @markdownDescription
      * Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).
      *
+     *
      * Some schemas have special meaning like:
      * - `untitled` - Used for new documents that have not yet been saved
      * - `vscode-notebook-cell` - Used for validating segments of a Notebook.
@@ -90,9 +91,9 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     showStatusAlignment?: 'Left' | 'Right';
 
     /**
-     * Show CSpell in-document directives as you type.
      * @markdownDescription
      * Show CSpell in-document directives as you type.
+     *
      * **Note:** VS Code must be restarted for this setting to take effect.
      * @scope language-overridable
      * @default false
@@ -125,8 +126,10 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * @uniqueItems true
      * @markdownDescription
      * Enable / Disable checking file types (languageIds).
+     *
      * These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
      * To disable a language, prefix with `!` as in `!json`,
+     *
      *
      * **Example: individual file types**
      * ```
@@ -134,6 +137,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * !json       // disable checking for json
      * kotlin      // enable checking for kotlin
      * ```
+     *
      *
      * **Example: enable all file types**
      * ```
@@ -165,7 +169,8 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *
      * This is used to find the `cspell.json` file for the workspace.
      *
-     * Example: use the `client` folder
+     *
+     * **Example: use the `client` folder**
      * ```
      * ${workspaceFolder:client}
      * ```
@@ -212,6 +217,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * Define custom dictionaries to be included by default.
      * If `addWords` is `true` words will be added to this dictionary.
      *
+     *
      * **Example:**
      *
      * ```js
@@ -236,7 +242,8 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * Only spell check files that are in the currently open workspace.
      * This same effect can be achieved using the `files` setting.
      *
-     * ```
+     *
+     * ```js
      * "cSpell.files": ["**"]
      * ```
      * @default false
@@ -285,13 +292,14 @@ type EnableCustomDictionary = boolean;
  * Enable / Disable checking file types (languageIds).
  * To disable a language, prefix with `!` as in `!json`,
  *
+ *
  * Example:
  * ```
  * jsonc       // enable checking for jsonc
  * !json       // disable checking for json
  * kotlin      // enable checking for kotlin
  * ```
- * @pattern ^!?(?!\s)[\s\w_.\-]+$
+ * @pattern (^!*(?!\s)[\s\w_.\-]+$)|(^!*[*]$)
  * @patternErrorMessage "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space."
  */
 type EnableFileTypeId = string;
@@ -301,10 +309,13 @@ interface SpellCheckerShouldCheckDocSettings {
      * @markdownDescription
      * The maximum line length.
      *
+     *
      * Block spell checking if lines are longer than the value given.
      * This is used to prevent spell checking generated files.
      *
+     *
      * **Error Message:** _Lines are too long._
+     *
      *
      * @scope language-overridable
      * @default 10000
@@ -314,12 +325,16 @@ interface SpellCheckerShouldCheckDocSettings {
      * @markdownDescription
      * The maximum length of a chunk of text without word breaks.
      *
+     *
      * It is used to prevent spell checking of generated files.
+     *
      *
      * A chunk is the characters between absolute word breaks.
      * Absolute word breaks match: `/[\s,{}[\]]/`, i.e. spaces or braces.
      *
+     *
      * **Error Message:** _Maximum Word Length is Too High._
+     *
      *
      * If you are seeing this message, it means that the file contains a very long line
      * without many word breaks.
@@ -332,10 +347,13 @@ interface SpellCheckerShouldCheckDocSettings {
      * @markdownDescription
      * The maximum average length of chunks of text without word breaks.
      *
+     *
      * A chunk is the characters between absolute word breaks.
      * Absolute word breaks match: `/[\s,{}[\]]/`
      *
+     *
      * **Error Message:** _Average Word Size is Too High._
+     *
      *
      * If you are seeing this message, it means that the file contains mostly long lines
      * without many word breaks.
@@ -367,7 +385,9 @@ export interface CustomDictionary {
      * @markdownDescription
      * The reference name of the dictionary.
      *
+     *
      * Example: `My Words` or `custom`
+     *
      *
      * If they name matches a pre-defined dictionary, it will override the pre-defined dictionary.
      * If you use: `typescript` it will replace the built-in TypeScript dictionary.
@@ -386,14 +406,19 @@ export interface CustomDictionary {
      * @markdownDescription
      * Define the path to the dictionary text file.
      *
+     *
      * **Note:** if path is `undefined` the `name`d dictionary is expected to be found
      * in the `dictionaryDefinitions`.
      *
+     *
      * File Format: Each line in the file is considered a dictionary entry.
+     *
      *
      * Case is preserved while leading and trailing space is removed.
      *
+     *
      * The path should be absolute, or relative to the workspace.
+     *
      *
      * **Example:** relative to User's folder
      *
@@ -401,11 +426,13 @@ export interface CustomDictionary {
      * ~/dictionaries/custom_dictionary.txt
      * ```
      *
+     *
      * **Example:** relative to the `client` folder in a multi-root workspace
      *
      * ```
      * ${workspaceFolder:client}/build/custom_dictionary.txt
      * ```
+     *
      *
      * **Example:** relative to the current workspace folder in a single-root workspace
      *
@@ -415,6 +442,7 @@ export interface CustomDictionary {
      * ```
      * ${workspaceFolder}/build/custom_dictionary.txt
      * ```
+     *
      *
      * **Example:** relative to the workspace folder in a single-root workspace or the first folder in
      * a multi-root workspace

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -243,6 +243,16 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     'experimental.enableRegexpView'?: boolean;
 }
 
+interface InternalSettings {
+    /**
+     * Map of known and enabled file types.
+     * `true` - enabled
+     * `false` - disabled
+     * @hidden
+     */
+    mapOfEnabledFileTypes?: Map<string, boolean>;
+}
+
 /**
  * @title Named dictionary to be enabled / disabled
  * @markdownDescription
@@ -733,7 +743,7 @@ type GlobDefX = GlobDef;
 
 export interface CustomDictionaryWithScope extends CustomDictionary {}
 
-export interface CSpellUserSettings extends SpellCheckerSettings, CSpellSettingsPackageProperties {}
+export interface CSpellUserSettings extends SpellCheckerSettings, CSpellSettingsPackageProperties, InternalSettings {}
 
 export type SpellCheckerSettingsProperties = keyof SpellCheckerSettings;
 export type SpellCheckerSettingsVSCodePropertyKeys = `cspell.${keyof CSpellUserSettings}`;

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -138,6 +138,19 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     enableFiletypes?: EnableFileTypeId[];
 
     /**
+     * @title Check Only Enabled File Types
+     * @scope resource
+     * @default true
+     * @markdownDescription
+     * By default, the spell checker checks only enabled file types. Use `cSpell.enableFiletypes`
+     * to turn on / off various file types.
+     *
+     * When this setting is `false`, all file types are checked except for the ones disabled by `cSpell.enableFiletypes`.
+     * See `cSpell.enableFiletypes` on how to disable a file type.
+     */
+    checkOnlyEnabledFileTypes?: boolean;
+
+    /**
      * @title Workspace Root Folder Path
      * @scope resource
      * @markdownDescription
@@ -901,6 +914,7 @@ type VSConfigFilesAndFolders = PrefixWithCspell<_VSConfigFilesAndFolders>;
 type _VSConfigFilesAndFolders = Pick<
     SpellCheckerSettingsVSCodeBase,
     | 'allowedSchemas'
+    | 'checkOnlyEnabledFileTypes'
     | 'enableFiletypes'
     | 'files'
     | 'globRoot'

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -128,11 +128,17 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * These are in additional to the file types specified by `cSpell.enabledLanguageIds`.
      * To disable a language, prefix with `!` as in `!json`,
      *
-     * Example:
+     * **Example: individual file types**
      * ```
      * jsonc       // enable checking for jsonc
      * !json       // disable checking for json
      * kotlin      // enable checking for kotlin
+     * ```
+     *
+     * **Example: enable all file types**
+     * ```
+     * *           // enable checking for all file types
+     * !json       // except for json
      * ```
      */
     enableFiletypes?: EnableFileTypeId[];

--- a/packages/_server/src/config/documentSettings.test.ts
+++ b/packages/_server/src/config/documentSettings.test.ts
@@ -11,6 +11,7 @@ import {
     debugExports,
     DocumentSettings,
     ExcludedByMatch,
+    isLanguageEnabled,
     isUriAllowed,
     isUriBlocked,
     __testing__,
@@ -182,6 +183,18 @@ describe('Validate DocumentSettings', () => {
         const r = __testing__.applyEnableFiletypes(enabled, settings);
         // cspell:ignore freeformfortran
         expect(r.enabledLanguageIds).toEqual(ac(['typescript', 'markdown', 'FreeFormFortran', 'json']));
+    });
+
+    test.each`
+        languageId      | settings                                                                      | expected
+        ${'typescript'} | ${{}}                                                                         | ${false}
+        ${'typescript'} | ${{ enableFiletypes: ['typescript'] }}                                        | ${true}
+        ${'typescript'} | ${{ enableFiletypes: ['!!!typescript'], enabledLanguageIds: ['typescript'] }} | ${false}
+        ${'javascript'} | ${{ enableFiletypes: ['typescript'], checkOnlyEnabledFileTypes: false }}      | ${true}
+        ${'javascript'} | ${{ enableFiletypes: ['typescript'], checkOnlyEnabledFileTypes: true }}       | ${false}
+        ${'javascript'} | ${{ enableFiletypes: ['!javascript'], checkOnlyEnabledFileTypes: false }}     | ${false}
+    `('isLanguageEnabled $languageId $settings', ({ languageId, settings, expected }) => {
+        expect(isLanguageEnabled(languageId, settings)).toBe(expected);
     });
 
     test('isExcludedBy', async () => {

--- a/packages/_server/src/config/documentSettings.test.ts
+++ b/packages/_server/src/config/documentSettings.test.ts
@@ -193,6 +193,12 @@ describe('Validate DocumentSettings', () => {
         ${'javascript'} | ${{ enableFiletypes: ['typescript'], checkOnlyEnabledFileTypes: false }}      | ${true}
         ${'javascript'} | ${{ enableFiletypes: ['typescript'], checkOnlyEnabledFileTypes: true }}       | ${false}
         ${'javascript'} | ${{ enableFiletypes: ['!javascript'], checkOnlyEnabledFileTypes: false }}     | ${false}
+        ${'typescript'} | ${{ enableFiletypes: ['*'] }}                                                 | ${true}
+        ${'typescript'} | ${{ enableFiletypes: ['*'], checkOnlyEnabledFileTypes: true }}                | ${true}
+        ${'typescript'} | ${{ enableFiletypes: ['*'], checkOnlyEnabledFileTypes: false }}               | ${true}
+        ${'typescript'} | ${{ enableFiletypes: ['!*'], checkOnlyEnabledFileTypes: true }}               | ${false}
+        ${'typescript'} | ${{ enableFiletypes: ['!*'], checkOnlyEnabledFileTypes: false }}              | ${true}
+        ${'java'}       | ${{ enableFiletypes: ['!*', 'java'], checkOnlyEnabledFileTypes: true }}       | ${true}
     `('isLanguageEnabled $languageId $settings', ({ languageId, settings, expected }) => {
         expect(isLanguageEnabled(languageId, settings)).toBe(expected);
     });

--- a/packages/_server/src/config/documentSettings.test.ts
+++ b/packages/_server/src/config/documentSettings.test.ts
@@ -67,6 +67,8 @@ const configFiles = {
     serverConfigVSCode: Path.resolve(pathWorkspaceServer, '.vscode/cspell.json'),
 };
 
+const ac = expect.arrayContaining;
+
 describe('Validate DocumentSettings', () => {
     beforeEach(() => {
         // Clear all mock instances and calls to constructor and all methods:
@@ -179,7 +181,7 @@ describe('Validate DocumentSettings', () => {
         });
         const r = __testing__.applyEnableFiletypes(enabled, settings);
         // cspell:ignore freeformfortran
-        expect(r.enabledLanguageIds).toEqual(['typescript', 'markdown', 'FreeFormFortran', 'json']);
+        expect(r.enabledLanguageIds).toEqual(ac(['typescript', 'markdown', 'FreeFormFortran', 'json']));
     });
 
     test('isExcludedBy', async () => {

--- a/packages/_server/src/config/documentSettings.ts
+++ b/packages/_server/src/config/documentSettings.ts
@@ -90,6 +90,8 @@ const _schemaMapToFile = {
 
 const schemeMapToFile: Record<string, true> = Object.freeze(_schemaMapToFile);
 
+const defaultCheckOnlyEnabledFileTypes = true;
+
 interface Clearable {
     clear: () => any;
 }
@@ -448,8 +450,9 @@ function calcMapOfEnabledFileTypes(
 
 export function isLanguageEnabled(languageId: string, settings: CSpellUserSettings): boolean {
     const mapOfEnabledFileTypes = settings.mapOfEnabledFileTypes || calcMapOfEnabledFileTypes(settings.enableFiletypes || [], settings);
-    const found = mapOfEnabledFileTypes.get(languageId);
-    return !!found;
+    const enabled = mapOfEnabledFileTypes.get(languageId);
+    const checkOnly = settings.checkOnlyEnabledFileTypes ?? defaultCheckOnlyEnabledFileTypes;
+    return checkOnly ? !!enabled : enabled !== false;
 }
 
 function _matchingFoldersForUri(folders: WorkspaceFolder[], docUri: string): WorkspaceFolder[] {

--- a/packages/_server/src/config/documentSettings.ts
+++ b/packages/_server/src/config/documentSettings.ts
@@ -451,8 +451,9 @@ function calcMapOfEnabledFileTypes(
 export function isLanguageEnabled(languageId: string, settings: CSpellUserSettings): boolean {
     const mapOfEnabledFileTypes = settings.mapOfEnabledFileTypes || calcMapOfEnabledFileTypes(settings.enableFiletypes || [], settings);
     const enabled = mapOfEnabledFileTypes.get(languageId);
+    const starEnabled = mapOfEnabledFileTypes.get('*');
     const checkOnly = settings.checkOnlyEnabledFileTypes ?? defaultCheckOnlyEnabledFileTypes;
-    return checkOnly ? !!enabled : enabled !== false;
+    return checkOnly && starEnabled !== true ? !!enabled : enabled !== false;
 }
 
 function _matchingFoldersForUri(folders: WorkspaceFolder[], docUri: string): WorkspaceFolder[] {

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -14,6 +14,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     blockCheckingWhenLineLengthGreaterThan: 'blockCheckingWhenLineLengthGreaterThan',
     blockCheckingWhenTextChunkSizeGreaterThan: 'blockCheckingWhenTextChunkSizeGreaterThan',
     checkLimit: 'checkLimit',
+    checkOnlyEnabledFileTypes: 'checkOnlyEnabledFileTypes',
     customDictionaries: 'customDictionaries',
     customFolderDictionaries: 'customFolderDictionaries',
     customUserDictionaries: 'customUserDictionaries',

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -22,6 +22,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     fixSpellingWithRenameProvider: 'fixSpellingWithRenameProvider',
     logLevel: 'logLevel',
     logFile: 'logFile',
+    mapOfEnabledFileTypes: 'mapOfEnabledFileTypes',
     maxDuplicateProblems: 'maxDuplicateProblems',
     maxNumberOfProblems: 'maxNumberOfProblems',
     noSuggestDictionaries: 'noSuggestDictionaries',


### PR DESCRIPTION
fix: #1927 
fix: #1935 - `checkOnlyEnabledFileTypes: false` gets it close. There are still differences for performance and personal preference reasons. It is still possible to get the extension to not check a file type.

### Example checking all file types except `java`:

```json
"cSpell.checkOnlyEnabledFileTypes": false,
"cSpell.enableFiletypes": ["!java"]
```

**Alternate method**
```json
"cSpell.enableFiletypes": ["*", "!java"]
```
 
