### PR TITLE
fix: Add default support for `vscode` `scminput` files.

### DIFF
--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -66,6 +66,7 @@ readonly
 restructuredtext
 rfdc
 rmwc
+scminput
 scrollbar
 shortname
 shrinkwrap

--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -578,7 +578,7 @@ Description
     - `vscode-userdata` - Needed to spell check `.code-snippets`
 
 Default
-: [ _`"file"`_, _`"gist"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_, _`"vscode-userdata"`_ ]
+: [ _`"file"`_, _`"gist"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode"`_, _`"vscode-notebook-cell"`_, _`"vscode-userdata"`_ ]
 
 ---
 
@@ -1396,6 +1396,6 @@ Description
 : Specify a list of file types to spell check. It is better to use `#cSpell.enableFiletypes#` to Enable / Disable checking files types.
 
 Default
-: [ _`"asciidoc"`_, _`"c"`_, _`"cpp"`_, _`"csharp"`_, _`"css"`_, _`"elixir"`_, _`"git-commit"`_, _`"go"`_, _`"graphql"`_, _`"handlebars"`_, _`"haskell"`_, _`"html"`_, _`"jade"`_, _`"java"`_, _`"javascript"`_, _`"javascriptreact"`_, _`"json"`_, _`"jsonc"`_, _`"jupyter"`_, _`"latex"`_, _`"less"`_, _`"markdown"`_, _`"php"`_, _`"plaintext"`_, _`"python"`_, _`"pug"`_, _`"restructuredtext"`_, _`"rust"`_, _`"scala"`_, _`"scss"`_, _`"swift"`_, _`"text"`_, _`"typescript"`_, _`"typescriptreact"`_, _`"vue"`_, _`"yaml"`_, _`"yml"`_ ]
+: [ _`"asciidoc"`_, _`"c"`_, _`"cpp"`_, _`"csharp"`_, _`"css"`_, _`"elixir"`_, _`"git-commit"`_, _`"go"`_, _`"graphql"`_, _`"handlebars"`_, _`"haskell"`_, _`"html"`_, _`"jade"`_, _`"java"`_, _`"javascript"`_, _`"javascriptreact"`_, _`"json"`_, _`"jsonc"`_, _`"jupyter"`_, _`"latex"`_, _`"less"`_, _`"markdown"`_, _`"php"`_, _`"plaintext"`_, _`"python"`_, _`"pug"`_, _`"restructuredtext"`_, _`"rust"`_, _`"scala"`_, _`"scminput"`_, _`"scss"`_, _`"swift"`_, _`"text"`_, _`"typescript"`_, _`"typescriptreact"`_, _`"vue"`_, _`"yaml"`_, _`"yml"`_ ]
 
 ---

--- a/package.json
+++ b/package.json
@@ -1122,6 +1122,7 @@
               "gist",
               "sftp",
               "untitled",
+              "vscode",
               "vscode-notebook-cell",
               "vscode-userdata"
             ],
@@ -2004,6 +2005,7 @@
               "restructuredtext",
               "rust",
               "scala",
+              "scminput",
               "scss",
               "swift",
               "text",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -745,6 +745,7 @@
             "gist",
             "sftp",
             "untitled",
+            "vscode",
             "vscode-notebook-cell",
             "vscode-userdata"
           ],
@@ -1627,6 +1628,7 @@
             "restructuredtext",
             "rust",
             "scala",
+            "scminput",
             "scss",
             "swift",
             "text",

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -52,7 +52,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * - `vscode-notebook-cell` - Used for validating segments of a Notebook.
      * - `vscode-userdata` - Needed to spell check `.code-snippets`
      * @scope window
-     * @default ["file", "gist", "sftp", "untitled", "vscode-notebook-cell", "vscode-userdata"]
+     * @default ["file", "gist", "sftp", "untitled", "vscode", "vscode-notebook-cell", "vscode-userdata"]
      */
     allowedSchemas?: string[];
 
@@ -618,6 +618,7 @@ interface CSpellSettingsPackageProperties extends CSpellSettings {
      *       "restructuredtext",
      *       "rust",
      *       "scala",
+     *       "scminput",
      *       "scss",
      *       "swift",
      *       "text",


### PR DESCRIPTION
Related to [SCM: Support input box spell checking · Issue #35571 · microsoft/vscode](https://github.com/microsoft/vscode/issues/35571)