### PR TITLE
Adds support for spell checking comment editors

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -800,9 +800,10 @@ Description
     - `vscode-notebook-cell` - Used for validating segments of a Notebook.
     - `vscode-userdata` - Needed to spell check `.code-snippets`
     - `vscode-scm` - Needed to spell check Source Control commit messages.
+    - `comment` - Used for new comment editors.
 
 Default
-: [ _`"file"`_, _`"gist"`_, _`"repo"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_, _`"vscode-scm"`_, _`"vscode-userdata"`_, _`"vscode-vfs"`_, _`"vsls"`_ ]
+: [ _`"file"`_, _`"gist"`_, _`"repo"`_, _`"sftp"`_, _`"untitled"`_, _`"vscode-notebook-cell"`_, _`"vscode-scm"`_, _`"comment"`_, _`"vscode-userdata"`_, _`"vscode-vfs"`_, _`"vsls"`_ ]
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1578,6 +1578,7 @@
               "untitled",
               "vscode-notebook-cell",
               "vscode-scm",
+              "comment",
               "vscode-userdata",
               "vscode-vfs",
               "vsls"
@@ -1585,7 +1586,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.",
+            "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
             "scope": "window",
             "title": "Define Allowed Schemas",
             "type": "array"

--- a/packages/__utils/src/uriHelper.ts
+++ b/packages/__utils/src/uriHelper.ts
@@ -1,6 +1,16 @@
 import { URI as Uri, Utils as UriUtils } from 'vscode-uri';
 
-export const supportedSchemes = ['file', 'gist', 'repo', 'sftp', 'untitled', 'vscode-notebook-cell', 'vscode-scm', 'vscode-userdata'];
+export const supportedSchemes = [
+    'file',
+    'gist',
+    'repo',
+    'sftp',
+    'untitled',
+    'vscode-notebook-cell',
+    'vscode-scm',
+    'vscode-userdata',
+    'comment',
+];
 export const setOfSupportedSchemes = new Set(supportedSchemes);
 
 export function isSupportedUri(uri?: Uri): boolean {

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1098,15 +1098,16 @@
             "untitled",
             "vscode-notebook-cell",
             "vscode-scm",
+            "comment",
             "vscode-userdata",
             "vscode-vfs",
             "vsls"
           ],
-          "description": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.",
+          "description": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
           "items": {
             "type": "string"
           },
-          "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.",
+          "markdownDescription": "Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemas have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
           "scope": "window",
           "title": "Define Allowed Schemas",
           "type": "array"

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -81,9 +81,10 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * - `vscode-notebook-cell` - Used for validating segments of a Notebook.
      * - `vscode-userdata` - Needed to spell check `.code-snippets`
      * - `vscode-scm` - Needed to spell check Source Control commit messages.
+     * - `comment` - Used for new comment editors.
      * @title Define Allowed Schemas
      * @scope window
-     * @default ["file", "gist", "repo", "sftp", "untitled", "vscode-notebook-cell", "vscode-scm", "vscode-userdata", "vscode-vfs", "vsls"]
+     * @default ["file", "gist", "repo", "sftp", "untitled", "vscode-notebook-cell", "vscode-scm", "comment", "vscode-userdata", "vscode-vfs", "vsls"]
      */
     allowedSchemas?: string[];
 


### PR DESCRIPTION
This enables spell check in VS Code's comment editors (commonly used while reviewing PRs). Depends on https://github.com/microsoft/vscode/pull/209512

<img width="654" alt="Screenshot 2024-04-04 at 1 40 27 PM" src="https://github.com/streetsidesoftware/vscode-spell-checker/assets/12821956/079b0254-af35-4410-bca4-685bac93301d">
