### PR TITLE
feat: Control which settings are passed to cspell

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -52,6 +52,7 @@ Default
 | [`cSpell.language`](#cspelllanguage)                           | resource | Current active spelling language.                                                                 |
 | [`cSpell.languageSettings`](#cspelllanguagesettings)           | resource | Additional settings for individual programming languages and locales.                             |
 | [`cSpell.noSuggestDictionaries`](#cspellnosuggestdictionaries) | resource | Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries… |
+| [`cSpell.suggestWords`](#cspellsuggestwords)                   |          | A list of suggested replacements for words. Suggested words provide a way to make preferred…      |
 | [`cSpell.userWords`](#cspelluserwords)                         | resource | Words to add to global dictionary -- should only be in the user config file.                      |
 | [`cSpell.words`](#cspellwords)                                 | resource | List of words to be considered correct.                                                           |
 
@@ -271,6 +272,35 @@ used when making spell correction suggestions.
     Note: if a word is suggested by another dictionary, but found in
     one of these dictionaries, it will be removed from the set of
     possible suggestions.
+
+Default
+: _- none -_
+
+---
+
+### `cSpell.suggestWords`
+
+Name
+: `cSpell.suggestWords`
+
+Type
+: string[]
+
+Scope
+:
+
+Description
+: A list of suggested replacements for words.
+Suggested words provide a way to make preferred suggestions on word replacements.
+To hint at a preferred change, but not to require it.
+
+    Format of `suggestWords`
+    - Single suggestion (possible auto fix)
+        - `word: suggestion`
+        - `word->suggestion`
+    - Multiple suggestions (not auto fixable)
+       - `word: first, second, third`
+       - `word->first, second, third`
 
 Default
 : _- none -_
@@ -652,6 +682,7 @@ Default
 | [`cSpell.globRoot`](#cspellglobroot)                                         | resource | The root to use for glob patterns found in this configuration. Default: The current workspace… |
 | [`cSpell.ignorePaths`](#cspellignorepaths)                                   | resource | Glob patterns of files to be ignored                                                           |
 | [`cSpell.import`](#cspellimport)                                             | resource | Allows this configuration to inherit configuration for one or more other files.                |
+| [`cSpell.mergeCSpellSettings`](#cspellmergecspellsettings)                   | resource | Specify which fields from `.vscode/settings.json` are passed to the spell checker. This only…  |
 | [`cSpell.noConfigSearch`](#cspellnoconfigsearch)                             | resource | Prevents searching for local configuration when checking individual documents.                 |
 | [`cSpell.spellCheckOnlyWorkspaceFiles`](#cspellspellcheckonlyworkspacefiles) | window   | Spell Check Only Workspace Files                                                               |
 | [`cSpell.useGitignore`](#cspellusegitignore)                                 | resource | Tells the spell checker to load `.gitignore` files and skip files that match the globs in the… |
@@ -830,6 +861,43 @@ Description
 
 Default
 : _- none -_
+
+---
+
+### `cSpell.mergeCSpellSettings`
+
+Name
+: `cSpell.mergeCSpellSettings`
+
+Type
+:
+
+Scope
+: resource
+
+Description
+: Specify which fields from `.vscode/settings.json` are passed to the spell checker.
+This only applies when there is a CSpell configuration file in the workspace.
+
+    The purpose of this setting to help provide a consistent result compared to the
+    CSpell spell checker command line tool.
+
+    Values:
+    - `true` - all settings will be merged
+    - `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.
+    - `{ words: true, userWords: false }` - specify which fields to pass through to the spell checker.
+
+    Note:
+
+    If specific fields are specified, they provide the ability to block settings even if a CSpell configuration
+    is not found. The following example could be used to block "cSpell.userWords" from a workspace.
+
+    ```jsonc
+    "cSpell.mergeCSpellSettings": { "userWords": false },
+    ```
+
+Default
+: _`false`_
 
 ---
 
@@ -1110,7 +1178,6 @@ Default
 | [`cSpell.includeRegExpList`](#cspellincluderegexplist) | resource | List of regular expression patterns or defined pattern names to match for spell checking.                          |
 | [`cSpell.overrides`](#cspelloverrides)                 | resource | Overrides are used to apply settings for specific files in your project.                                           |
 | [`cSpell.patterns`](#cspellpatterns)                   | resource | Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and `#cSpell.includeRegExpList#`… |
-| [`cSpell.suggestWords`](#cspellsuggestwords)           |          | A list of suggested replacements for words. Suggested words provide a way to make preferred…                       |
 
 ## Definitions
 
@@ -1232,35 +1299,6 @@ Description
       }
     ]
     ```
-
-Default
-: _- none -_
-
----
-
-### `cSpell.suggestWords`
-
-Name
-: `cSpell.suggestWords`
-
-Type
-: string[]
-
-Scope
-:
-
-Description
-: A list of suggested replacements for words.
-Suggested words provide a way to make preferred suggestions on word replacements.
-To hint at a preferred change, but not to require it.
-
-    Format of `suggestWords`
-    - Single suggestion (possible auto fix)
-        - `word: suggestion`
-        - `word->suggestion`
-    - Multiple suggestions (not auto fixable)
-       - `word: first, second, third`
-       - `word->first, second, third`
 
 Default
 : _- none -_

--- a/package.json
+++ b/package.json
@@ -1188,13 +1188,6 @@
             "markdownDescription": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and\n`#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc\n\"cSpell.patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*​/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  }\n]\n```",
             "scope": "resource",
             "type": "array"
-          },
-          "cSpell.suggestWords": {
-            "items": {
-              "type": "string"
-            },
-            "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-            "type": "array"
           }
         },
         "title": "CSpell",
@@ -1303,6 +1296,130 @@
             "markdownDescription": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
             "scope": "resource",
             "type": "array"
+          },
+          "cSpell.mergeCSpellSettings": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "allowCompoundWords": {
+                    "type": "boolean"
+                  },
+                  "caseSensitive": {
+                    "type": "boolean"
+                  },
+                  "dictionaries": {
+                    "type": "boolean"
+                  },
+                  "dictionaryDefinitions": {
+                    "type": "boolean"
+                  },
+                  "enableFiletypes": {
+                    "type": "boolean"
+                  },
+                  "enableGlobDot": {
+                    "type": "boolean"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "enabledLanguageIds": {
+                    "type": "boolean"
+                  },
+                  "features": {
+                    "type": "boolean"
+                  },
+                  "files": {
+                    "type": "boolean"
+                  },
+                  "flagWords": {
+                    "type": "boolean"
+                  },
+                  "gitignoreRoot": {
+                    "type": "boolean"
+                  },
+                  "globRoot": {
+                    "type": "boolean"
+                  },
+                  "ignorePaths": {
+                    "type": "boolean"
+                  },
+                  "ignoreRegExpList": {
+                    "type": "boolean"
+                  },
+                  "ignoreWords": {
+                    "type": "boolean"
+                  },
+                  "import": {
+                    "type": "boolean"
+                  },
+                  "includeRegExpList": {
+                    "type": "boolean"
+                  },
+                  "language": {
+                    "type": "boolean"
+                  },
+                  "languageId": {
+                    "type": "boolean"
+                  },
+                  "languageSettings": {
+                    "type": "boolean"
+                  },
+                  "loadDefaultConfiguration": {
+                    "type": "boolean"
+                  },
+                  "minWordLength": {
+                    "type": "boolean"
+                  },
+                  "noConfigSearch": {
+                    "type": "boolean"
+                  },
+                  "noSuggestDictionaries": {
+                    "type": "boolean"
+                  },
+                  "numSuggestions": {
+                    "type": "boolean"
+                  },
+                  "overrides": {
+                    "type": "boolean"
+                  },
+                  "patterns": {
+                    "type": "boolean"
+                  },
+                  "pnpFiles": {
+                    "type": "boolean"
+                  },
+                  "reporters": {
+                    "type": "boolean"
+                  },
+                  "suggestWords": {
+                    "type": "boolean"
+                  },
+                  "useGitignore": {
+                    "type": "boolean"
+                  },
+                  "usePnP": {
+                    "type": "boolean"
+                  },
+                  "userWords": {
+                    "type": "boolean"
+                  },
+                  "validateDirectives": {
+                    "type": "boolean"
+                  },
+                  "words": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "default": false,
+            "markdownDescription": "Specify which fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n- `{ words: true, userWords: false }` - specify which fields to pass through to the spell checker.\n\nNote:\n\nIf specific fields are specified, they provide the ability to block settings even if a CSpell configuration\nis not found. The following example could be used to block \"cSpell.userWords\" from a workspace.\n\n```jsonc\n\"cSpell.mergeCSpellSettings\": { \"userWords\": false },\n```",
+            "scope": "resource"
           },
           "cSpell.noConfigSearch": {
             "markdownDescription": "Prevents searching for local configuration when checking individual documents.",
@@ -1821,6 +1938,13 @@
             },
             "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
             "scope": "resource",
+            "type": "array"
+          },
+          "cSpell.suggestWords": {
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
             "type": "array"
           },
           "cSpell.userWords": {

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -808,14 +808,6 @@
           "markdownDescription": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and\n`#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc\n\"cSpell.patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*​/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  }\n]\n```",
           "scope": "resource",
           "type": "array"
-        },
-        "cSpell.suggestWords": {
-          "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-          "type": "array"
         }
       },
       "title": "CSpell",
@@ -921,6 +913,131 @@
           "markdownDescription": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
           "scope": "resource",
           "type": "array"
+        },
+        "cSpell.mergeCSpellSettings": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "allowCompoundWords": {
+                  "type": "boolean"
+                },
+                "caseSensitive": {
+                  "type": "boolean"
+                },
+                "dictionaries": {
+                  "type": "boolean"
+                },
+                "dictionaryDefinitions": {
+                  "type": "boolean"
+                },
+                "enableFiletypes": {
+                  "type": "boolean"
+                },
+                "enableGlobDot": {
+                  "type": "boolean"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "enabledLanguageIds": {
+                  "type": "boolean"
+                },
+                "features": {
+                  "type": "boolean"
+                },
+                "files": {
+                  "type": "boolean"
+                },
+                "flagWords": {
+                  "type": "boolean"
+                },
+                "gitignoreRoot": {
+                  "type": "boolean"
+                },
+                "globRoot": {
+                  "type": "boolean"
+                },
+                "ignorePaths": {
+                  "type": "boolean"
+                },
+                "ignoreRegExpList": {
+                  "type": "boolean"
+                },
+                "ignoreWords": {
+                  "type": "boolean"
+                },
+                "import": {
+                  "type": "boolean"
+                },
+                "includeRegExpList": {
+                  "type": "boolean"
+                },
+                "language": {
+                  "type": "boolean"
+                },
+                "languageId": {
+                  "type": "boolean"
+                },
+                "languageSettings": {
+                  "type": "boolean"
+                },
+                "loadDefaultConfiguration": {
+                  "type": "boolean"
+                },
+                "minWordLength": {
+                  "type": "boolean"
+                },
+                "noConfigSearch": {
+                  "type": "boolean"
+                },
+                "noSuggestDictionaries": {
+                  "type": "boolean"
+                },
+                "numSuggestions": {
+                  "type": "boolean"
+                },
+                "overrides": {
+                  "type": "boolean"
+                },
+                "patterns": {
+                  "type": "boolean"
+                },
+                "pnpFiles": {
+                  "type": "boolean"
+                },
+                "reporters": {
+                  "type": "boolean"
+                },
+                "suggestWords": {
+                  "type": "boolean"
+                },
+                "useGitignore": {
+                  "type": "boolean"
+                },
+                "usePnP": {
+                  "type": "boolean"
+                },
+                "userWords": {
+                  "type": "boolean"
+                },
+                "validateDirectives": {
+                  "type": "boolean"
+                },
+                "words": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "default": false,
+          "description": "Specify which fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n- `{ words: true, userWords: false }` - specify which fields to pass through to the spell checker.\n\nNote:\n\nIf specific fields are specified, they provide the ability to block settings even if a CSpell configuration is not found. The following example could be used to block \"cSpell.userWords\" from a workspace.\n\n```jsonc \"cSpell.mergeCSpellSettings\": { \"userWords\": false }, ```",
+          "markdownDescription": "Specify which fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n- `{ words: true, userWords: false }` - specify which fields to pass through to the spell checker.\n\nNote:\n\nIf specific fields are specified, they provide the ability to block settings even if a CSpell configuration\nis not found. The following example could be used to block \"cSpell.userWords\" from a workspace.\n\n```jsonc\n\"cSpell.mergeCSpellSettings\": { \"userWords\": false },\n```",
+          "scope": "resource"
         },
         "cSpell.noConfigSearch": {
           "description": "Prevents searching for local configuration when checking individual documents.",
@@ -1475,6 +1592,14 @@
           },
           "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
           "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.suggestWords": {
+          "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
           "type": "array"
         },
         "cSpell.userWords": {

--- a/packages/_server/src/config/cspellConfig/CSpellSettingsPackageProperties.mts
+++ b/packages/_server/src/config/cspellConfig/CSpellSettingsPackageProperties.mts
@@ -353,6 +353,26 @@ export interface CSpellSettingsPackageProperties extends CSpellSettings {
     validateDirectives?: CSpellSettings['validateDirectives'];
 }
 
+export type CSpellFields = keyof CSpellSettingsPackageProperties;
+
+export type CSpellMergeFields = Exclude<
+    CSpellFields,
+    | '$schema'
+    | 'cache'
+    | 'description'
+    | 'failFast'
+    | 'id'
+    | 'maxDuplicateProblems'
+    | 'maxNumberOfProblems'
+    | 'name'
+    | 'readonly'
+    | 'showStatus'
+    | 'spellCheckDelayMs'
+    | 'suggestionNumChanges'
+    | 'suggestionsTimeout'
+    | 'version'
+>;
+
 /**
  * @hidden
  */

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -1,4 +1,5 @@
 import type { EnableFileTypeId, RegExpString } from './annotatedTypes.mjs';
+import type { CSpellMergeFields } from './CSpellSettingsPackageProperties.mjs';
 import type { CustomDictionaries, CustomDictionaryEntry } from './CustomDictionary.mjs';
 import type { SpellCheckerShouldCheckDocSettings } from './SpellCheckerShouldCheckDocSettings.mjs';
 
@@ -322,6 +323,32 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * @hidden
      */
     // addWordsTo?: AddToTargets;
+
+    /**
+     * Specify which fields from `.vscode/settings.json` are passed to the spell checker.
+     * This only applies when there is a CSpell configuration file in the workspace.
+     *
+     * The purpose of this setting to help provide a consistent result compared to the
+     * CSpell spell checker command line tool.
+     *
+     * Values:
+     * - `true` - all settings will be merged
+     * - `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.
+     * - `{ words: true, userWords: false }` - specify which fields to pass through to the spell checker.
+     *
+     * Note:
+     *
+     * If specific fields are specified, they provide the ability to block settings even if a CSpell configuration
+     * is not found. The following example could be used to block "cSpell.userWords" from a workspace.
+     *
+     * ```jsonc
+     * "cSpell.mergeCSpellSettings": { "userWords": false },
+     * ```
+     *
+     * @scope resource
+     * @default false
+     */
+    mergeCSpellSettings?: boolean | Partial<Record<CSpellMergeFields, boolean>>;
 }
 
 type AutoOrBoolean = boolean | 'auto';

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -123,6 +123,7 @@ type _VSConfigLanguageAndDictionaries = Pick<
     | 'language'
     | 'languageSettings'
     | 'noSuggestDictionaries'
+    | 'suggestWords'
     | 'userWords'
     | 'words'
 >;
@@ -197,6 +198,7 @@ type _VSConfigFilesAndFolders = Pick<
     | 'globRoot'
     | 'ignorePaths'
     | 'import'
+    | 'mergeCSpellSettings'
     | 'noConfigSearch'
     | 'spellCheckOnlyWorkspaceFiles'
     | 'useGitignore'

--- a/packages/_server/src/config/cspellConfig/cspellMergeFields.mts
+++ b/packages/_server/src/config/cspellConfig/cspellMergeFields.mts
@@ -1,0 +1,64 @@
+import type { CSpellUserSettings } from './cspellConfig.mjs';
+import type { CSpellMergeFields } from './CSpellSettingsPackageProperties.mjs';
+
+export const cspellMergeFields: Record<CSpellMergeFields, true> = {
+    allowCompoundWords: true,
+    caseSensitive: true,
+    dictionaries: true,
+    dictionaryDefinitions: true,
+    enabled: true,
+    enabledLanguageIds: true,
+    enableFiletypes: true,
+    enableGlobDot: true,
+    features: true,
+    files: true,
+    flagWords: true,
+    gitignoreRoot: true,
+    globRoot: true,
+    ignorePaths: true,
+    ignoreRegExpList: true,
+    ignoreWords: true,
+    import: true,
+    includeRegExpList: true,
+    language: true,
+    languageId: true,
+    languageSettings: true,
+    loadDefaultConfiguration: true,
+    minWordLength: true,
+    noConfigSearch: true,
+    noSuggestDictionaries: true,
+    numSuggestions: true,
+    overrides: true,
+    parser: true,
+    patterns: true,
+    pnpFiles: true,
+    reporters: true,
+    suggestWords: true,
+    useGitignore: true,
+    usePnP: true,
+    userWords: true,
+    validateDirectives: true,
+    words: true,
+};
+
+const fields = Object.keys(cspellMergeFields) as CSpellMergeFields[];
+
+/**
+ * Filter fields to be passed to cspell.
+ * @param settings - settings from vscode and imports
+ * @param mergeCSpellSettings - the filter
+ * @returns filtered settings
+ */
+export function filterMergeFields(
+    settings: Readonly<CSpellUserSettings>,
+    mergeCSpellSettings: CSpellUserSettings['mergeCSpellSettings'],
+): CSpellUserSettings {
+    if (mergeCSpellSettings === true) return settings;
+    const copy = { ...settings };
+    mergeCSpellSettings = mergeCSpellSettings || {};
+    for (const field of fields) {
+        if (mergeCSpellSettings[field]) continue;
+        delete copy[field];
+    }
+    return copy;
+}

--- a/packages/_server/src/config/cspellConfig/cspellMergeFields.test.mts
+++ b/packages/_server/src/config/cspellConfig/cspellMergeFields.test.mts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'vitest';
+
+import { filterMergeFields } from './cspellMergeFields.mjs';
+
+describe('cspellMergeFields', () => {
+    test.each`
+        settings                                 | filter                             | expected
+        ${{}}                                    | ${true}                            | ${{}}
+        ${{ words: [] }}                         | ${true}                            | ${{ words: [] }}
+        ${{ words: [] }}                         | ${undefined}                       | ${{}}
+        ${{ words: [] }}                         | ${false}                           | ${{}}
+        ${{ words: [], enabled: true }}          | ${{ words: false, enabled: true }} | ${{ enabled: true }}
+        ${{ words: [], spellCheckDelayMs: 500 }} | ${{ enabled: true }}               | ${{ spellCheckDelayMs: 500 }}
+    `('filterMergeFields $settings $filter', ({ settings, filter, expected }) => {
+        expect(filterMergeFields(settings, filter)).toEqual(expected);
+    });
+});

--- a/packages/_server/src/config/documentSettings.test.mts
+++ b/packages/_server/src/config/documentSettings.test.mts
@@ -54,6 +54,7 @@ const cspellConfigInVsCode: CSpellUserSettings = {
         '${workspaceFolder:_server}/sampleSourceFiles/cSpell.json',
     ],
     enabledLanguageIds: ['typescript', 'javascript', 'php', 'json', 'jsonc'],
+    mergeCSpellSettings: true,
 };
 
 const sampleFiles = {
@@ -303,7 +304,7 @@ describe('Validate DocumentSettings', () => {
     `('isExcludedBy $filename', async ({ filename, expected }: IsExcludeByTest) => {
         const mockFolders: WorkspaceFolder[] = [workspaceFolderRoot, workspaceFolderClient, workspaceFolderServer];
         mockGetWorkspaceFolders.mockReturnValue(Promise.resolve(mockFolders));
-        mockGetConfiguration.mockReturnValue(Promise.resolve([{}, {}]));
+        mockGetConfiguration.mockReturnValue(Promise.resolve([{ mergeCSpellSettings: true }, {}]));
         const docSettings = newDocumentSettings();
         const configFile = Path.join(pathSampleSourceFiles, 'cspell-exclude-tests.json');
         await docSettings.registerConfigurationFile(configFile);

--- a/packages/_server/src/server.mts
+++ b/packages/_server/src/server.mts
@@ -67,7 +67,7 @@ const overRideDefaults: CSpellUserSettings = {
 const defaultSettings: CSpellUserSettings = {
     ...CSpell.mergeSettings(getDefaultSettings(), CSpell.getGlobalSettings(), overRideDefaults),
     checkLimit: defaultCheckLimit,
-    enabled: false,
+    // enabled: false,
 };
 const defaultDebounceMs = 50;
 // Refresh the dictionary cache every 1000ms.

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -34,6 +34,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     mapOfEnabledFileTypes: 'mapOfEnabledFileTypes',
     maxDuplicateProblems: 'maxDuplicateProblems',
     maxNumberOfProblems: 'maxNumberOfProblems',
+    mergeCSpellSettings: 'mergeCSpellSettings',
     noSuggestDictionaries: 'noSuggestDictionaries',
     showAutocompleteSuggestions: 'showAutocompleteSuggestions',
     showCommandsInEditorContextMenu: 'showCommandsInEditorContextMenu',


### PR DESCRIPTION
One of the common issues is that the results seen in the extension do not match the results seen by the command line tool.

This is often due to settings in VSCode influencing the extension results.

- `mergeCSpellSettings` - allows more control over what settings are passed to `cspell`. By default, if a cspell config file is found, settings that might impact the result are not sent.