### PR TITLE
fix: allow custom dictionaries with non-txt extension

### DIFF
--- a/packages/_server/src/config/documentSettings.ts
+++ b/packages/_server/src/config/documentSettings.ts
@@ -628,7 +628,7 @@ export function extractTargetDictionaries(settings: CSpellUserSettings): Diction
     const regIsTextFile = /\.txt$/;
     const targetDicts = activeDicts
         .filter(isDictionaryDefinitionCustom)
-        .filter((d) => regIsTextFile.test(d.path) && d.addWords)
+        .filter((d) => d.addWords || (regIsTextFile.test(d.path) && d.addWords))
         .filter((d) => !regExIsOwnedByCspell.test(d.path))
         .filter((d) => !regExIsOwnedByExtension.test(d.path));
     return targetDicts;

--- a/packages/client/src/infoViewer/infoHelper.ts
+++ b/packages/client/src/infoViewer/infoHelper.ts
@@ -18,6 +18,7 @@ import type {
     ConfigTargetCSpell,
     CSpellUserSettings,
     DictionaryDefinition,
+    DictionaryDefinitionCustom,
     GetConfigurationForDocumentResult,
 } from '../client';
 import { CSpellClient } from '../client';
@@ -237,16 +238,17 @@ function extractDictionariesFromConfig(config: CSpellUserSettings | undefined): 
     return [...dictionariesByName.values()];
 }
 
-function mapDict(e: DictionaryDefinition): DictionaryEntry {
-    const dictUri = Uri.joinPath(Uri.file(e.path || ''), e.file || '');
+function mapDict(def: DictionaryDefinition): DictionaryEntry {
+    const dictUri = Uri.joinPath(Uri.file(def.path || ''), def.file || '');
     const dictUriStr = dictUri.toString();
-    const isCustomDict = regIsTextFile.test(dictUriStr) && !regIsCspellDict.test(dictUriStr);
+    const isCustomDict =
+        (<DictionaryDefinitionCustom>def).addWords || (regIsTextFile.test(dictUriStr) && !regIsCspellDict.test(dictUriStr));
 
     return {
-        name: e.name,
+        name: def.name,
         locales: [],
         languageIds: [],
-        description: e.description,
+        description: def.description,
         uri: isCustomDict ? dictUriStr : undefined,
         uriName: isCustomDict ? normalizeFilenameToFriendlyName(dictUri) : undefined,
     };

--- a/packages/client/src/settings/CSpellSettings.test.ts
+++ b/packages/client/src/settings/CSpellSettings.test.ts
@@ -130,7 +130,7 @@ describe('Validate CSpellSettings functions', () => {
 
     test.each`
         file              | name       | error
-        ${''}             | ${'dict'}  | ${e(sm(/Failed to add words to dictionary "dict".*, unsupported format./))}
+        ${''}             | ${'dict'}  | ${e(sm(/Failed to add words to dictionary "dict", EISDIR/))}
         ${'words.txt.gz'} | ${'words'} | ${e(sm(/"words".*unsupported format:.*words.txt.gz/))}
         ${'cspell.json'}  | ${'json'}  | ${e(sm(/"json".*unsupported format:.*cspell.json/))}
     `('addWordsToCustomDictionary_failures "$name" $file', async ({ file, name, error }) => {

--- a/packages/client/src/settings/DictionaryTarget.ts
+++ b/packages/client/src/settings/DictionaryTarget.ts
@@ -1,3 +1,4 @@
+import { isErrnoException } from 'common-utils/index.js';
 import { uriToName } from 'common-utils/uriHelper.js';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -6,7 +7,7 @@ import { Uri } from 'vscode';
 import { ConfigRepository, createCSpellConfigRepository } from './configRepository';
 import { addWordsFn, removeWordsFn, updaterAddWords, updaterRemoveWords } from './configUpdaters';
 
-const regIsSupportedCustomDictionaryFormat = /\.txt$/i;
+const regBlockUpdateDictionaryFormat = /(\.((gz|jsonc?|yaml|yml|c?js)$|trie\b)|^$|[/\\]$)/i;
 
 export interface DictionaryTarget {
     /** Name of dictionary */
@@ -80,7 +81,7 @@ async function addWordsToCustomDictionary(words: string[], dict: CustomDictDef):
 
 async function updateWordInCustomDictionary(updateFn: (words: string[]) => string[], dict: CustomDictDef): Promise<void> {
     const fsPath = dict.uri.fsPath;
-    if (!regIsSupportedCustomDictionaryFormat.test(fsPath)) {
+    if (regBlockUpdateDictionaryFormat.test(fsPath)) {
         return Promise.reject(new Error(`Failed to add words to dictionary "${dict.name}", unsupported format: "${dict.uri.fsPath}".`));
     }
     try {
@@ -89,6 +90,7 @@ async function updateWordInCustomDictionary(updateFn: (words: string[]) => strin
         await fs.mkdirp(path.dirname(fsPath));
         await fs.writeFile(fsPath, lines.join('\n').trim().concat('\n'));
     } catch (e) {
-        return Promise.reject(new Error(`Failed to add words to dictionary "${dict.name}", ${format(e)}`));
+        const errMsg = isErrnoException(e) ? e.message : format(e);
+        return Promise.reject(new Error(`Failed to add words to dictionary "${dict.name}", ${errMsg}`));
     }
 }

--- a/samples/custom-dictionary/README.md
+++ b/samples/custom-dictionary/README.md
@@ -7,3 +7,7 @@ wordb
 wordc
 wordd
 worde
+
+Here is text from `dict`:
+
+Compaknee.

--- a/samples/custom-dictionary/cspell.json
+++ b/samples/custom-dictionary/cspell.json
@@ -1,13 +1,21 @@
 {
-    "version": "0.1",
+    "version": "0.2",
     "name": "custom-dictionary",
     "description": "Config with a custom dictionary.",
     "dictionaryDefinitions": [
         {
             "name": "words",
             "path": "./words.txt"
+        },
+        {
+            "name": "dict",
+            "path": "./dict.dic",
+            "addWords": true
         }
     ],
-    "dictionaries": ["words"],
+    "dictionaries": [
+        "words",
+        "dict"
+    ],
     "words": []
 }

--- a/samples/custom-dictionary/dict.dic
+++ b/samples/custom-dictionary/dict.dic
@@ -1,0 +1,1 @@
+Compaknee


### PR DESCRIPTION
Need to use `addWords: true` to enable writing to non-txt files.
Fix: #2001