### PR TITLE
Remove "vscode" from the list of blocked schemes

### DIFF
--- a/packages/_server/src/config/documentSettings.ts
+++ b/packages/_server/src/config/documentSettings.ts
@@ -80,7 +80,7 @@ const defaultExclude: Glob[] = [
 ];
 
 const defaultAllowedSchemes = ['gist', 'file', 'sftp', 'untitled', 'vscode-notebook-cell'];
-const schemeBlockList = ['git', 'output', 'debug', 'vscode'];
+const schemeBlockList = ['git', 'output', 'debug'];
 
 const defaultRootUri = toFileUri(process.cwd()).toString();
 


### PR DESCRIPTION
👋🏻 I am a member of the VS Code team and I have been looking at a feature request (https://github.com/microsoft/vscode/issues/35571) to enable spell check for the SCM input field. I have validated that extension authors already have all the necessary APIs in place to access the text document that is associated with the SCM input field.

Looking at the code of this particular extension, the only blocker at the moment to enable this functionality is due to the fact that the `vscode` scheme is in the list of clocked schemes. Removing it from there, one case use the existing settings to configure the extension to provide spell checking capabilities to the SCM input field.