### PR TITLE
fix: Do not show duplicate actions.

### DIFF
--- a/packages/_server/src/utils/position.ts
+++ b/packages/_server/src/utils/position.ts
@@ -1,0 +1,24 @@
+import { Position } from 'vscode-languageserver';
+
+/**
+ * Compares two positions
+ * @param a
+ * @param b
+ * @returns
+ *   negative - a < b
+ *   zero - a == b
+ *   positive a > b
+ */
+export function compare(a: Position, b: Position): number {
+    return a.line - b.line || a.character - b.character;
+}
+
+/**
+ * Check if two positions are equivalent.
+ * @param a - Position
+ * @param b - Position
+ * @returns true if they represent the same position.
+ */
+export function equal(a: Position, b: Position): boolean {
+    return a === b || compare(a, b) === 0;
+}

--- a/packages/_server/src/utils/range.ts
+++ b/packages/_server/src/utils/range.ts
@@ -1,0 +1,33 @@
+import type { Range } from 'vscode-languageserver';
+
+import * as UtilPosition from './position';
+
+export function intersect(a: Range, b: Range): Range | undefined {
+    if (a === b) return a;
+
+    const start = UtilPosition.compare(a.start, b.start) >= 0 ? a.start : b.start;
+    const end = UtilPosition.compare(a.end, b.end) <= 0 ? a.end : b.end;
+
+    return UtilPosition.compare(start, end) > 0 ? undefined : { start, end };
+}
+
+/**
+ * Check if two ranges are equivalent.
+ * @param a - Range
+ * @param b - Range
+ * @returns true if they are equivalent.
+ */
+export function equal(a: Range, b: Range): boolean {
+    return UtilPosition.equal(a.start, b.start) && UtilPosition.equal(a.end, b.end);
+}
+
+/**
+ * Check if `b` is fully contained in `a`.
+ * @param a - Outer Range
+ * @param b - Inner Range
+ * @returns
+ */
+export function contains(a: Range, b: Range): boolean {
+    const intersection = intersect(a, b);
+    return (intersection && equal(intersection, b)) || false;
+}


### PR DESCRIPTION

- Do not show code actions if the selection is multiple words.
  This fixes the issue where spelling suggestions hide refactoring and other Code Actions.
- fixes #2482
- Start the process to support `@cspell/eslint-plugin` by providing the ability to add to dictionary.
- If an issues is handled by both ESLint `@cspell/spellchecker` and this extension, defer to ESLint.

