### PR TITLE
feat: Move Spelling Menu items into a submenu

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -297,19 +297,20 @@ Default
 
 # Reporting and Display
 
-| Setting                                                                            | Scope                | Description                                                                     |
-| ---------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
-| [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                                 | resource             | Set Diagnostic Reporting Level                                                  |
-| [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                       | resource             | The maximum number of times the same word can be flagged as an error in a file. |
-| [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                         | resource             | Controls the maximum number of spelling errors per document.                    |
-| [`cSpell.minWordLength`](#cspellminwordlength)                                     | resource             | The minimum length of a word before checking it against a dictionary.           |
-| [`cSpell.numSuggestions`](#cspellnumsuggestions)                                   | resource             | Controls the number of suggestions shown.                                       |
-| [`cSpell.showAutocompleteSuggestions`](#cspellshowautocompletesuggestions)         | language-overridable | Show CSpell in-document directives as you type.                                 |
-| [`cSpell.showCommandsInEditorContextMenu`](#cspellshowcommandsineditorcontextmenu) | application          | Show Spell Checker actions in Editor Context Menu                               |
-| [`cSpell.showStatus`](#cspellshowstatus)                                           | application          | Display the spell checker status on the status bar.                             |
-| [`cSpell.showStatusAlignment`](#cspellshowstatusalignment)                         | application          | The side of the status bar to display the spell checker status.                 |
-| [`cSpell.suggestionMenuType`](#cspellsuggestionmenutype)                           | resource             | The type of menu used to display spelling suggestions.                          |
-| [`cSpell.suggestionNumChanges`](#cspellsuggestionnumchanges)                       | resource             | The maximum number of changes allowed on a word to be considered a suggestions. |
+| Setting                                                                                     | Scope                | Description                                                                     |
+| ------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                                          | resource             | Set Diagnostic Reporting Level                                                  |
+| [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                                | resource             | The maximum number of times the same word can be flagged as an error in a file. |
+| [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                                  | resource             | Controls the maximum number of spelling errors per document.                    |
+| [`cSpell.minWordLength`](#cspellminwordlength)                                              | resource             | The minimum length of a word before checking it against a dictionary.           |
+| [`cSpell.numSuggestions`](#cspellnumsuggestions)                                            | resource             | Controls the number of suggestions shown.                                       |
+| [`cSpell.showAutocompleteSuggestions`](#cspellshowautocompletesuggestions)                  | language-overridable | Show CSpell in-document directives as you type.                                 |
+| [`cSpell.showCommandsInEditorContextMenu`](#cspellshowcommandsineditorcontextmenu)          | application          | Show Spell Checker actions in Editor Context Menu                               |
+| [`cSpell.showStatus`](#cspellshowstatus)                                                    | application          | Display the spell checker status on the status bar.                             |
+| [`cSpell.showStatusAlignment`](#cspellshowstatusalignment)                                  | application          | The side of the status bar to display the spell checker status.                 |
+| [`cSpell.showSuggestionsLinkInEditorConte…`](#cspellshowsuggestionslinkineditorcontextmenu) | application          | Show Spelling Suggestions link in the top level context menu.                   |
+| [`cSpell.suggestionMenuType`](#cspellsuggestionmenutype)                                    | resource             | The type of menu used to display spelling suggestions.                          |
+| [`cSpell.suggestionNumChanges`](#cspellsuggestionnumchanges)                                | resource             | The maximum number of changes allowed on a word to be considered a suggestions. |
 
 ## Definitions
 
@@ -491,6 +492,25 @@ Description
 
 Default
 : _`"Right"`_
+
+---
+
+### `cSpell.showSuggestionsLinkInEditorContextMenu`
+
+Name
+: `cSpell.showSuggestionsLinkInEditorContextMenu`
+
+Type
+: boolean
+
+Scope
+: application
+
+Description
+: Show Spelling Suggestions link in the top level context menu.
+
+Default
+: _`true`_
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,19 @@
       "editor/context": [
         {
           "command": "cSpell.suggestSpellingCorrections",
-          "when": "editorTextFocus && cSpell.editorMenuContext.showSuggestions",
+          "when": "editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions",
+          "group": "A_cspell@000"
+        },
+        {
+          "submenu": "cSpell.spelling",
+          "group": "A_cspell@001",
+          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu"
+        }
+      ],
+      "cSpell.spelling": [
+        {
+          "command": "cSpell.suggestSpellingCorrections",
+          "when": "editorTextFocus && !config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions",
           "group": "A_cspell@001"
         },
         {
@@ -100,19 +112,31 @@
           "group": "A_cspell@060"
         },
         {
-          "command": "cSpell.createCustomDictionary",
-          "when": "editorTextFocus && cSpell.editorMenuContext.createCustomDictionary",
-          "group": "A_cspell@070"
+          "command": "cSpell.addIgnoreWord",
+          "when": "editorTextFocus && cSpell.editorMenuContext.addIgnoreWord",
+          "group": "A_cspell@090"
         },
         {
           "command": "cSpell.createCSpellConfig",
           "when": "editorTextFocus && cSpell.editorMenuContext.createCSpellConfig",
-          "group": "A_cspell@080"
+          "group": "B_cspell@010"
         },
         {
-          "command": "cSpell.addIgnoreWord",
-          "when": "editorTextFocus && cSpell.editorMenuContext.addIgnoreWord",
-          "group": "A_cspell@090"
+          "command": "cSpell.createCustomDictionary",
+          "when": "editorTextFocus && cSpell.editorMenuContext.createCustomDictionary",
+          "group": "B_cspell@020"
+        }
+      ],
+      "cSpell.configMenu": [
+        {
+          "command": "cSpell.createCSpellConfig",
+          "when": "editorTextFocus && cSpell.editorMenuContext.createCSpellConfig",
+          "group": "A_cspell@010"
+        },
+        {
+          "command": "cSpell.createCustomDictionary",
+          "when": "editorTextFocus && cSpell.editorMenuContext.createCustomDictionary",
+          "group": "A_cspell@070"
         }
       ],
       "commandPalette": [
@@ -133,6 +157,16 @@
         }
       ]
     },
+    "submenus": [
+      {
+        "id": "cSpell.spelling",
+        "label": "Spelling"
+      },
+      {
+        "id": "cSpell.configMenu",
+        "label": "Spell Checker Configuration"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {
@@ -2151,6 +2185,12 @@
             ],
             "scope": "application",
             "type": "string"
+          },
+          "cSpell.showSuggestionsLinkInEditorContextMenu": {
+            "default": true,
+            "description": "Show Spelling Suggestions link in the top level context menu.",
+            "scope": "application",
+            "type": "boolean"
           },
           "cSpell.suggestionMenuType": {
             "default": "quickPick",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1775,6 +1775,12 @@
           "scope": "application",
           "type": "string"
         },
+        "cSpell.showSuggestionsLinkInEditorContextMenu": {
+          "default": true,
+          "description": "Show Spelling Suggestions link in the top level context menu.",
+          "scope": "application",
+          "type": "boolean"
+        },
         "cSpell.suggestionMenuType": {
           "default": "quickPick",
           "enum": [

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -154,6 +154,13 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     showCommandsInEditorContextMenu?: boolean;
 
     /**
+     * Show Spelling Suggestions link in the top level context menu.
+     * @scope application
+     * @default true
+     */
+    showSuggestionsLinkInEditorContextMenu?: boolean;
+
+    /**
      * @title File Types to Check
      * @scope resource
      * @uniqueItems true
@@ -1004,6 +1011,7 @@ type _VSConfigReporting = Pick<
     | 'showCommandsInEditorContextMenu'
     | 'showStatus'
     | 'showStatusAlignment'
+    | 'showSuggestionsLinkInEditorContextMenu'
     | 'suggestionMenuType'
     | 'suggestionNumChanges'
 >;

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -204,7 +204,7 @@ async function _updateDocumentRelatedContext(client: CSpellClient, doc: TextDocu
     context.editorMenuContext.createCSpellConfig = show && showCreateConfig;
     context.editorMenuContext.addIgnoreWord = show && hasIssues;
 
-    context.editorMenuContext.showSuggestions = show && hasIssues;
+    context.editorMenuContext.showSuggestions = (show || cfg.settings?.showSuggestionsLinkInEditorContextMenu || false) && hasIssues;
 
     await setContext(context);
     return;

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -33,6 +33,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     showCommandsInEditorContextMenu: 'showCommandsInEditorContextMenu',
     showStatus: 'showStatus',
     showStatusAlignment: 'showStatusAlignment',
+    showSuggestionsLinkInEditorContextMenu: 'showSuggestionsLinkInEditorContextMenu',
     spellCheckDelayMs: 'spellCheckDelayMs',
     spellCheckOnlyWorkspaceFiles: 'spellCheckOnlyWorkspaceFiles',
     suggestionMenuType: 'suggestionMenuType',


### PR DESCRIPTION
- Move all spelling commands into a `Spelling` submenu
- Add a setting to show suggestions in the context menu: `cSpell. showSuggestionsLinkInEditorContextMenu`
- Adjust order of the spelling commands