### PR TITLE
Document `diagnosticLevel` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
     //   Error - Report Spelling Issues as Errors
     //   Warning - Report Spelling Issues as Warnings
     //   Information - Report Spelling Issues as Information (default)
-    //   Hint	- Report Spelling Issues as Hints, will not show up in Problems
+    //   Hint - Report Spelling Issues as Hints, will not show up in Problems
     "cSpell.diagnosticLevel": "Information",
 ```
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
 
     // Set the delay before spell checking the document. Default is 50.
     "cSpell.spellCheckDelayMs": 50,
+
+    // Set Diagnostic Reporting Level
+    //   Error - Report Spelling Issues as Errors
+    //   Warning - Report Spelling Issues as Warnings
+    //   Information - Report Spelling Issues as Information (default)
+    //   Hint	- Report Spelling Issues as Hints, will not show up in Problems
+    "cSpell.diagnosticLevel": "Information",
 ```
 
 ## Dictionaries


### PR DESCRIPTION
In many codebases, the Problems panel will quickly fill up with issues that are not misspellings, but words relating to code. These make it more difficult to spot 'actual' problems such as linting or type-checking.

I have been using the VS Code extension for a long time, but only recently learned how to change this behaviour. (I initially searched the README for the word 'Problems').

Judging from the votes [on this StackOverflow post](https://stackoverflow.com/a/72723985/119822), other people would also find this useful to know about.

I have copied the configuration details from https://streetsidesoftware.com/vscode-spell-checker/docs/configuration/#cspelldiagnosticlevel
