### PR TITLE
fix: Do not show context menu if `editorReadonly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
       "editor/context": [
         {
           "command": "cSpell.suggestSpellingCorrections",
-          "when": "editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions",
+          "when": "!editorReadonly && editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions",
           "group": "A_cspell@000"
         },
         {
           "submenu": "cSpell.spelling",
           "group": "A_cspell@001",
-          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu"
+          "when": "!editorReadonly && editorTextFocus && config.cSpell.showCommandsInEditorContextMenu"
         }
       ],
       "cSpell.spelling": [

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -77,6 +77,10 @@ const defaultEditorMenuContext: EditorMenuContext = Object.freeze({
     addIgnoreWord: false,
 });
 
+const allowContextMenuForScheme: Record<string, boolean | undefined> = {
+    output: false,
+};
+
 /**
  * Set context values
  * @param name - name of context to set
@@ -116,6 +120,10 @@ export async function updateDocumentRelatedContext(client: CSpellClient, doc: Te
 
     if (!doc) {
         await setContext(context);
+        return;
+    }
+
+    if (allowContextMenuForScheme[doc.uri.scheme] === false) {
         return;
     }
 


### PR DESCRIPTION
fixes #2580