### PR TITLE
feat: Add light/dark theme support

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -353,6 +353,7 @@ Default
 | [`cSpell.autoFormatConfigFile`](#cspellautoformatconfigfile)                                     | window               | Auto Format Configuration File                                                  |
 | [`cSpell.diagnosticLevel`](#cspelldiagnosticlevel)                                               | resource             | Set Diagnostic Reporting Level                                                  |
 | [`cSpell.diagnosticLevelFlaggedWords`](#cspelldiagnosticlevelflaggedwords)                       | resource             | Set Diagnostic Reporting Level for Flagged Words                                |
+| [`cSpell.diagnosticLevelSCM`](#cspelldiagnosticlevelscm)                                         | resource             | Set Diagnostic Reporting Level in SCM Commit Message                            |
 | [`cSpell.hideAddToDictionaryCodeActions`](#cspellhideaddtodictionarycodeactions)                 | resource             | Hide the options to add words to dictionaries or settings.                      |
 | [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                                     | resource             | The maximum number of times the same word can be flagged as an error in a file. |
 | [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                                       | resource             | Controls the maximum number of spelling errors per document.                    |
@@ -439,6 +440,34 @@ Default
 
 Version
 : 4.0.0
+
+---
+
+### `cSpell.diagnosticLevelSCM`
+
+Name
+: `cSpell.diagnosticLevelSCM` -- Set Diagnostic Reporting Level in SCM Commit Message
+
+Type
+: ( `"Error"` \| `"Warning"` \| `"Information"` \| `"Hint"` \| `"Off"` )
+
+    | `Error` | Report Spelling Issues as Errors |
+    | `Warning` | Report Spelling Issues as Warnings |
+    | `Information` | Report Spelling Issues as Information |
+    | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
+    | `Off` | Do not Report Spelling Issues |
+
+Scope
+: resource
+
+Description
+: Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.
+This affects the color of the squiggle.
+
+    By default, this setting will match `#cSpell.diagnosticLevel#`.
+
+Default
+: _- none -_
 
 ---
 
@@ -1342,11 +1371,36 @@ Default
 
 | Setting                                                  | Scope       | Description                                                                               |
 | -------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| [`cSpell.dark`](#cspelldark)                             | application | Decoration for dark themes.                                                               |
 | [`cSpell.decorateIssues`](#cspelldecorateissues)         | application | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
+| [`cSpell.light`](#cspelllight)                           | application | Decoration for light themes.                                                              |
 | [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor) | application | The CSS color used to show issues in the ruler.                                           |
 | [`cSpell.textDecoration`](#cspelltextdecoration)         | application | The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`. |
 
 ## Definitions
+
+### `cSpell.dark`
+
+Name
+: `cSpell.dark`
+
+Type
+: object
+
+Scope
+: application
+
+Description
+: Decoration for dark themes.
+
+    See:
+    - `#cSpell.overviewRulerColor#`
+    - `#cSpell.textDecoration#`
+
+Default
+: _- none -_
+
+---
 
 ### `cSpell.decorateIssues`
 
@@ -1370,6 +1424,29 @@ Version
 
 ---
 
+### `cSpell.light`
+
+Name
+: `cSpell.light`
+
+Type
+: object
+
+Scope
+: application
+
+Description
+: Decoration for light themes.
+
+    See:
+    - `#cSpell.overviewRulerColor#`
+    - `#cSpell.textDecoration#`
+
+Default
+: _- none -_
+
+---
+
 ### `cSpell.overviewRulerColor`
 
 Name
@@ -1384,17 +1461,20 @@ Scope
 Description
 : The CSS color used to show issues in the ruler.
 
-    - Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)
+    See:
+    - [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)
+    - [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)
     - Hex colors
-    - Use `` (empty string) to disable.
+    - Use "" (empty string) to disable.
 
     Examples:
     - `green`
     - `DarkYellow`
     - `#ffff0080` - semi-transparent yellow.
+    - `rgb(255 153 0 / 80%)`
 
 Default
-: _`"#00800080"`_
+: _`"#fc4c"`_
 
 Version
 : 4.0.0
@@ -1417,15 +1497,22 @@ Description
 
     See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
 
-    - Use `` (empty string) to disable text decoration.
+    - Use "" (empty string) to disable text decoration.
+
+    Format:  `<line> [style] <color> [thickness]`
+
+    - line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
+    - style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)
+    - color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)
+    - thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)
 
     Examples:
-    - `blue`
-    - `yellow`
-    - `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.
+    - `underline green`
+    - `underline dotted yellow 0.2rem`
+    - `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.
 
 Default
-: _`"underline wavy #00800080"`_
+: _`"underline wavy #fc4"`_
 
 Version
 : 4.0.0

--- a/package.json
+++ b/package.json
@@ -1963,6 +1963,28 @@
         "additionalProperties": false,
         "order": 6,
         "properties": {
+          "cSpell.dark": {
+            "additionalProperties": false,
+            "markdownDescription": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+            "properties": {
+              "overviewRulerColor": {
+                "default": "#fc4c",
+                "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                "scope": "application",
+                "type": "string",
+                "version": "4.0.0"
+              },
+              "textDecoration": {
+                "default": "underline wavy #fc4",
+                "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+                "scope": "application",
+                "type": "string",
+                "version": "4.0.0"
+              }
+            },
+            "scope": "application",
+            "type": "object"
+          },
           "cSpell.decorateIssues": {
             "default": false,
             "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
@@ -1970,16 +1992,38 @@
             "type": "boolean",
             "version": "4.0.0"
           },
+          "cSpell.light": {
+            "additionalProperties": false,
+            "markdownDescription": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+            "properties": {
+              "overviewRulerColor": {
+                "default": "#fc4c",
+                "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                "scope": "application",
+                "type": "string",
+                "version": "4.0.0"
+              },
+              "textDecoration": {
+                "default": "underline wavy #fc4",
+                "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+                "scope": "application",
+                "type": "string",
+                "version": "4.0.0"
+              }
+            },
+            "scope": "application",
+            "type": "object"
+          },
           "cSpell.overviewRulerColor": {
-            "default": "#00800080",
-            "markdownDescription": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
+            "default": "#fc4c",
+            "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
             "scope": "application",
             "type": "string",
             "version": "4.0.0"
           },
           "cSpell.textDecoration": {
-            "default": "underline wavy #00800080",
-            "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
+            "default": "underline wavy #fc4",
+            "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
             "scope": "application",
             "type": "string",
             "version": "4.0.0"
@@ -2597,6 +2641,26 @@
             "title": "Set Diagnostic Reporting Level for Flagged Words",
             "type": "string",
             "version": "4.0.0"
+          },
+          "cSpell.diagnosticLevelSCM": {
+            "enum": [
+              "Error",
+              "Warning",
+              "Information",
+              "Hint",
+              "Off"
+            ],
+            "enumDescriptions": [
+              "Report Spelling Issues as Errors",
+              "Report Spelling Issues as Warnings",
+              "Report Spelling Issues as Information",
+              "Report Spelling Issues as Hints, will not show up in Problems",
+              "Do not Report Spelling Issues"
+            ],
+            "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+            "scope": "resource",
+            "title": "Set Diagnostic Reporting Level in SCM Commit Message",
+            "type": "string"
           },
           "cSpell.hideAddToDictionaryCodeActions": {
             "default": false,

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1620,6 +1620,31 @@
       "additionalProperties": false,
       "order": 6,
       "properties": {
+        "cSpell.dark": {
+          "additionalProperties": false,
+          "description": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "markdownDescription": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "properties": {
+            "overviewRulerColor": {
+              "default": "#fc4c",
+              "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "scope": "application",
+              "type": "string",
+              "version": "4.0.0"
+            },
+            "textDecoration": {
+              "default": "underline wavy #fc4",
+              "description": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "scope": "application",
+              "type": "string",
+              "version": "4.0.0"
+            }
+          },
+          "scope": "application",
+          "type": "object"
+        },
         "cSpell.decorateIssues": {
           "default": false,
           "description": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
@@ -1628,18 +1653,43 @@
           "type": "boolean",
           "version": "4.0.0"
         },
+        "cSpell.light": {
+          "additionalProperties": false,
+          "description": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "markdownDescription": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "properties": {
+            "overviewRulerColor": {
+              "default": "#fc4c",
+              "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "scope": "application",
+              "type": "string",
+              "version": "4.0.0"
+            },
+            "textDecoration": {
+              "default": "underline wavy #fc4",
+              "description": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "scope": "application",
+              "type": "string",
+              "version": "4.0.0"
+            }
+          },
+          "scope": "application",
+          "type": "object"
+        },
         "cSpell.overviewRulerColor": {
-          "default": "#00800080",
-          "description": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
-          "markdownDescription": "The CSS color used to show issues in the ruler.\n\n- Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use `` (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.",
+          "default": "#fc4c",
+          "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+          "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
           "scope": "application",
           "type": "string",
           "version": "4.0.0"
         },
         "cSpell.textDecoration": {
-          "default": "underline wavy #00800080",
-          "description": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
-          "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use `` (empty string) to disable text decoration.\n\nExamples:\n- `blue`\n- `yellow`\n- `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.",
+          "default": "underline wavy #fc4",
+          "description": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+          "markdownDescription": "The CSS Style used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\n- Use \"\" (empty string) to disable text decoration.\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
           "scope": "application",
           "type": "string",
           "version": "4.0.0"
@@ -2250,6 +2300,21 @@
           "title": "Set Diagnostic Reporting Level for Flagged Words",
           "type": "string",
           "version": "4.0.0"
+        },
+        "cSpell.diagnosticLevelSCM": {
+          "description": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+          "enum": ["Error", "Warning", "Information", "Hint", "Off"],
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems",
+            "Do not Report Spelling Issues"
+          ],
+          "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+          "scope": "resource",
+          "title": "Set Diagnostic Reporting Level in SCM Commit Message",
+          "type": "string"
         },
         "cSpell.hideAddToDictionaryCodeActions": {
           "default": false,

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -3,6 +3,9 @@ import type { CSpellMergeFields } from './CSpellSettingsPackageProperties.mjs';
 import type { CustomDictionaries, CustomDictionaryEntry } from './CustomDictionary.mjs';
 import type { SpellCheckerShouldCheckDocSettings } from './SpellCheckerShouldCheckDocSettings.mjs';
 
+export type DiagnosticLevel = 'Error' | 'Warning' | 'Information' | 'Hint';
+export type DiagnosticLevelExt = DiagnosticLevel | 'Off';
+
 export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings, AppearanceSettings {
     /**
      * If a `cspell` configuration file is updated, format the configuration file
@@ -32,7 +35,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *  "Report Spelling Issues as Information",
      *  "Report Spelling Issues as Hints, will not show up in Problems"]
      */
-    diagnosticLevel?: 'Error' | 'Warning' | 'Information' | 'Hint';
+    diagnosticLevel?: DiagnosticLevel;
 
     /**
      * Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
@@ -46,7 +49,24 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *  "Report Spelling Issues as Information",
      *  "Report Spelling Issues as Hints, will not show up in Problems"]
      */
-    diagnosticLevelFlaggedWords?: 'Error' | 'Warning' | 'Information' | 'Hint';
+    diagnosticLevelFlaggedWords?: DiagnosticLevel;
+
+    /**
+     * Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.
+     * This affects the color of the squiggle.
+     *
+     * By default, this setting will match `#cSpell.diagnosticLevel#`.
+     *
+     * @title Set Diagnostic Reporting Level in SCM Commit Message
+     * @scope resource
+     * @enumDescriptions [
+     *  "Report Spelling Issues as Errors",
+     *  "Report Spelling Issues as Warnings",
+     *  "Report Spelling Issues as Information",
+     *  "Report Spelling Issues as Hints, will not show up in Problems",
+     *  "Do not Report Spelling Issues"]
+     */
+    diagnosticLevelSCM?: DiagnosticLevelExt;
 
     /**
      * Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).
@@ -414,31 +434,25 @@ export interface AddToTargets extends AddToDictionaryTarget {
     cspell?: AutoOrBoolean;
 }
 
-export interface AppearanceSettings {
-    /**
-     * Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
-     *
-     * @scope application
-     * @version 4.0.0
-     * @default false
-     */
-    decorateIssues?: boolean;
-
+export interface Decoration {
     /**
      * The CSS color used to show issues in the ruler.
      *
-     * - Supports named colors: [CSS Colors](https://www.w3schools.com/cssref/css_colors.php)
+     * See:
+     * - [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)
+     * - [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)
      * - Hex colors
-     * - Use `` (empty string) to disable.
+     * - Use "" (empty string) to disable.
      *
      * Examples:
      * - `green`
      * - `DarkYellow`
      * - `#ffff0080` - semi-transparent yellow.
+     * - `rgb(255 153 0 / 80%)`
      *
      * @scope application
+     * @default "#fc4c"
      * @version 4.0.0
-     * @default "#00800080"
      */
     overviewRulerColor?: string;
 
@@ -447,16 +461,56 @@ export interface AppearanceSettings {
      *
      * See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
      *
-     * - Use `` (empty string) to disable text decoration.
+     * - Use "" (empty string) to disable text decoration.
+     *
+     * Format:  `<line> [style] <color> [thickness]`
+     *
+     * - line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
+     * - style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)
+     * - color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)
+     * - thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)
      *
      * Examples:
-     * - `blue`
-     * - `yellow`
-     * - `underline wavy #ffff0080 1.5px` - Wavy underline with 1.5px line width in semi-transparent yellow.
+     * - `underline green`
+     * - `underline dotted yellow 0.2rem`
+     * - `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.
+     *
+     * @scope application
+     * @default "underline wavy #fc4"
+     * @version 4.0.0
+     */
+    textDecoration?: string;
+}
+
+interface Appearance extends Decoration {
+    /**
+     * Decoration for light themes.
+     *
+     * See:
+     * - `#cSpell.overviewRulerColor#`
+     * - `#cSpell.textDecoration#`
+     * @scope application
+     */
+    light?: Decoration;
+
+    /**
+     * Decoration for dark themes.
+     *
+     * See:
+     * - `#cSpell.overviewRulerColor#`
+     * - `#cSpell.textDecoration#`
+     * @scope application
+     */
+    dark?: Decoration;
+}
+
+export interface AppearanceSettings extends Appearance {
+    /**
+     * Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
      *
      * @scope application
      * @version 4.0.0
-     * @default "underline wavy #00800080"
+     * @default false
      */
-    textDecoration?: string;
+    decorateIssues?: boolean;
 }

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -138,6 +138,7 @@ type _VSConfigReporting = Pick<
     | 'autoFormatConfigFile'
     | 'diagnosticLevel'
     | 'diagnosticLevelFlaggedWords'
+    | 'diagnosticLevelSCM'
     | 'hideAddToDictionaryCodeActions'
     | 'maxDuplicateProblems'
     | 'maxNumberOfProblems'

--- a/packages/_server/src/config/docUriHelper.mts
+++ b/packages/_server/src/config/docUriHelper.mts
@@ -71,3 +71,10 @@ function handleExtractUriFromQuery(param: string, appendFile?: string): (uri: Ur
 function getHandler(uri: Uri): SpecialHandlingFunction {
     return schemaMapToHandler[uri.scheme];
 }
+
+export function isScmUri(uri: Uri | string): boolean {
+    if (typeof uri === 'string') {
+        return uri.startsWith(schemasWithSpecialHandling.vscodeScm + ':');
+    }
+    return uri.scheme === schemasWithSpecialHandling.vscodeScm;
+}

--- a/packages/client/src/settings/configFields.ts
+++ b/packages/client/src/settings/configFields.ts
@@ -28,6 +28,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     customWorkspaceDictionaries: 'customWorkspaceDictionaries',
     diagnosticLevel: 'diagnosticLevel',
     diagnosticLevelFlaggedWords: 'diagnosticLevelFlaggedWords',
+    diagnosticLevelSCM: 'diagnosticLevelSCM',
     fixSpellingWithRenameProvider: 'fixSpellingWithRenameProvider',
     hideAddToDictionaryCodeActions: 'hideAddToDictionaryCodeActions',
     logLevel: 'logLevel',
@@ -51,6 +52,8 @@ export const ConfigFields: CSpellUserSettingsFields = {
     decorateIssues: 'decorateIssues',
     textDecoration: 'textDecoration',
     overviewRulerColor: 'overviewRulerColor',
+    dark: 'dark',
+    light: 'light',
 };
 
 // export const ConfigKeysNames = Object.values(ConfigKeysByField);


### PR DESCRIPTION
Features:
- Add light/dark theme support for decorations
- Add `diagnosticLevelSCM` setting to allow for showing issues differently while editing the commit message.
