### PR TITLE
feat: Support remote dictionaries

### DIFF
--- a/fixtures/workspaces/dictionaries/remote/README.md
+++ b/fixtures/workspaces/dictionaries/remote/README.md
@@ -1,0 +1,5 @@
+# Remote Dictionaries
+
+It is possible to define a remote dictionary file using `https://` url.
+
+This directory contains an example

--- a/fixtures/workspaces/dictionaries/remote/cspell.json
+++ b/fixtures/workspaces/dictionaries/remote/cspell.json
@@ -1,0 +1,16 @@
+{
+    "dictionaryDefinitions": [
+        {
+            "name": "cities-remote",
+            "path": "https://github.com/streetsidesoftware/cspell/raw/main/packages/cspell-io/samples/cities.txt.gz",
+            "type": "W"
+        }
+    ],
+    "dictionaries": ["cities-remote"],
+    "overrides": [
+        {
+            "filename": "**/test.txt",
+            "language": "unknown"
+        }
+    ]
+}

--- a/fixtures/workspaces/dictionaries/remote/test.txt
+++ b/fixtures/workspaces/dictionaries/remote/test.txt
@@ -1,0 +1,8 @@
+New York
+New Amsterdam
+Las Angles
+San Francisco
+New Delhi
+Mexico City
+London
+Paris

--- a/packages/_server/src/utils/fileWatcher.ts
+++ b/packages/_server/src/utils/fileWatcher.ts
@@ -99,7 +99,7 @@ export class FileWatcher implements Disposable {
 function watch(filename: string, callback: (eventType?: EventType, filename?: string) => void): Watcher {
     const uri = toFileUri(filename);
     if (uri.scheme === 'file') {
-        return nodeWatch(uri.fsPath, { persistent: false }, callback);
+        return nodeWatch(filename, { persistent: false }, callback);
     }
 
     return {

--- a/packages/_server/src/utils/fileWatcher.ts
+++ b/packages/_server/src/utils/fileWatcher.ts
@@ -1,6 +1,7 @@
 import { logError } from 'common-utils/log.js';
+import { toFileUri } from 'common-utils/uriHelper.js';
 import { FSWatcher } from 'fs';
-import watch from 'node-watch';
+import nodeWatch from 'node-watch';
 import { format } from 'util';
 import type { Disposable } from 'vscode-languageserver/node';
 
@@ -9,8 +10,10 @@ export type EventType = KnownEvents | string;
 
 export type Listener = (eventType?: EventType, filename?: string) => void;
 
+type Watcher = Pick<FSWatcher, 'close'>;
+
 export class FileWatcher implements Disposable {
-    private watchedFile = new Map<string, FSWatcher>();
+    private watchedFile = new Map<string, Watcher>();
     private listeners = new Set<Listener>();
 
     /**
@@ -51,7 +54,7 @@ export class FileWatcher implements Disposable {
     addFile(filename: string): boolean {
         if (!this.watchedFile.has(filename)) {
             try {
-                this.watchedFile.set(filename, watch(filename, { persistent: false }, this.trigger));
+                this.watchedFile.set(filename, watch(filename, this.trigger));
             } catch (e) {
                 logError(format(e));
                 return false;
@@ -91,4 +94,17 @@ export class FileWatcher implements Disposable {
             listener(eventType, filename);
         }
     }
+}
+
+function watch(filename: string, callback: (eventType?: EventType, filename?: string) => void): Watcher {
+    const uri = toFileUri(filename);
+    if (uri.scheme === 'file') {
+        return nodeWatch(uri.fsPath, { persistent: false }, callback);
+    }
+
+    return {
+        close() {
+            callback('close', filename);
+        },
+    };
 }


### PR DESCRIPTION
CSpell 6.2.2 supports using remote dictionaries. Fix an issues with the extension that prevent reading remote dictionaries.

Related to #2044