### PR TITLE
doc: README - Add "locale" in-document setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ All settings are prefixed with `cSpell:` or `spell-checker:`.
 -   `enable` -- turn the spell checker back on after it has been turned off.
 -   `ignore` -- specify a list of words to be ignored.
 -   `words` -- specify a list of words to be considered correct and will appear in the suggestions list.
--   `locale` -- set locale (example: `cSpell:locale fr` to use French language)
+-   `locale` -- set locale (example: `cSpell:locale fr,en` to use French and English languages)
 -   `ignoreRegExp` -- Any text matching the regular expression will NOT be checked for spelling.
 -   `includeRegExp` -- Only text matching the collection of includeRegExp will be checked.
 -   `enableCompoundWords` / `disableCompoundWords` -- Allow / disallow words like: "stringlength".
@@ -566,4 +566,5 @@ See: [FAQ](https://github.com/streetsidesoftware/vscode-spell-checker/blob/main/
     cSpell:ignore mkdirp githubusercontent streetsidesoftware vsmarketplacebadge visualstudio lightbulb stringlength
     cSpell:ignore errormessage errornumber medicalterms acanthopterygious
     cSpell:words Verdana
+    cSpell:locale en
 -->

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ All settings are prefixed with `cSpell:` or `spell-checker:`.
 -   `enable` -- turn the spell checker back on after it has been turned off.
 -   `ignore` -- specify a list of words to be ignored.
 -   `words` -- specify a list of words to be considered correct and will appear in the suggestions list.
+-   `locale` -- set locale (example: `cSpell:locale fr` to use French language)
 -   `ignoreRegExp` -- Any text matching the regular expression will NOT be checked for spelling.
 -   `includeRegExp` -- Only text matching the collection of includeRegExp will be checked.
 -   `enableCompoundWords` / `disableCompoundWords` -- Allow / disallow words like: "stringlength".


### PR DESCRIPTION
Hi

I'm searching for a while howto be able to declare per-file language and finally found the answer in #676.

I don't know why it's not documented in [cSpell documentation](https://cspell.org/configuration/document-settings/#in-document-settings). I probably would make a PR there too