### PR TITLE
feat: Format CSpell Configuration on Update

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -299,6 +299,7 @@ Default
 
 | Setting                                                                                     | Scope                | Description                                                                     |
 | ------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------- |
+| [`cSpell.autoFormatConfigFile`](#cspellautoformatconfigfile)                                | window               | Auto Format Configuration File                                                  |
 | [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                                          | resource             | Set Diagnostic Reporting Level                                                  |
 | [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                                | resource             | The maximum number of times the same word can be flagged as an error in a file. |
 | [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                                  | resource             | Controls the maximum number of spelling errors per document.                    |
@@ -313,6 +314,27 @@ Default
 | [`cSpell.suggestionNumChanges`](#cspellsuggestionnumchanges)                                | resource             | The maximum number of changes allowed on a word to be considered a suggestions. |
 
 ## Definitions
+
+### `cSpell.autoFormatConfigFile`
+
+Name
+: `cSpell.autoFormatConfigFile` -- Auto Format Configuration File
+
+Type
+: boolean
+
+Scope
+: window
+
+Description
+: If a `cspell` configuration file is updated, format the configuration file
+using the VS Code Format Document Provider. This will cause the configuration
+file to be saved prior to being updated.
+
+Default
+: _`false`_
+
+---
 
 ### `cSpell.diagnosticLevel`
 

--- a/package.json
+++ b/package.json
@@ -2112,6 +2112,13 @@
         "additionalProperties": false,
         "order": 2,
         "properties": {
+          "cSpell.autoFormatConfigFile": {
+            "default": false,
+            "markdownDescription": "If a `cspell` configuration file is updated, format the configuration file\nusing the VS Code Format Document Provider. This will cause the configuration\nfile to be saved prior to being updated.",
+            "scope": "window",
+            "title": "Auto Format Configuration File",
+            "type": "boolean"
+          },
           "cSpell.diagnosticLevel": {
             "default": "Information",
             "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1561,6 +1561,13 @@
       "additionalProperties": false,
       "order": 2,
       "properties": {
+        "cSpell.autoFormatConfigFile": {
+          "default": false,
+          "markdownDescription": "If a `cspell` configuration file is updated, format the configuration file\nusing the VS Code Format Document Provider. This will cause the configuration\nfile to be saved prior to being updated.",
+          "scope": "window",
+          "title": "Auto Format Configuration File",
+          "type": "boolean"
+        },
         "cSpell.diagnosticLevel": {
           "default": "Information",
           "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",

--- a/packages/_server/src/config/cspellConfig.ts
+++ b/packages/_server/src/config/cspellConfig.ts
@@ -22,6 +22,16 @@ export type {
 
 export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings {
     /**
+     * @title Auto Format Configuration File
+     * @markdownDescription
+     * If a `cspell` configuration file is updated, format the configuration file
+     * using the VS Code Format Document Provider. This will cause the configuration
+     * file to be saved prior to being updated.
+     * @scope window
+     * @default false
+     */
+    autoFormatConfigFile?: boolean;
+    /**
      * The limit in K-Characters to be checked in a file.
      * @scope resource
      * @default 500
@@ -1003,6 +1013,7 @@ type _VSConfigLanguageAndDictionaries = Pick<
 type VSConfigReporting = PrefixWithCspell<_VSConfigReporting>;
 type _VSConfigReporting = Pick<
     SpellCheckerSettingsVSCodeBase,
+    | 'autoFormatConfigFile'
     | 'diagnosticLevel'
     | 'maxDuplicateProblems'
     | 'maxNumberOfProblems'

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -11,6 +11,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     ...CSpellConfigFields,
     'advanced.feature.useReferenceProviderRemove': 'advanced.feature.useReferenceProviderRemove',
     'advanced.feature.useReferenceProviderWithRename': 'advanced.feature.useReferenceProviderWithRename',
+    autoFormatConfigFile: 'autoFormatConfigFile',
     allowedSchemas: 'allowedSchemas',
     blockCheckingWhenAverageChunkSizeGreaterThan: 'blockCheckingWhenAverageChunkSizeGreaterThan',
     blockCheckingWhenLineLengthGreaterThan: 'blockCheckingWhenLineLengthGreaterThan',


### PR DESCRIPTION
fixes #2151

- Added a new option `autoFormatConfigFile` (default: `false`)
- Support formatting CSpell configuration files when updating them.

When `autoFormatConfigfile` is `true` the following steps are taken:
1. the file is saved if it is open in an editor
2. the file is updated
3. the file is formatted and saved.

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/3740137/185448235-85698a1f-aed4-4eb9-a1ba-ade08f648dd0.png">
