### PR TITLE
fix: change `fixSpellingWithRenameProvider` defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,13 +403,16 @@
       }
     ],
     "configurationDefaults": {
-      "[php]": {
-        "cSpell.fixSpellingWithRenameProvider": false
-      },
       "[markdown]": {
         "cSpell.fixSpellingWithRenameProvider": true,
         "cSpell.advanced.feature.useReferenceProviderWithRename": true,
         "cSpell.advanced.feature.useReferenceProviderRemove": "/^#+\\s/"
+      },
+      "[scss]": {
+        "cSpell.fixSpellingWithRenameProvider": false
+      },
+      "[css]": {
+        "cSpell.fixSpellingWithRenameProvider": false
       }
     },
     "configuration": [

--- a/samples/scss/example.css
+++ b/samples/scss/example.css
@@ -1,0 +1,30 @@
+#page {
+    display: grid;
+    width: 100%;
+    height: 200px;
+    grid-template:
+        [header-left] 'head head' 30px [header-right]
+        [main-left] 'nav  main' 1fr [main-right]
+        [footer-left] 'nav  foot' 30px [footer-right]
+        / 120px 1fr;
+}
+
+header {
+    background-color: lime;
+    grid-area: head;
+}
+
+nav {
+    background-color: lightblue;
+    grid-area: nav;
+}
+
+main {
+    background-color: yellow;
+    grid-area: main;
+}
+
+footer {
+    background-color: red;
+    grid-area: foot;
+}

--- a/samples/scss/example.sass
+++ b/samples/scss/example.sass
@@ -1,0 +1,30 @@
+#page {
+    display: grid;
+    width: 100%;
+    height: 200px;
+    grid-template:
+        [header-left] 'head head' 30px [header-right]
+        [main-left] 'nav  main' 1fr [main-right]
+        [footer-left] 'nav  foot' 30px [footer-right]
+        / 120px 1fr;
+}
+
+header {
+    background-color: lime;
+    grid-area: head;
+}
+
+nav {
+    background-color: lightblue;
+    grid-area: nav;
+}
+
+main {
+    background-color: yellow;
+    grid-area: main;
+}
+
+footer {
+    background-color: red;
+    grid-area: foot;
+}

--- a/samples/scss/example.scss
+++ b/samples/scss/example.scss
@@ -1,0 +1,30 @@
+#page {
+    display: grid;
+    width: 100%;
+    height: 200px;
+    grid-template:
+        [header-left] 'head head' 30px [header-right]
+        [main-left] 'nav  main' 1fr [main-right]
+        [footer-left] 'nav  foot' 30px [footer-right]
+        / 120px 1fr;
+}
+
+header {
+    background-color: lime;
+    grid-area: head;
+}
+
+nav {
+    background-color: lightblue;
+    grid-area: nav;
+}
+
+main {
+    background-color: yellow;
+    grid-area: main;
+}
+
+footer {
+    background-color: red;
+    grid-area: foot;
+}


### PR DESCRIPTION
fix: #2268

- Turn on rename provider in PHP. It no-longer crashes.
- Turn off rename provider for CSS and SCSS. It does the wrong thing.