### PR TITLE
feat: support custom decorators

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -351,7 +351,6 @@ Default
 | Setting                                                                                          | Scope                | Description                                                                     |
 | ------------------------------------------------------------------------------------------------ | -------------------- | ------------------------------------------------------------------------------- |
 | [`cSpell.autoFormatConfigFile`](#cspellautoformatconfigfile)                                     | window               | Auto Format Configuration File                                                  |
-| [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                                               | resource             | Set Diagnostic Reporting Level                                                  |
 | [`cSpell.hideAddToDictionaryCodeActions`](#cspellhideaddtodictionarycodeactions)                 | resource             | Hide the options to add words to dictionaries or settings.                      |
 | [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                                     | resource             | The maximum number of times the same word can be flagged as an error in a file. |
 | [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                                       | resource             | Controls the maximum number of spelling errors per document.                    |
@@ -386,30 +385,6 @@ file to be saved prior to being updated.
 
 Default
 : _`false`_
-
----
-
-### `cSpell.diagnosticLevel`
-
-Name
-: `cSpell.diagnosticLevel` -- Set Diagnostic Reporting Level
-
-Type
-: ( `"Error"` \| `"Warning"` \| `"Information"` \| `"Hint"` )
-
-    | `Error` | Report Spelling Issues as Errors |
-    | `Warning` | Report Spelling Issues as Warnings |
-    | `Information` | Report Spelling Issues as Information |
-    | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
-
-Scope
-: resource
-
-Description
-: Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
-
-Default
-: _`"Information"`_
 
 ---
 
@@ -1311,11 +1286,13 @@ Default
 
 # Appearance
 
-| Setting                                                  | Scope       | Description                                                                               |
-| -------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
-| [`cSpell.decorateIssues`](#cspelldecorateissues)         | application | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
-| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor) | application | The CSS color used to show issues in the ruler.                                           |
-| [`cSpell.textDecoration`](#cspelltextdecoration)         | application | The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`. |
+| Setting                                                                    | Scope       | Description                                                                               |
+| -------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| [`cSpell.decorateIssues`](#cspelldecorateissues)                           | application | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
+| [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                         | resource    | Set Diagnostic Reporting Level                                                            |
+| [`cSpell.diagnosticLevelFlaggedWords`](#cspelldiagnosticlevelflaggedwords) | resource    | Set Diagnostic Reporting Level for Flagged Words                                          |
+| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor)                   | application | The CSS color used to show issues in the ruler.                                           |
+| [`cSpell.textDecoration`](#cspelltextdecoration)                           | application | The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`. |
 
 ## Definitions
 
@@ -1335,6 +1312,58 @@ Description
 
 Default
 : _`false`_
+
+Version
+: 4.0.0
+
+---
+
+### `cSpell.diagnosticLevel`
+
+Name
+: `cSpell.diagnosticLevel` -- Set Diagnostic Reporting Level
+
+Type
+: ( `"Error"` \| `"Warning"` \| `"Information"` \| `"Hint"` )
+
+    | `Error` | Report Spelling Issues as Errors |
+    | `Warning` | Report Spelling Issues as Warnings |
+    | `Information` | Report Spelling Issues as Information |
+    | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
+
+Scope
+: resource
+
+Description
+: Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
+
+Default
+: _`"Information"`_
+
+---
+
+### `cSpell.diagnosticLevelFlaggedWords`
+
+Name
+: `cSpell.diagnosticLevelFlaggedWords` -- Set Diagnostic Reporting Level for Flagged Words
+
+Type
+: ( `"Error"` \| `"Warning"` \| `"Information"` \| `"Hint"` )
+
+    | `Error` | Report Spelling Issues as Errors |
+    | `Warning` | Report Spelling Issues as Warnings |
+    | `Information` | Report Spelling Issues as Information |
+    | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
+
+Scope
+: resource
+
+Description
+: Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
+By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.
+
+Default
+: _- none -_
 
 Version
 : 4.0.0

--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -8,6 +8,7 @@
 - [Files, Folders, and Workspaces](#files-folders-and-workspaces)
 - [Performance](#performance)
 - [CSpell](#cspell)
+- [Appearance](#appearance)
 - [Advanced](#advanced)
 - [Experimental](#experimental)
 - [Legacy](#legacy)
@@ -1305,6 +1306,100 @@ Description
 
 Default
 : _- none -_
+
+---
+
+# Appearance
+
+| Setting                                                  | Scope       | Description                                                                               |
+| -------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| [`cSpell.decorateIssues`](#cspelldecorateissues)         | application | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
+| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor) | application | The CSS color used to show issues in the ruler.                                           |
+| [`cSpell.textDecoration`](#cspelltextdecoration)         | application | The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`. |
+
+## Definitions
+
+### `cSpell.decorateIssues`
+
+Name
+: `cSpell.decorateIssues`
+
+Type
+: boolean
+
+Scope
+: application
+
+Description
+: Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
+
+Default
+: _`false`_
+
+Version
+: 4.0.0
+
+---
+
+### `cSpell.overviewRulerColor`
+
+Name
+: `cSpell.overviewRulerColor`
+
+Type
+: string
+
+Scope
+: application
+
+Description
+: The CSS color used to show issues in the ruler.
+
+    - Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)
+    - Hex colors
+    - Use `` (empty string) to disable.
+
+    Examples:
+    - `green`
+    - `DarkYellow`
+    - `#ffff0080` - semi-transparent yellow.
+
+Default
+: _`"#00800080"`_
+
+Version
+: 4.0.0
+
+---
+
+### `cSpell.textDecoration`
+
+Name
+: `cSpell.textDecoration`
+
+Type
+: string
+
+Scope
+: application
+
+Description
+: The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.
+
+    See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
+
+    - Use `` (empty string) to disable text decoration.
+
+    Examples:
+    - `blue`
+    - `yellow`
+    - `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.
+
+Default
+: _`"underline wavy #00800080"`_
+
+Version
+: 4.0.0
 
 ---
 

--- a/fixtures/workspaces/jupyter/.vscode/settings.json
+++ b/fixtures/workspaces/jupyter/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.diagnosticLevel": "Hint"
+}

--- a/fixtures/workspaces/jupyter/.vscode/settings.json
+++ b/fixtures/workspaces/jupyter/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "cSpell.diagnosticLevel": "Hint"
+    "cSpell.diagnosticLevel": "Hint",
+    "cSpell.diagnosticLevelFlaggedWords": "Information"
 }

--- a/fixtures/workspaces/jupyter/cspell.json
+++ b/fixtures/workspaces/jupyter/cspell.json
@@ -1,0 +1,11 @@
+{
+    "flagWords": ["forbidd->forbid"],
+    "ignorePaths": [
+        "package-lock.json",
+        "node_modules",
+        "vscode-extension",
+        ".git/objects",
+        ".vscode",
+        ".vscode-insiders"
+    ]
+}

--- a/fixtures/workspaces/jupyter/getting-started/README.md
+++ b/fixtures/workspaces/jupyter/getting-started/README.md
@@ -5,3 +5,5 @@ Thesse are wordz to livve by.
 Whaat do youu thinkk?
 
 How about trying it agaain?
+
+forbidd

--- a/fixtures/workspaces/jupyter/getting-started/sample.ipynb
+++ b/fixtures/workspaces/jupyter/getting-started/sample.ipynb
@@ -27,7 +27,11 @@
                 "\n",
                 "Below is some code.\n",
                 "\n",
-                "Let's have a spelling errror."
+                "Let's have a spelling errror.\n",
+                "\n",
+                "annnother error.\n",
+                "\n",
+                "1 12 123 1234 12345"
             ]
         },
         {
@@ -58,7 +62,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.4 (v3.10.4:9d38120e33, Mar 23 2022, 17:29:05) [Clang 13.0.0 (clang-1300.0.29.30)]"
+            "version": "3.11.2"
         },
         "orig_nbformat": 4
     },

--- a/fixtures/workspaces/jupyter/hello.py
+++ b/fixtures/workspaces/jupyter/hello.py
@@ -1,0 +1,12 @@
+# Primt Hello, world!
+
+print('Hello, world!')
+
+# More commentss the Uuse.
+
+# With
+
+# Some errrors and on some lines.
+# We have lines without errors.
+# It is important for checking the minimap.
+# But it is not obvious what should happen.

--- a/package.json
+++ b/package.json
@@ -1961,6 +1961,35 @@
       },
       {
         "additionalProperties": false,
+        "order": 6,
+        "properties": {
+          "cSpell.decorateIssues": {
+            "default": false,
+            "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
+            "scope": "application",
+            "type": "boolean",
+            "version": "4.0.0"
+          },
+          "cSpell.overviewRulerColor": {
+            "default": "#00800080",
+            "markdownDescription": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
+            "scope": "application",
+            "type": "string",
+            "version": "4.0.0"
+          },
+          "cSpell.textDecoration": {
+            "default": "underline wavy #00800080",
+            "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
+            "scope": "application",
+            "type": "string",
+            "version": "4.0.0"
+          }
+        },
+        "title": "Appearance",
+        "type": "object"
+      },
+      {
+        "additionalProperties": false,
         "order": 20,
         "properties": {
           "cSpell.allowCompoundWords": {

--- a/package.json
+++ b/package.json
@@ -1970,6 +1970,44 @@
             "type": "boolean",
             "version": "4.0.0"
           },
+          "cSpell.diagnosticLevel": {
+            "default": "Information",
+            "enum": [
+              "Error",
+              "Warning",
+              "Information",
+              "Hint"
+            ],
+            "enumDescriptions": [
+              "Report Spelling Issues as Errors",
+              "Report Spelling Issues as Warnings",
+              "Report Spelling Issues as Information",
+              "Report Spelling Issues as Hints, will not show up in Problems"
+            ],
+            "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+            "scope": "resource",
+            "title": "Set Diagnostic Reporting Level",
+            "type": "string"
+          },
+          "cSpell.diagnosticLevelFlaggedWords": {
+            "enum": [
+              "Error",
+              "Warning",
+              "Information",
+              "Hint"
+            ],
+            "enumDescriptions": [
+              "Report Spelling Issues as Errors",
+              "Report Spelling Issues as Warnings",
+              "Report Spelling Issues as Information",
+              "Report Spelling Issues as Hints, will not show up in Problems"
+            ],
+            "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+            "scope": "resource",
+            "title": "Set Diagnostic Reporting Level for Flagged Words",
+            "type": "string",
+            "version": "4.0.0"
+          },
           "cSpell.overviewRulerColor": {
             "default": "#00800080",
             "markdownDescription": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
@@ -2559,25 +2597,6 @@
             "scope": "window",
             "title": "Auto Format Configuration File",
             "type": "boolean"
-          },
-          "cSpell.diagnosticLevel": {
-            "default": "Information",
-            "enum": [
-              "Error",
-              "Warning",
-              "Information",
-              "Hint"
-            ],
-            "enumDescriptions": [
-              "Report Spelling Issues as Errors",
-              "Report Spelling Issues as Warnings",
-              "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems"
-            ],
-            "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
-            "scope": "resource",
-            "title": "Set Diagnostic Reporting Level",
-            "type": "string"
           },
           "cSpell.hideAddToDictionaryCodeActions": {
             "default": false,

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1628,6 +1628,36 @@
           "type": "boolean",
           "version": "4.0.0"
         },
+        "cSpell.diagnosticLevel": {
+          "default": "Information",
+          "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+          "enum": ["Error", "Warning", "Information", "Hint"],
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems"
+          ],
+          "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+          "scope": "resource",
+          "title": "Set Diagnostic Reporting Level",
+          "type": "string"
+        },
+        "cSpell.diagnosticLevelFlaggedWords": {
+          "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+          "enum": ["Error", "Warning", "Information", "Hint"],
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems"
+          ],
+          "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+          "scope": "resource",
+          "title": "Set Diagnostic Reporting Level for Flagged Words",
+          "type": "string",
+          "version": "4.0.0"
+        },
         "cSpell.overviewRulerColor": {
           "default": "#00800080",
           "description": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
@@ -2220,21 +2250,6 @@
           "scope": "window",
           "title": "Auto Format Configuration File",
           "type": "boolean"
-        },
-        "cSpell.diagnosticLevel": {
-          "default": "Information",
-          "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
-          "enum": ["Error", "Warning", "Information", "Hint"],
-          "enumDescriptions": [
-            "Report Spelling Issues as Errors",
-            "Report Spelling Issues as Warnings",
-            "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems"
-          ],
-          "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
-          "scope": "resource",
-          "title": "Set Diagnostic Reporting Level",
-          "type": "string"
         },
         "cSpell.hideAddToDictionaryCodeActions": {
           "default": false,

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1618,6 +1618,38 @@
     },
     {
       "additionalProperties": false,
+      "order": 6,
+      "properties": {
+        "cSpell.decorateIssues": {
+          "default": false,
+          "description": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
+          "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
+          "scope": "application",
+          "type": "boolean",
+          "version": "4.0.0"
+        },
+        "cSpell.overviewRulerColor": {
+          "default": "#00800080",
+          "description": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
+          "markdownDescription": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
+          "scope": "application",
+          "type": "string",
+          "version": "4.0.0"
+        },
+        "cSpell.textDecoration": {
+          "default": "underline wavy #00800080",
+          "description": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
+          "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
+          "scope": "application",
+          "type": "string",
+          "version": "4.0.0"
+        }
+      },
+      "title": "Appearance",
+      "type": "object"
+    },
+    {
+      "additionalProperties": false,
       "order": 20,
       "properties": {
         "cSpell.allowCompoundWords": {
@@ -2306,7 +2338,7 @@
       "type": "object"
     }
   ],
-  "maxItems": 9,
-  "minItems": 9,
+  "maxItems": 10,
+  "minItems": 10,
   "type": "array"
 }

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -35,6 +35,20 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     diagnosticLevel?: 'Error' | 'Warning' | 'Information' | 'Hint';
 
     /**
+     * Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
+     * By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.
+     * @title Set Diagnostic Reporting Level for Flagged Words
+     * @scope resource
+     * @version 4.0.0
+     * @enumDescriptions [
+     *  "Report Spelling Issues as Errors",
+     *  "Report Spelling Issues as Warnings",
+     *  "Report Spelling Issues as Information",
+     *  "Report Spelling Issues as Hints, will not show up in Problems"]
+     */
+    diagnosticLevelFlaggedWords?: 'Error' | 'Warning' | 'Information' | 'Hint';
+
+    /**
      * Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).
      *
      *

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -3,7 +3,7 @@ import type { CSpellMergeFields } from './CSpellSettingsPackageProperties.mjs';
 import type { CustomDictionaries, CustomDictionaryEntry } from './CustomDictionary.mjs';
 import type { SpellCheckerShouldCheckDocSettings } from './SpellCheckerShouldCheckDocSettings.mjs';
 
-export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings {
+export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings, AppearanceSettings {
     /**
      * If a `cspell` configuration file is updated, format the configuration file
      * using the VS Code Format Document Provider. This will cause the configuration
@@ -398,4 +398,51 @@ export interface AddToTargets extends AddToDictionaryTarget {
      * @default "auto"
      */
     cspell?: AutoOrBoolean;
+}
+
+export interface AppearanceSettings {
+    /**
+     * Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
+     *
+     * @scope application
+     * @version 4.0.0
+     * @default false
+     */
+    decorateIssues?: boolean;
+
+    /**
+     * The CSS color used to show issues in the ruler.
+     *
+     * - Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)
+     * - Hex colors
+     * - Use `` (empty string) to disable.
+     *
+     * Examples:
+     * - `green`
+     * - `DarkYellow`
+     * - `#ffff0080` - semi-transparent yellow.
+     *
+     * @scope application
+     * @version 4.0.0
+     * @default "#00800080"
+     */
+    overviewRulerColor?: string;
+
+    /**
+     * The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.
+     *
+     * See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
+     *
+     * - Use `` (empty string) to disable text decoration.
+     *
+     * Examples:
+     * - `blue`
+     * - `yellow`
+     * - `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.
+     *
+     * @scope application
+     * @version 4.0.0
+     * @default "underline wavy #00800080"
+     */
+    textDecoration?: string;
 }

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -136,7 +136,6 @@ type VSConfigReporting = PrefixWithCspell<_VSConfigReporting>;
 type _VSConfigReporting = Pick<
     SpellCheckerSettingsVSCodeBase,
     | 'autoFormatConfigFile'
-    | 'diagnosticLevel'
     | 'hideAddToDictionaryCodeActions'
     | 'maxDuplicateProblems'
     | 'maxNumberOfProblems'
@@ -212,7 +211,10 @@ type _VSConfigFilesAndFolders = Pick<
  * @order 6
  */
 type VSConfigAppearance = PrefixWithCspell<_VSConfigAppearance>;
-type _VSConfigAppearance = Pick<SpellCheckerSettingsVSCodeBase, keyof AppearanceSettings>;
+type _VSConfigAppearance = Pick<
+    SpellCheckerSettingsVSCodeBase,
+    keyof AppearanceSettings | 'diagnosticLevel' | 'diagnosticLevelFlaggedWords'
+>;
 
 /**
  * @title Legacy

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -5,7 +5,7 @@ import type { LanguageSetting, OverrideSettings } from '@cspell/cspell-types';
 
 import type { CSpellSettingsPackageProperties } from './CSpellSettingsPackageProperties.mjs';
 import type { DictionaryDef } from './CustomDictionary.mjs';
-import type { SpellCheckerSettings } from './SpellCheckerSettings.mjs';
+import type { AppearanceSettings, SpellCheckerSettings } from './SpellCheckerSettings.mjs';
 
 interface InternalSettings {
     /**
@@ -175,6 +175,7 @@ type VSConfigCSpell = PrefixWithCspell<_VSConfigCSpell>;
 type _VSConfigCSpell = Omit<
     SpellCheckerSettingsVSCodeBase,
     | keyof _VSConfigAdvanced
+    | keyof _VSConfigAppearance
     | keyof _VSConfigExperimental
     | keyof _VSConfigLanguageAndDictionaries
     | keyof _VSConfigLegacy
@@ -205,6 +206,13 @@ type _VSConfigFilesAndFolders = Pick<
     | 'usePnP'
     | 'workspaceRootPath'
 >;
+
+/**
+ * @title Appearance
+ * @order 6
+ */
+type VSConfigAppearance = PrefixWithCspell<_VSConfigAppearance>;
+type _VSConfigAppearance = Pick<SpellCheckerSettingsVSCodeBase, keyof AppearanceSettings>;
 
 /**
  * @title Legacy
@@ -244,6 +252,7 @@ export type SpellCheckerSettingsVSCode = [
     VSConfigExperimental,
     VSConfigFilesAndFolders,
     VSConfigLanguageAndDictionaries,
+    VSConfigAppearance,
     VSConfigLegacy,
     VSConfigPerf,
     VSConfigReporting,

--- a/packages/client/src/decorate.ts
+++ b/packages/client/src/decorate.ts
@@ -1,0 +1,71 @@
+import { createDisposableList } from 'utils-disposables';
+import type { DecorationOptions, Diagnostic, DiagnosticChangeEvent, TextEditor, TextEditorDecorationType, Uri } from 'vscode';
+import vscode, { MarkdownString } from 'vscode';
+
+import { getCSpellDiags } from './diags';
+import type { Disposable } from './disposable';
+
+export class SpellingIssueDecorator implements Disposable {
+    private decorationType: TextEditorDecorationType | undefined;
+    private disposables = createDisposableList();
+    public dispose = this.disposables.dispose;
+
+    constructor() {
+        this.decorationType = this.createDecorator();
+        this.disposables.push(
+            () => this.clearDecoration(),
+            vscode.workspace.onDidChangeConfiguration((e) => e.affectsConfiguration('cSpell') && this.resetDecorator()),
+        );
+    }
+
+    handleOnDidChangeDiagnostics(event: DiagnosticChangeEvent) {
+        this.refreshDiagnostics(event.uris);
+    }
+
+    refreshDiagnostics(uris: readonly Uri[]) {
+        const updated = new Set(uris.map((uri) => uri.toString()));
+        const editors = vscode.window.visibleTextEditors.filter((editor) => updated.has(editor.document.uri.toString()));
+        editors.forEach((editor) => this.refreshDiagnosticsInEditor(editor));
+    }
+
+    refreshDiagnosticsInEditor(editor: TextEditor) {
+        if (!this.decorationType) return;
+        const diags = getCSpellDiags(editor.document.uri);
+
+        const decorations: DecorationOptions[] = diags.map(diagToDecorationOptions);
+        editor.setDecorations(this.decorationType, decorations);
+    }
+
+    private clearDecoration() {
+        this.decorationType?.dispose();
+        this.decorationType = undefined;
+    }
+
+    private resetDecorator() {
+        this.decorationType = this.createDecorator();
+    }
+
+    private createDecorator(): TextEditorDecorationType | undefined {
+        this.clearDecoration();
+        const diagLevel = vscode.workspace.getConfiguration('cSpell').get('diagnosticLevel');
+        const decorateIssues = vscode.workspace.getConfiguration('cSpell').get('decorateIssues');
+        if (diagLevel !== 'Hint' || !decorateIssues) return undefined;
+
+        const overviewRulerColor: string | undefined = vscode.workspace.getConfiguration('cSpell').get('overviewRulerColor') || undefined;
+        const textDecoration: string | undefined = vscode.workspace.getConfiguration('cSpell').get('textDecoration') || undefined;
+
+        return vscode.window.createTextEditorDecorationType({
+            isWholeLine: false,
+            rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed,
+            overviewRulerLane: vscode.OverviewRulerLane.Right,
+            overviewRulerColor: overviewRulerColor,
+            textDecoration: textDecoration,
+        });
+    }
+}
+
+function diagToDecorationOptions(diag: Diagnostic): DecorationOptions {
+    const { range } = diag;
+    const hoverMessage = new MarkdownString(diag.message);
+    return { range, hoverMessage };
+}

--- a/packages/client/src/decorate.ts
+++ b/packages/client/src/decorate.ts
@@ -1,6 +1,6 @@
 import { createDisposableList } from 'utils-disposables';
 import type { DecorationOptions, Diagnostic, DiagnosticChangeEvent, TextEditor, TextEditorDecorationType, Uri } from 'vscode';
-import vscode, { MarkdownString } from 'vscode';
+import vscode, { DiagnosticSeverity, MarkdownString } from 'vscode';
 
 import { getCSpellDiags } from './diags';
 import type { Disposable } from './disposable';
@@ -32,7 +32,9 @@ export class SpellingIssueDecorator implements Disposable {
         if (!this.decorationType) return;
         const diags = getCSpellDiags(editor.document.uri);
 
-        const decorations: DecorationOptions[] = diags.map(diagToDecorationOptions);
+        const decorations: DecorationOptions[] = diags
+            .filter((diag) => diag.severity === DiagnosticSeverity.Hint)
+            .map(diagToDecorationOptions);
         editor.setDecorations(this.decorationType, decorations);
     }
 

--- a/packages/client/src/extensionRegEx/extensionRegEx.ts
+++ b/packages/client/src/extensionRegEx/extensionRegEx.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext, clientSpellChecker: C
     const outline = new RegexpOutlineProvider();
     let patternMatcherClient: PatternMatcherClient | undefined;
 
-    vscode.window.registerTreeDataProvider('cSpellRegExpView', outline);
+    disposables.add(vscode.window.registerTreeDataProvider('cSpellRegExpView', outline));
 
     let timeout: NodeJS.Timeout | undefined = undefined;
 

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -27,6 +27,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     customUserDictionaries: 'customUserDictionaries',
     customWorkspaceDictionaries: 'customWorkspaceDictionaries',
     diagnosticLevel: 'diagnosticLevel',
+    diagnosticLevelFlaggedWords: 'diagnosticLevelFlaggedWords',
     fixSpellingWithRenameProvider: 'fixSpellingWithRenameProvider',
     hideAddToDictionaryCodeActions: 'hideAddToDictionaryCodeActions',
     logLevel: 'logLevel',

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -47,6 +47,9 @@ export const ConfigFields: CSpellUserSettingsFields = {
     suggestionNumChanges: 'suggestionNumChanges',
     suggestionsTimeout: 'suggestionsTimeout',
     workspaceRootPath: 'workspaceRootPath',
+    decorateIssues: 'decorateIssues',
+    textDecoration: 'textDecoration',
+    overviewRulerColor: 'overviewRulerColor',
 };
 
 // export const ConfigKeysNames = Object.values(ConfigKeysByField);


### PR DESCRIPTION
Fixes: #2885, #186 
Related to: #872, #1535, #144, #128

- Support custom decorators
- Support setting a different diag level for flagged words

When the `diagnosticLevel` is set to Hint, allow for custom text decoration and colors in the ruler.

<img width="432" alt="image" src="https://github.com/streetsidesoftware/vscode-spell-checker/assets/3740137/674d78ed-c3aa-4256-a149-e9d74c316066">

<img width="467" alt="image" src="https://github.com/streetsidesoftware/vscode-spell-checker/assets/3740137/e842171f-d02c-4497-be5e-f64a9964f6d2">

<img width="1394" alt="image" src="https://github.com/streetsidesoftware/vscode-spell-checker/assets/3740137/f2985ace-50f6-449a-b47f-c581d9f24a8d">
