### PR TITLE
fix: reduce reloading when opening a cspell config

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "contributes": {
     "virtualWorkspaces": {
       "supported": "limited",
-      "description": "In virtual workspaces, it is not possible to load the cspell configuration from a JavaScript file. The configuration must be in a JSON, JSONC, or YAML file. Any configuration that relies upon `node_modules` will not be loaded."
+      "description": "In virtual workspaces, it is not possible to load the CSpell configuration from a JavaScript file. The configuration must be in a JSON, JSONC, or YAML file. Any configuration that relies upon `node_modules` will not be loaded."
     },
     "untrustedWorkspaces": {
       "supported": false

--- a/packages/_server/src/vfs/CSpellFileSystemProvider.mts
+++ b/packages/_server/src/vfs/CSpellFileSystemProvider.mts
@@ -9,7 +9,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { ServerSideApi } from '../api.js';
 import { FileType } from '../api.js';
 
-const debugFileProtocol = true;
+const debugFileProtocol = false;
 
 const NotHandledProtocols: Record<string, boolean> = {
     'http:': true,

--- a/packages/client/src/extension.ts
+++ b/packages/client/src/extension.ts
@@ -128,8 +128,8 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi>
         detectPossibleCSpellConfigChange(event.files);
     }
 
-    function handleOpenFile(doc: vscode.TextDocument) {
-        detectPossibleCSpellConfigChange([doc.uri]);
+    function handleOpenFile(_doc: vscode.TextDocument) {
+        // detectPossibleCSpellConfigChange([doc.uri]);
     }
 
     function handleOnDidChangeActiveTextEditor(e?: vscode.TextEditor) {

--- a/packages/client/src/settings/CSpellSettings.ts
+++ b/packages/client/src/settings/CSpellSettings.ts
@@ -34,6 +34,7 @@ export const configFileLocations = [
     // Dynamic config is looked for last
     'cspell.config.js',
     'cspell.config.cjs',
+    'cspell.config.mjs',
     // .config
     '.config/.cspell.json',
     '.config/cspell.json',
@@ -51,7 +52,16 @@ export const configFileLocations = [
     '.config/cspell.config.cjs',
 ] as const;
 
-export const configFileLocationGlob = `**/{${configFileLocations.join(',')}}`;
+const setOfConfigFilesNames = new Set(configFileLocations.map((filename) => filename.split('/').slice(-1)[0]));
+
+/**
+ * A set of files that if changed, could indicate that the cspell configuration changed.
+ *
+ * An alias of possibleConfigFiles
+ */
+export const configFilesToWatch: Set<string> = Object.freeze(setOfConfigFilesNames);
+
+export const configFileLocationGlob = `**/{${[...setOfConfigFilesNames].join(',')}}`;
 
 type ConfigFileNames = (typeof configFileLocations)[number];
 
@@ -59,16 +69,7 @@ export const nestedConfigLocations = ['package.json'];
 
 export const cspellConfigDirectory = '.cspell';
 
-export const possibleConfigFiles = Object.freeze(new Set(configFileLocations));
-
 export const preferredConfigFiles: ConfigFileNames[] = ['cspell.json', 'cspell.config.yaml', 'package.json'];
-
-/**
- * A set of files that if changed, could indicate that the cspell configuration changed.
- *
- * An alias of possibleConfigFiles
- */
-export const configFilesToWatch = possibleConfigFiles as Set<string>;
 
 export type CSpellSettings = CSpellUserSettings;
 


### PR DESCRIPTION
Everytime a cspell config file was opened, the configuration was reset causing all the dictionaries to reload.