### PR TITLE
chore: protect against publishing alpha versions

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -41,6 +41,11 @@ jobs:
             const manifest = JSON.parse(fs.readFileSync('package.json', 'utf8'));
             const version = manifest.version;
             core.setOutput('version', version);
+            const alpha = version.includes('alpha');
+            core.setOutput('alpha', alpha);
+            const validVersion = /^\d+\.\d+\.\d+$/.test(version);
+            core.setOutput('valid_version', validVersion);
+            return validVersion
 
       - name: Display Info
         uses: streetsidesoftware/actions/public/summary@v1
@@ -50,6 +55,7 @@ jobs:
             ref: ${{ inputs.ref }}
             version: `${{ steps.version.outputs.version }}`
             alpha: ${{ contains(steps.version.outputs.version, 'alpha') }}
+            versionInfo: ${{ steps.version.outputs }}
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Check Version
         if: ${{ steps.version.outputs.validVersion != 'true' }}
         run: |
-          echo "::warning title=Invalid Version::The version in package.json is not a releasable version."
-          echo "::notice title=Exiting Workflow::The package will not be published."
+          echo "::warning title=Do NOT Publish::The version in package.json is not a releasable version."
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Get Package Version
+      - name: Check Package Version
         id: version
         uses: actions/github-script@v7
         with:
@@ -45,7 +45,7 @@ jobs:
             core.setOutput('alpha', alpha);
             const validVersion = /^\d+\.\d+\.\d+$/.test(version);
             core.setOutput('valid_version', validVersion);
-            return validVersion
+            return validVersion || '';
 
       - name: Display Info
         uses: streetsidesoftware/actions/public/summary@v1

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -31,6 +31,30 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Get Package Version
+        id: version
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const version = manifest.version;
+            core.setOutput('version', version);
+
+      - name: Display Info
+        uses: streetsidesoftware/actions/public/output@v1
+        with:
+          value: |
+            # Package Version
+            ref: ${{ inputs.ref }}
+            version: `${{ steps.version.outputs.version }}`
+
+      - name: Test Exit
+        run: |
+          echo "::error title=Test::This is a test error"
+          exit 1
+
       - name: Install
         run: |
           npm install

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -42,7 +42,7 @@ jobs:
             const version = manifest.version;
             core.setOutput('version', version);
             const alpha = version.includes('alpha');
-            core.setOutput('alpha', alpha);
+            core.setOutput('alpha', alpha || '');
             const validVersion = /^\d+\.\d+\.\d+$/.test(version);
             core.setOutput('validVersion', validVersion || '');
             return {
@@ -61,6 +61,12 @@ jobs:
             alpha: ${{ contains(steps.version.outputs.version, 'alpha') }}
             validVersion: ${{ steps.version.outputs.validVersion }}
             versionInfo: ${{ toJSON(steps.version.outputs) }}
+
+      - name: Check Version
+        if: ${{ steps.version.outputs.validVersion != 'true' }}
+        run: |
+          echo "::error title=Invalid Version::The version in package.json is not a releasable version."
+          exit 1
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -49,6 +49,7 @@ jobs:
             # Package Info
             ref: ${{ inputs.ref }}
             version: `${{ steps.version.outputs.version }}`
+            alpha: ${{ contains(steps.version.outputs.version, 'alpha') }}
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -66,7 +66,7 @@ jobs:
         if: ${{ steps.version.outputs.validVersion != 'true' }}
         run: |
           echo "::warning title=Invalid Version::The version in package.json is not a releasable version."
-          echo "::notice: title=Exiting Workflow::The package will not be published."
+          echo "::notice title=Exiting Workflow::The package will not be published."
           exit 0
 
       - name: Test Exit

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -43,10 +43,10 @@ jobs:
             core.setOutput('version', version);
 
       - name: Display Info
-        uses: streetsidesoftware/actions/public/output@v1
+        uses: streetsidesoftware/actions/public/summary@v1
         with:
-          value: |
-            # Package Version
+          text: |
+            # Package Info
             ref: ${{ inputs.ref }}
             version: `${{ steps.version.outputs.version }}`
 

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -65,8 +65,9 @@ jobs:
       - name: Check Version
         if: ${{ steps.version.outputs.validVersion != 'true' }}
         run: |
-          echo "::error title=Invalid Version::The version in package.json is not a releasable version."
-          exit 1
+          echo "::warning title=Invalid Version::The version in package.json is not a releasable version."
+          echo "::notice: title=Exiting Workflow::The package will not be published."
+          exit 0
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -24,8 +24,12 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  publish:
+  check_version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      alpha: ${{ steps.version.outputs.alpha }}
+      validVersion: ${{ steps.version.outputs.validVersion }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,7 +71,16 @@ jobs:
         run: |
           echo "::warning title=Invalid Version::The version in package.json is not a releasable version."
           echo "::notice title=Exiting Workflow::The package will not be published."
-          exit 0
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: check_version
+    if: ${{ needs.check_version.outputs.validVersion == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -55,7 +55,7 @@ jobs:
             ref: ${{ inputs.ref }}
             version: `${{ steps.version.outputs.version }}`
             alpha: ${{ contains(steps.version.outputs.version, 'alpha') }}
-            versionInfo: ${{ steps.version.outputs }}
+            versionInfo: ${{ toJSON(steps.version.outputs) }}
 
       - name: Test Exit
         run: |

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -44,8 +44,12 @@ jobs:
             const alpha = version.includes('alpha');
             core.setOutput('alpha', alpha);
             const validVersion = /^\d+\.\d+\.\d+$/.test(version);
-            core.setOutput('valid_version', validVersion);
-            return validVersion || '';
+            core.setOutput('validVersion', validVersion || '');
+            return {
+              version,
+              alpha,
+              validVersion
+            };
 
       - name: Display Info
         uses: streetsidesoftware/actions/public/summary@v1
@@ -55,6 +59,7 @@ jobs:
             ref: ${{ inputs.ref }}
             version: `${{ steps.version.outputs.version }}`
             alpha: ${{ contains(steps.version.outputs.version, 'alpha') }}
+            validVersion: ${{ steps.version.outputs.validVersion }}
             versionInfo: ${{ toJSON(steps.version.outputs) }}
 
       - name: Test Exit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,7 +70,7 @@ jobs:
   publish:
     needs:
       - release-please
-    if: ${{ needs.release-please.outputs.release_created && !contains('alpha', needs.release-please.outputs.tag_name) }}
+    if: ${{ needs.release-please.outputs.release_created && !contains(needs.release-please.outputs.tag_name, 'alpha') }}
     uses: ./.github/workflows/manual-publish.yml
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,7 +70,7 @@ jobs:
   publish:
     needs:
       - release-please
-    if: ${{ needs.release-please.outputs.release_created && !contains(needs.release-please.outputs.tag_name, 'alpha') }}
+    if: ${{ needs.release-please.outputs.release_created }}
     uses: ./.github/workflows/manual-publish.yml
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-    "bootstrap-sha": "569b42758f06ccd890eb4404b2176118e6f933ec",
     "release-type": "node",
     "versioning": "prerelease",
     "prerelease-type": "alpha",
@@ -74,8 +73,6 @@
         }
     ],
     "packages": {
-        ".": {
-            "include-component-in-tag": false
-        }
+        ".": {}
     }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -74,6 +74,8 @@
         }
     ],
     "packages": {
-        ".": {}
+        ".": {
+            "include-component-in-tag": false
+        }
     }
 }


### PR DESCRIPTION
Adjust the workflows to prevent accidental publishing of alpha versions.

Note: The "Test Exit" is still in to workflow until we have tried to publish the first alpha release.