### PR TITLE
fix: Add `vsls` to schemes to support Live Share

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -802,7 +802,7 @@ Description
     - `vscode-scm` - Needed to spell check Source Control commit messages.
 
 Default
-: [ _`"file"`_, _`"gist"`_, _`"repo"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_, _`"vscode-scm"`_, _`"vscode-userdata"`_, _`"vscode-vfs"`_ ]
+: [ _`"file"`_, _`"gist"`_, _`"repo"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_, _`"vscode-scm"`_, _`"vscode-userdata"`_, _`"vscode-vfs"`_, _`"vsls"`_ ]
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1579,7 +1579,8 @@
               "vscode-notebook-cell",
               "vscode-scm",
               "vscode-userdata",
-              "vscode-vfs"
+              "vscode-vfs",
+              "vsls"
             ],
             "items": {
               "type": "string"

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1099,7 +1099,8 @@
             "vscode-notebook-cell",
             "vscode-scm",
             "vscode-userdata",
-            "vscode-vfs"
+            "vscode-vfs",
+            "vsls"
           ],
           "description": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.",
           "items": {

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -83,7 +83,7 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * - `vscode-scm` - Needed to spell check Source Control commit messages.
      * @title Define Allowed Schemas
      * @scope window
-     * @default ["file", "gist", "repo", "sftp", "untitled", "vscode-notebook-cell", "vscode-scm", "vscode-userdata", "vscode-vfs"]
+     * @default ["file", "gist", "repo", "sftp", "untitled", "vscode-notebook-cell", "vscode-scm", "vscode-userdata", "vscode-vfs", "vsls"]
      */
     allowedSchemas?: string[];
 

--- a/packages/_server/src/config/documentSettings.mts
+++ b/packages/_server/src/config/documentSettings.mts
@@ -101,7 +101,16 @@ const defaultExclude: Glob[] = [
     '__pycache__/**', // ignore cache files. cspell:ignore pycache
 ];
 
-const defaultAllowedSchemes = ['gist', 'repo', 'file', 'sftp', 'untitled', 'vscode-notebook-cell', 'vscode-vfs'];
+const defaultAllowedSchemes = [
+    'gist',
+    'repo',
+    'file',
+    'sftp',
+    'untitled',
+    'vscode-notebook-cell',
+    'vscode-vfs', // Visual Studio Remote File System
+    'vsls', // Visual Studio Live Share
+];
 const schemeBlockList = ['git', 'output', 'debug'];
 
 const defaultRootUri = toFileUri(process.cwd()).toString();


### PR DESCRIPTION
Related to (#1554 Live Share Comment)[https://github.com/streetsidesoftware/vscode-spell-checker/issues/1554#issuecomment-1985273705]