### PR TITLE
fix: Make sure `__proto__` cannot be overwritten.

### DIFF
--- a/packages/jest-mock-vscode/src/vscode/WorkspaceConfiguration.ts
+++ b/packages/jest-mock-vscode/src/vscode/WorkspaceConfiguration.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import type * as vscode from 'vscode';
 import { ConfigurationTarget } from './extHostTypes';
 
@@ -209,7 +210,8 @@ function setKeyValue(data: Record<string, any>, section: string, value: any): an
     function r(data: Record<string, any>, path: string[]): any {
         if (!path.length) return value;
         const head = path[0];
-        data[head] = r(data[head] || {}, path.slice(1));
+        assert(head !== '__proto__');
+        data[head] = r(data[head] || Object.create(null), path.slice(1));
         return data;
     }
 


### PR DESCRIPTION
Address:
> This assignment may alter Object.prototype if a malicious '__proto__' string is injected.