### PR TITLE
fix: Adjust the default settings

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -436,10 +436,12 @@ Scope
 : resource
 
 Description
-: Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
+: The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
+Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+to control how issues are displayed in the document.
 
 Default
-: _`"Information"`_
+: _`"Hint"`_
 
 ---
 
@@ -977,7 +979,7 @@ This only applies when there is a CSpell configuration file in the workspace.
     Note: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.
 
 Default
-: _`false`_
+: _`true`_
 
 Version
 : 4.0.0
@@ -1499,7 +1501,7 @@ Description
 : Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
 
 Default
-: _`false`_
+: _`true`_
 
 Version
 : 4.0.0

--- a/package.json
+++ b/package.json
@@ -734,7 +734,7 @@
                   "type": "string"
                 },
                 "diagnosticLevel": {
-                  "default": "Information",
+                  "default": "Hint",
                   "enum": [
                     "Error",
                     "Warning",
@@ -747,7 +747,7 @@
                     "Report Spelling Issues as Information",
                     "Report Spelling Issues as Hints, will not show up in Problems"
                   ],
-                  "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+                  "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
                   "scope": "resource",
                   "title": "Set Diagnostic Reporting Level",
                   "type": "string"
@@ -1651,7 +1651,7 @@
             "type": "array"
           },
           "cSpell.mergeCSpellSettings": {
-            "default": false,
+            "default": true,
             "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
             "scope": "resource",
             "type": "boolean",
@@ -2545,7 +2545,7 @@
             "type": "object"
           },
           "cSpell.decorateIssues": {
-            "default": false,
+            "default": true,
             "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
             "scope": "application",
             "type": "boolean",
@@ -3256,7 +3256,7 @@
             "type": "boolean"
           },
           "cSpell.diagnosticLevel": {
-            "default": "Information",
+            "default": "Hint",
             "enum": [
               "Error",
               "Warning",
@@ -3269,7 +3269,7 @@
               "Report Spelling Issues as Information",
               "Report Spelling Issues as Hints, will not show up in Problems"
             ],
-            "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+            "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
             "scope": "resource",
             "title": "Set Diagnostic Reporting Level",
             "type": "string"

--- a/packages/_integrationTests/src/helper.mts
+++ b/packages/_integrationTests/src/helper.mts
@@ -70,6 +70,14 @@ export async function loadDocument(docUri: Uri): Promise<DocumentContext | undef
     }
 }
 
+export async function loadFolder(folderUri: Uri): Promise<void> {
+    return await vscode.commands.executeCommand('vscode.openFolder', folderUri);
+}
+
+export function getVscodeWorkspace(): typeof vscode.workspace {
+    return vscode.workspace;
+}
+
 export async function sleep(ms: number): Promise<undefined> {
     return new Promise((resolve) => setTimeout(() => resolve(undefined), ms));
 }

--- a/packages/_integrationTests/testFixtures/.vscode/settings.json
+++ b/packages/_integrationTests/testFixtures/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.diagnosticLevel": "Information"
+}

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -133,8 +133,8 @@
                 "type": "string"
               },
               "diagnosticLevel": {
-                "default": "Information",
-                "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+                "default": "Hint",
+                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.",
                 "enum": [
                   "Error",
                   "Warning",
@@ -147,7 +147,7 @@
                   "Report Spelling Issues as Information",
                   "Report Spelling Issues as Hints, will not show up in Problems"
                 ],
-                "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
                 "scope": "resource",
                 "title": "Set Diagnostic Reporting Level",
                 "type": "string"
@@ -1182,7 +1182,7 @@
           "type": "array"
         },
         "cSpell.mergeCSpellSettings": {
-          "default": false,
+          "default": true,
           "description": "Specify if fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
           "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
           "scope": "resource",
@@ -2184,7 +2184,7 @@
           "type": "object"
         },
         "cSpell.decorateIssues": {
-          "default": false,
+          "default": true,
           "description": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
           "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
           "scope": "application",
@@ -2975,8 +2975,8 @@
           "type": "boolean"
         },
         "cSpell.diagnosticLevel": {
-          "default": "Information",
-          "description": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+          "default": "Hint",
+          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.",
           "enum": [
             "Error",
             "Warning",
@@ -2989,7 +2989,7 @@
             "Report Spelling Issues as Information",
             "Report Spelling Issues as Hints, will not show up in Problems"
           ],
-          "markdownDescription": "Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.",
+          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
           "scope": "resource",
           "title": "Set Diagnostic Reporting Level",
           "type": "string"

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -178,7 +178,7 @@ export interface AppearanceSettings extends Appearance {
      *
      * @scope application
      * @version 4.0.0
-     * @default false
+     * @default true
      */
     decorateIssues?: boolean;
 }

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -27,10 +27,12 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
     checkLimit?: number;
 
     /**
-     * Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
+     * The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
+     * Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+     * to control how issues are displayed in the document.
      * @title Set Diagnostic Reporting Level
      * @scope resource
-     * @default "Information"
+     * @default "Hint"
      * @enumDescriptions [
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
@@ -375,7 +377,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *
      * @scope resource
      * @version 4.0.0
-     * @default false
+     * @default true
      */
     mergeCSpellSettings?: boolean;
 

--- a/packages/client/src/issueViewer/issuesViewerByFile.ts
+++ b/packages/client/src/issueViewer/issuesViewerByFile.ts
@@ -516,6 +516,7 @@ function collectIssuesByFile(context: Context): FileWithIssuesTreeItem[] {
     const comp = new Intl.Collator().compare;
 
     const sorted = [...groupedByFile]
+        .filter(([_, issues]) => issues.length)
         .map(([doc, issues]) => new FileWithIssuesTreeItem(context, doc, issues))
         .sort((a, b) => comp(a.document.uri.toString(true), b.document.uri.toString(true)));
 


### PR DESCRIPTION
- merge vscode settings by default, this is to preserve existing behavior.
- Use the Spell Checker's decorator by default.
- Use `Hint` to hide issues from the Problems Pane