### PR TITLE
feat: Hide spelling issues while typing.

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -5,9 +5,7 @@ flagWords:
   - hte
 ignorePaths:
   - .git/*/**
-  - .git/index
-  - .git/*HEAD
-  - .git/*refs
+  - .git/!(COMMIT_EDITMSG)
   - .gitignore
   - .vscodeignore
   - '*.lock'

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -4,7 +4,10 @@ language: en-US
 flagWords:
   - hte
 ignorePaths:
-  - .git
+  - .git/*/**
+  - .git/index
+  - .git/*HEAD
+  - .git/*refs
   - .gitignore
   - .vscodeignore
   - '*.lock'

--- a/docs/_includes/generated-docs/commands.md
+++ b/docs/_includes/generated-docs/commands.md
@@ -34,7 +34,7 @@
 | `cSpell.goToNextSpellingIssueAndSuggest`             | Go to Next Spelling Issue and Suggest                                                                           |
 | `cSpell.goToPreviousSpellingIssue`                   | Go to Previous Spelling Issue                                                                                   |
 | `cSpell.goToPreviousSpellingIssueAndSuggest`         | Go to Previous Spelling Issue and Suggest                                                                       |
-| `cSpell.hide`                                        | Hide Decorations                                                                                                |
+| `cSpell.hide`                                        | Hide Spelling Decorations                                                                                       |
 | `cSpell.insertDisableLineDirective`                  | Insert Disable Current Line Directive                                                                           |
 | `cSpell.insertDisableNextLineDirective`              | Insert Disable Next Line Directive                                                                              |
 | `cSpell.insertIgnoreWordsDirective`                  | Insert Ignore Words Directive                                                                                   |
@@ -48,7 +48,7 @@
 | `cSpell.removeWordFromFolderDictionary`              | Remove Words from the Folder Dictionary                                                                         |
 | `cSpell.removeWordFromUserDictionary`                | Remove Words from the Global Dictionary                                                                         |
 | `cSpell.removeWordFromWorkspaceDictionary`           | Remove Words from the Workspace Dictionaries                                                                    |
-| `cSpell.show`                                        | Show Decorations                                                                                                |
+| `cSpell.show`                                        | Show Spelling Decorations                                                                                       |
 | `cSpell.suggestSpellingCorrections`                  | Spelling Suggestions...<br>**When:**<br> `editorTextFocus && cSpell.editorMenuContext.showSuggestions`          |
 | `cSpell.toggleEnableForGlobal`                       | Toggle Spell Checking in User Settings                                                                          |
 | `cSpell.toggleEnableForWorkspace`                    | Toggle Spell Checking for Workspace                                                                             |

--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -383,10 +383,12 @@ Default
 | [`cSpell.diagnosticLevelFlaggedWords`](#cspelldiagnosticlevelflaggedwords)                       | resource             | Set Diagnostic Reporting Level for Flagged Words                                |
 | [`cSpell.diagnosticLevelSCM`](#cspelldiagnosticlevelscm)                                         | resource             | Set Diagnostic Reporting Level in SCM Commit Message                            |
 | [`cSpell.hideAddToDictionaryCodeActions`](#cspellhideaddtodictionarycodeactions)                 | resource             | Hide the options to add words to dictionaries or settings.                      |
+| [`cSpell.hideIssuesWhileTyping`](#cspellhideissueswhiletyping)                                   | machine              | Hide Issues While Typing                                                        |
 | [`cSpell.maxDuplicateProblems`](#cspellmaxduplicateproblems)                                     | resource             | The maximum number of times the same word can be flagged as an error in a file. |
 | [`cSpell.maxNumberOfProblems`](#cspellmaxnumberofproblems)                                       | resource             | Controls the maximum number of spelling errors per document.                    |
 | [`cSpell.minWordLength`](#cspellminwordlength)                                                   | resource             | The minimum length of a word before checking it against a dictionary.           |
 | [`cSpell.numSuggestions`](#cspellnumsuggestions)                                                 | resource             | Controls the number of suggestions shown.                                       |
+| [`cSpell.revealIssuesAfterDelayMS`](#cspellrevealissuesafterdelayms)                             | machine              | Reveal Issues After a Delay in Milliseconds                                     |
 | [`cSpell.showAutocompleteDirectiveSuggestions`](#cspellshowautocompletedirectivesuggestions)     | language-overridable | Show CSpell in-document directives as you type.                                 |
 | [`cSpell.showCommandsInEditorContextMenu`](#cspellshowcommandsineditorcontextmenu)               | application          | Show Spell Checker actions in Editor Context Menu                               |
 | [`cSpell.showStatus`](#cspellshowstatus)                                                         | application          | Display the spell checker status on the status bar.                             |
@@ -426,12 +428,13 @@ Name
 
 <!-- prettier-ignore-start -->
 Type
-: `( "Error" | "Warning" | "Information" | "Hint" )`
+: `( "Error" | "Warning" | "Information" | "Hint" | "Off" )`
 
     | `Error` | Report Spelling Issues as Errors |
     | `Warning` | Report Spelling Issues as Warnings |
     | `Information` | Report Spelling Issues as Information |
     | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
+    | `Off` | Do not Report Spelling Issues |
 
 <!-- prettier-ignore-end -->
 
@@ -440,8 +443,10 @@ Scope
 
 Description
 : The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
-Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
 to control how issues are displayed in the document.
+
+    See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
 
 Default
 : _`"Hint"`_
@@ -455,12 +460,13 @@ Name
 
 <!-- prettier-ignore-start -->
 Type
-: `( "Error" | "Warning" | "Information" | "Hint" )`
+: `( "Error" | "Warning" | "Information" | "Hint" | "Off" )`
 
     | `Error` | Report Spelling Issues as Errors |
     | `Warning` | Report Spelling Issues as Warnings |
     | `Information` | Report Spelling Issues as Information |
     | `Hint` | Report Spelling Issues as Hints, will not show up in Problems |
+    | `Off` | Do not Report Spelling Issues |
 
 <!-- prettier-ignore-end -->
 
@@ -470,6 +476,8 @@ Scope
 Description
 : Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
 By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.
+
+    See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
 
 Default
 : _- none -_
@@ -505,8 +513,13 @@ This affects the color of the squiggle.
 
     By default, this setting will match `#cSpell.diagnosticLevel#`.
 
+    See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
+
 Default
 : _- none -_
+
+Since Version
+: 4.0.0
 
 ---
 
@@ -526,6 +539,37 @@ Description
 
 Default
 : _`false`_
+
+---
+
+### `cSpell.hideIssuesWhileTyping`
+
+Name
+: `cSpell.hideIssuesWhileTyping` -- Hide Issues While Typing
+
+<!-- prettier-ignore-start -->
+Type
+: `( "Off" | "Word" | "Line" | "Document" )`
+
+    | `Off` | Show issues while typing |
+    | `Word` | Hide issues in the current word |
+    | `Line` | Hide issues on the line |
+    | `Document` | Hide all issues in the document |
+
+<!-- prettier-ignore-end -->
+
+Scope
+: machine
+
+Description
+: Control how spelling issues are displayed while typing.
+See: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.
+
+Default
+: _`"Word"`_
+
+Since Version
+: 4.0.0
 
 ---
 
@@ -602,6 +646,28 @@ Description
 
 Default
 : _`8`_
+
+---
+
+### `cSpell.revealIssuesAfterDelayMS`
+
+Name
+: `cSpell.revealIssuesAfterDelayMS` -- Reveal Issues After a Delay in Milliseconds
+
+Type
+: `number`
+
+Scope
+: machine
+
+Description
+: Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.
+
+Default
+: _`1500`_
+
+Since Version
+: 4.0.0
 
 ---
 
@@ -1525,18 +1591,18 @@ Since Version
 
 # Appearance
 
-| Setting                                                                  | Scope       | Description                                                                               |
-| ------------------------------------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------- |
-| [`cSpell.dark`](#cspelldark)                                             | application | Decoration for dark themes.                                                               |
-| [`cSpell.decorateIssues`](#cspelldecorateissues)                         | application | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
-| [`cSpell.light`](#cspelllight)                                           | application | Decoration for light themes.                                                              |
-| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor)                 | application | The CSS color used to show issues in the ruler.                                           |
-| [`cSpell.textDecoration`](#cspelltextdecoration)                         | application | The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.   |
-| [`cSpell.textDecorationColor`](#cspelltextdecorationcolor)               | application | The decoration color for normal spelling issues.                                          |
-| [`cSpell.textDecorationColorFlagged`](#cspelltextdecorationcolorflagged) | application | The decoration color for flagged issues.                                                  |
-| [`cSpell.textDecorationLine`](#cspelltextdecorationline)                 | application | The CSS line type used to decorate issues.                                                |
-| [`cSpell.textDecorationStyle`](#cspelltextdecorationstyle)               | application | The CSS line style used to decorate issues.                                               |
-| [`cSpell.textDecorationThickness`](#cspelltextdecorationthickness)       | application | The CSS line thickness used to decorate issues.                                           |
+| Setting                                                                  | Scope   | Description                                                                               |
+| ------------------------------------------------------------------------ | ------- | ----------------------------------------------------------------------------------------- |
+| [`cSpell.dark`](#cspelldark)                                             | machine | Decoration for dark themes.                                                               |
+| [`cSpell.decorateIssues`](#cspelldecorateissues)                         | machine | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
+| [`cSpell.light`](#cspelllight)                                           | machine | Decoration for light themes.                                                              |
+| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor)                 | machine | The CSS color used to show issues in the ruler.                                           |
+| [`cSpell.textDecoration`](#cspelltextdecoration)                         | machine | The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.   |
+| [`cSpell.textDecorationColor`](#cspelltextdecorationcolor)               | machine | The decoration color for normal spelling issues.                                          |
+| [`cSpell.textDecorationColorFlagged`](#cspelltextdecorationcolorflagged) | machine | The decoration color for flagged issues.                                                  |
+| [`cSpell.textDecorationLine`](#cspelltextdecorationline)                 | machine | The CSS line type used to decorate issues.                                                |
+| [`cSpell.textDecorationStyle`](#cspelltextdecorationstyle)               | machine | The CSS line style used to decorate issues.                                               |
+| [`cSpell.textDecorationThickness`](#cspelltextdecorationthickness)       | machine | The CSS line thickness used to decorate issues.                                           |
 
 ## Definitions
 
@@ -1549,7 +1615,7 @@ Type
 : `object`
 
 Scope
-: application
+: machine
 
 Description
 : Decoration for dark themes.
@@ -1560,6 +1626,9 @@ Description
 
 Default
 : _- none -_
+
+Since Version
+: 4.0.0
 
 ---
 
@@ -1572,7 +1641,7 @@ Type
 : `boolean`
 
 Scope
-: application
+: machine
 
 Description
 : Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
@@ -1594,7 +1663,7 @@ Type
 : `object`
 
 Scope
-: application
+: machine
 
 Description
 : Decoration for light themes.
@@ -1605,6 +1674,9 @@ Description
 
 Default
 : _- none -_
+
+Since Version
+: 4.0.0
 
 ---
 
@@ -1617,7 +1689,7 @@ Type
 : `string`
 
 Scope
-: application
+: machine
 
 Description
 : The CSS color used to show issues in the ruler.
@@ -1651,7 +1723,7 @@ Type
 : `string`
 
 Scope
-: application
+: machine
 
 Description
 : The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.
@@ -1693,7 +1765,7 @@ Type
 : `string`
 
 Scope
-: application
+: machine
 
 Description
 : The decoration color for normal spelling issues.
@@ -1723,7 +1795,7 @@ Type
 : `string`
 
 Scope
-: application
+: machine
 
 Description
 : The decoration color for flagged issues.
@@ -1753,7 +1825,7 @@ Type
 : `( "underline" | "overline" | "line-through" )`
 
 Scope
-: application
+: machine
 
 Description
 : The CSS line type used to decorate issues.
@@ -1778,7 +1850,7 @@ Type
 : `( "solid" | "wavy" | "dotted" | "dashed" | "double" )`
 
 Scope
-: application
+: machine
 
 Description
 : The CSS line style used to decorate issues.
@@ -1803,7 +1875,7 @@ Type
 : `string`
 
 Scope
-: application
+: machine
 
 Description
 : The CSS line thickness used to decorate issues.

--- a/package.json
+++ b/package.json
@@ -547,7 +547,7 @@
       {
         "command": "cSpell.show",
         "category": "Spell",
-        "title": "Show Decorations",
+        "title": "Show Spelling Decorations",
         "shortTitle": "Show",
         "when": "config.cSpell.decorateIssues && !cSpell.showDecorations",
         "icon": "$(eye)"
@@ -555,7 +555,7 @@
       {
         "command": "cSpell.hide",
         "category": "Spell",
-        "title": "Hide Decorations",
+        "title": "Hide Spelling Decorations",
         "shortTitle": "Hide",
         "when": "config.cSpell.decorateIssues && cSpell.showDecorations",
         "icon": "$(eye-closed)"
@@ -827,15 +827,17 @@
                     "Error",
                     "Warning",
                     "Information",
-                    "Hint"
+                    "Hint",
+                    "Off"
                   ],
                   "enumDescriptions": [
                     "Report Spelling Issues as Errors",
                     "Report Spelling Issues as Warnings",
                     "Report Spelling Issues as Information",
-                    "Report Spelling Issues as Hints, will not show up in Problems"
+                    "Report Spelling Issues as Hints, will not show up in Problems",
+                    "Do not Report Spelling Issues"
                   ],
-                  "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
+                  "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                   "scope": "resource",
                   "title": "Set Diagnostic Reporting Level",
                   "type": "string"
@@ -845,15 +847,17 @@
                     "Error",
                     "Warning",
                     "Information",
-                    "Hint"
+                    "Hint",
+                    "Off"
                   ],
                   "enumDescriptions": [
                     "Report Spelling Issues as Errors",
                     "Report Spelling Issues as Warnings",
                     "Report Spelling Issues as Information",
-                    "Report Spelling Issues as Hints, will not show up in Problems"
+                    "Report Spelling Issues as Hints, will not show up in Problems",
+                    "Do not Report Spelling Issues"
                   ],
-                  "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+                  "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                   "scope": "resource",
                   "since": "4.0.0",
                   "title": "Set Diagnostic Reporting Level for Flagged Words",
@@ -2965,27 +2969,27 @@
               "overviewRulerColor": {
                 "default": "#fc4c",
                 "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecoration": {
                 "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationColor": {
                 "default": "#fc4",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorFlagged": {
                 "default": "#f44",
                 "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
@@ -2997,7 +3001,7 @@
                   "line-through"
                 ],
                 "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
@@ -3011,25 +3015,26 @@
                   "double"
                 ],
                 "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationThickness": {
                 "default": "auto",
                 "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               }
             },
-            "scope": "application",
+            "scope": "machine",
+            "since": "4.0.0",
             "type": "object"
           },
           "cSpell.decorateIssues": {
             "default": true,
             "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "boolean"
           },
@@ -3040,27 +3045,27 @@
               "overviewRulerColor": {
                 "default": "#fc4c",
                 "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecoration": {
                 "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationColor": {
                 "default": "#fc4",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorFlagged": {
                 "default": "#f44",
                 "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
@@ -3072,7 +3077,7 @@
                   "line-through"
                 ],
                 "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
@@ -3086,45 +3091,46 @@
                   "double"
                 ],
                 "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               },
               "textDecorationThickness": {
                 "default": "auto",
                 "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                "scope": "application",
+                "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
               }
             },
-            "scope": "application",
+            "scope": "machine",
+            "since": "4.0.0",
             "type": "object"
           },
           "cSpell.overviewRulerColor": {
             "default": "#fc4c",
             "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecoration": {
             "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationColor": {
             "default": "#fc4",
             "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationColorFlagged": {
             "default": "#f44",
             "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
@@ -3136,7 +3142,7 @@
               "line-through"
             ],
             "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
@@ -3150,14 +3156,14 @@
               "double"
             ],
             "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationThickness": {
             "default": "auto",
             "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-            "scope": "application",
+            "scope": "machine",
             "since": "4.0.0",
             "type": "string"
           }
@@ -3743,15 +3749,17 @@
               "Error",
               "Warning",
               "Information",
-              "Hint"
+              "Hint",
+              "Off"
             ],
             "enumDescriptions": [
               "Report Spelling Issues as Errors",
               "Report Spelling Issues as Warnings",
               "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems"
+              "Report Spelling Issues as Hints, will not show up in Problems",
+              "Do not Report Spelling Issues"
             ],
-            "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
+            "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
             "title": "Set Diagnostic Reporting Level",
             "type": "string"
@@ -3761,15 +3769,17 @@
               "Error",
               "Warning",
               "Information",
-              "Hint"
+              "Hint",
+              "Off"
             ],
             "enumDescriptions": [
               "Report Spelling Issues as Errors",
               "Report Spelling Issues as Warnings",
               "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems"
+              "Report Spelling Issues as Hints, will not show up in Problems",
+              "Do not Report Spelling Issues"
             ],
-            "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+            "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
             "since": "4.0.0",
             "title": "Set Diagnostic Reporting Level for Flagged Words",
@@ -3790,8 +3800,9 @@
               "Report Spelling Issues as Hints, will not show up in Problems",
               "Do not Report Spelling Issues"
             ],
-            "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+            "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
+            "since": "4.0.0",
             "title": "Set Diagnostic Reporting Level in SCM Commit Message",
             "type": "string"
           },
@@ -3800,6 +3811,26 @@
             "markdownDescription": "Hide the options to add words to dictionaries or settings.",
             "scope": "resource",
             "type": "boolean"
+          },
+          "cSpell.hideIssuesWhileTyping": {
+            "default": "Word",
+            "enum": [
+              "Off",
+              "Word",
+              "Line",
+              "Document"
+            ],
+            "enumDescriptions": [
+              "Show issues while typing",
+              "Hide issues in the current word",
+              "Hide issues on the line",
+              "Hide all issues in the document"
+            ],
+            "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.",
+            "scope": "machine",
+            "since": "4.0.0",
+            "title": "Hide Issues While Typing",
+            "type": "string"
           },
           "cSpell.maxDuplicateProblems": {
             "default": 20,
@@ -3823,6 +3854,20 @@
             "default": 8,
             "markdownDescription": "Controls the number of suggestions shown.",
             "scope": "resource",
+            "type": "number"
+          },
+          "cSpell.revealIssuesAfterDelayMS": {
+            "default": 1500,
+            "enumDescriptions": [
+              "Show issues while typing",
+              "Hide issues in the current word",
+              "Hide issues on the line",
+              "Hide all issues in the document"
+            ],
+            "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+            "scope": "machine",
+            "since": "4.0.0",
+            "title": "Reveal Issues After a Delay in Milliseconds",
             "type": "number"
           },
           "cSpell.showAutocompleteDirectiveSuggestions": {

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -218,39 +218,43 @@
               },
               "diagnosticLevel": {
                 "default": "Hint",
-                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.",
+                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "enum": [
                   "Error",
                   "Warning",
                   "Information",
-                  "Hint"
+                  "Hint",
+                  "Off"
                 ],
                 "enumDescriptions": [
                   "Report Spelling Issues as Errors",
                   "Report Spelling Issues as Warnings",
                   "Report Spelling Issues as Information",
-                  "Report Spelling Issues as Hints, will not show up in Problems"
+                  "Report Spelling Issues as Hints, will not show up in Problems",
+                  "Do not Report Spelling Issues"
                 ],
-                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
+                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "scope": "resource",
                 "title": "Set Diagnostic Reporting Level",
                 "type": "string"
               },
               "diagnosticLevelFlaggedWords": {
-                "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+                "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "enum": [
                   "Error",
                   "Warning",
                   "Information",
-                  "Hint"
+                  "Hint",
+                  "Off"
                 ],
                 "enumDescriptions": [
                   "Report Spelling Issues as Errors",
                   "Report Spelling Issues as Warnings",
                   "Report Spelling Issues as Information",
-                  "Report Spelling Issues as Hints, will not show up in Problems"
+                  "Report Spelling Issues as Hints, will not show up in Problems",
+                  "Do not Report Spelling Issues"
                 ],
-                "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
+                "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "scope": "resource",
                 "since": "4.0.0",
                 "title": "Set Diagnostic Reporting Level for Flagged Words",
@@ -2627,14 +2631,14 @@
               "default": "#fc4c",
               "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
             "textDecoration": {
               "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
               "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2642,7 +2646,7 @@
               "default": "#fc4",
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2650,7 +2654,7 @@
               "default": "#f44",
               "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2663,7 +2667,7 @@
                 "line-through"
               ],
               "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2678,7 +2682,7 @@
                 "double"
               ],
               "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2686,19 +2690,20 @@
               "default": "auto",
               "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             }
           },
-          "scope": "application",
+          "scope": "machine",
+          "since": "4.0.0",
           "type": "object"
         },
         "cSpell.decorateIssues": {
           "default": true,
           "description": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
           "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "boolean"
         },
@@ -2711,14 +2716,14 @@
               "default": "#fc4c",
               "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
             "textDecoration": {
               "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
               "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2726,7 +2731,7 @@
               "default": "#fc4",
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2734,7 +2739,7 @@
               "default": "#f44",
               "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2747,7 +2752,7 @@
                 "line-through"
               ],
               "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2762,7 +2767,7 @@
                 "double"
               ],
               "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             },
@@ -2770,26 +2775,27 @@
               "default": "auto",
               "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-              "scope": "application",
+              "scope": "machine",
               "since": "4.0.0",
               "type": "string"
             }
           },
-          "scope": "application",
+          "scope": "machine",
+          "since": "4.0.0",
           "type": "object"
         },
         "cSpell.overviewRulerColor": {
           "default": "#fc4c",
           "description": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
           "markdownDescription": "The CSS color used to show issues in the ruler.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n- Use \"\" (empty string) to disable.\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecoration": {
           "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
           "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
@@ -2797,7 +2803,7 @@
           "default": "#fc4",
           "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
@@ -2805,7 +2811,7 @@
           "default": "#f44",
           "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
@@ -2818,7 +2824,7 @@
             "line-through"
           ],
           "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
@@ -2833,7 +2839,7 @@
             "double"
           ],
           "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         },
@@ -2841,7 +2847,7 @@
           "default": "auto",
           "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
           "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-          "scope": "application",
+          "scope": "machine",
           "since": "4.0.0",
           "type": "string"
         }
@@ -3487,46 +3493,7 @@
         },
         "cSpell.diagnosticLevel": {
           "default": "Hint",
-          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.",
-          "enum": [
-            "Error",
-            "Warning",
-            "Information",
-            "Hint"
-          ],
-          "enumDescriptions": [
-            "Report Spelling Issues as Errors",
-            "Report Spelling Issues as Warnings",
-            "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems"
-          ],
-          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.",
-          "scope": "resource",
-          "title": "Set Diagnostic Reporting Level",
-          "type": "string"
-        },
-        "cSpell.diagnosticLevelFlaggedWords": {
-          "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
-          "enum": [
-            "Error",
-            "Warning",
-            "Information",
-            "Hint"
-          ],
-          "enumDescriptions": [
-            "Report Spelling Issues as Errors",
-            "Report Spelling Issues as Warnings",
-            "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems"
-          ],
-          "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.",
-          "scope": "resource",
-          "since": "4.0.0",
-          "title": "Set Diagnostic Reporting Level for Flagged Words",
-          "type": "string"
-        },
-        "cSpell.diagnosticLevelSCM": {
-          "description": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "enum": [
             "Error",
             "Warning",
@@ -3541,8 +3508,52 @@
             "Report Spelling Issues as Hints, will not show up in Problems",
             "Do not Report Spelling Issues"
           ],
-          "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.",
+          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "scope": "resource",
+          "title": "Set Diagnostic Reporting Level",
+          "type": "string"
+        },
+        "cSpell.diagnosticLevelFlaggedWords": {
+          "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "enum": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint",
+            "Off"
+          ],
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems",
+            "Do not Report Spelling Issues"
+          ],
+          "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "scope": "resource",
+          "since": "4.0.0",
+          "title": "Set Diagnostic Reporting Level for Flagged Words",
+          "type": "string"
+        },
+        "cSpell.diagnosticLevelSCM": {
+          "description": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "enum": [
+            "Error",
+            "Warning",
+            "Information",
+            "Hint",
+            "Off"
+          ],
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems",
+            "Do not Report Spelling Issues"
+          ],
+          "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "scope": "resource",
+          "since": "4.0.0",
           "title": "Set Diagnostic Reporting Level in SCM Commit Message",
           "type": "string"
         },
@@ -3552,6 +3563,27 @@
           "markdownDescription": "Hide the options to add words to dictionaries or settings.",
           "scope": "resource",
           "type": "boolean"
+        },
+        "cSpell.hideIssuesWhileTyping": {
+          "default": "Word",
+          "description": "Control how spelling issues are displayed while typing. See: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.",
+          "enum": [
+            "Off",
+            "Word",
+            "Line",
+            "Document"
+          ],
+          "enumDescriptions": [
+            "Show issues while typing",
+            "Hide issues in the current word",
+            "Hide issues on the line",
+            "Hide all issues in the document"
+          ],
+          "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.",
+          "scope": "machine",
+          "since": "4.0.0",
+          "title": "Hide Issues While Typing",
+          "type": "string"
         },
         "cSpell.maxDuplicateProblems": {
           "default": 20,
@@ -3579,6 +3611,21 @@
           "description": "Controls the number of suggestions shown.",
           "markdownDescription": "Controls the number of suggestions shown.",
           "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.revealIssuesAfterDelayMS": {
+          "default": 1500,
+          "description": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+          "enumDescriptions": [
+            "Show issues while typing",
+            "Hide issues in the current word",
+            "Hide issues on the line",
+            "Hide all issues in the document"
+          ],
+          "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+          "scope": "machine",
+          "since": "4.0.0",
+          "title": "Reveal Issues After a Delay in Milliseconds",
           "type": "number"
         },
         "cSpell.showAutocompleteDirectiveSuggestions": {

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -17,9 +17,9 @@ interface Decoration {
      * - `#ffff0080` - semi-transparent yellow.
      * - `rgb(255 153 0 / 80%)`
      *
-     * @scope application
-     * @default "#fc4c"
+     * @scope machine
      * @since 4.0.0
+     * @default "#fc4c"
      */
     overviewRulerColor?: string;
 
@@ -46,7 +46,7 @@ interface Decoration {
      * - `underline dotted yellow 0.2rem`
      * - `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.
      *
-     * @scope application
+     * @scope machine
      * @since 4.0.0
      */
     textDecoration?: string;
@@ -57,9 +57,9 @@ interface Decoration {
      * See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
      * - line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
      *
-     * @scope application
-     * @default "underline"
+     * @scope machine
      * @since 4.0.0
+     * @default "underline"
      */
     textDecorationLine?: 'underline' | 'overline' | 'line-through';
 
@@ -69,9 +69,9 @@ interface Decoration {
      * See: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
      * - style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)
      *
-     * @scope application
-     * @default "wavy"
+     * @scope machine
      * @since 4.0.0
+     * @default "wavy"
      */
     textDecorationStyle?: 'solid' | 'wavy' | 'dotted' | 'dashed' | 'double';
 
@@ -88,9 +88,9 @@ interface Decoration {
      * - `1.5px`
      * - `10%`
      *
-     * @scope application
-     * @default "auto"
+     * @scope machine
      * @since 4.0.0
+     * @default "auto"
      */
     textDecorationThickness?: 'auto' | 'from-font' | string;
 
@@ -105,9 +105,9 @@ interface Decoration {
      * - `yellow`
      * - `#ff0c`
      *
-     * @scope application
-     * @default "#fc4"
+     * @scope machine
      * @since 4.0.0
+     * @default "#fc4"
      */
     textDecorationColor?: string;
 
@@ -122,9 +122,9 @@ interface Decoration {
      * - `yellow`
      * - `#ff0c`
      *
-     * @scope application
-     * @default "#f44"
+     * @scope machine
      * @since 4.0.0
+     * @default "#f44"
      */
     textDecorationColorFlagged?: string;
 
@@ -139,9 +139,9 @@ interface Decoration {
      * - `yellow`
      * - `#ff0c`
      *
-     * @scope application
-     * @default "#888"
+     * @scope machine
      * @since 4.0.0
+     * @default "#888"
      * @hidden hide this for now. It won't be used until we have a way to get pure suggestions.
      */
     textDecorationColorSuggestion?: string;
@@ -157,7 +157,8 @@ interface Appearance extends Decoration {
      * See:
      * - `#cSpell.overviewRulerColor#`
      * - `#cSpell.textDecoration#`
-     * @scope application
+     * @scope machine
+     * @since 4.0.0
      */
     light?: Decoration;
 
@@ -167,7 +168,8 @@ interface Appearance extends Decoration {
      * See:
      * - `#cSpell.overviewRulerColor#`
      * - `#cSpell.textDecoration#`
-     * @scope application
+     * @scope machine
+     * @since 4.0.0
      */
     dark?: Decoration;
 }
@@ -176,7 +178,7 @@ export interface AppearanceSettings extends Appearance {
     /**
      * Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
      *
-     * @scope application
+     * @scope machine
      * @since 4.0.0
      * @default true
      */

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -5,9 +5,9 @@ import type { CustomDictionaries, CustomDictionaryEntry } from './CustomDictiona
 import type { SpellCheckerShouldCheckDocSettings } from './SpellCheckerShouldCheckDocSettings.mjs';
 
 export type DiagnosticLevel = 'Error' | 'Warning' | 'Information' | 'Hint';
-export type DiagnosticLevelExt = DiagnosticLevel | 'Off';
+export type DiagnosticLevelExt = 'Error' | 'Warning' | 'Information' | 'Hint' | 'Off';
 
-export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings, AppearanceSettings {
+export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings, SpellCheckerBehaviorSettings, AppearanceSettings {
     /**
      * If a `cspell` configuration file is updated, format the configuration file
      * using the VS Code Format Document Provider. This will cause the configuration
@@ -28,8 +28,10 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
 
     /**
      * The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
-     * Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+     * Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
      * to control how issues are displayed in the document.
+     *
+     * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
      * @title Set Diagnostic Reporting Level
      * @scope resource
      * @default "Hint"
@@ -37,13 +39,16 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
      *  "Report Spelling Issues as Information",
-     *  "Report Spelling Issues as Hints, will not show up in Problems"]
+     *  "Report Spelling Issues as Hints, will not show up in Problems",
+     *  "Do not Report Spelling Issues"]
      */
-    diagnosticLevel?: DiagnosticLevel;
+    diagnosticLevel?: DiagnosticLevelExt;
 
     /**
      * Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
      * By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.
+     *
+     * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
      * @title Set Diagnostic Reporting Level for Flagged Words
      * @scope resource
      * @since 4.0.0
@@ -51,9 +56,10 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
      *  "Report Spelling Issues as Information",
-     *  "Report Spelling Issues as Hints, will not show up in Problems"]
+     *  "Report Spelling Issues as Hints, will not show up in Problems",
+     *  "Do not Report Spelling Issues"]
      */
-    diagnosticLevelFlaggedWords?: DiagnosticLevel;
+    diagnosticLevelFlaggedWords?: DiagnosticLevelExt;
 
     /**
      * Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.
@@ -61,8 +67,10 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *
      * By default, this setting will match `#cSpell.diagnosticLevel#`.
      *
+     * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
      * @title Set Diagnostic Reporting Level in SCM Commit Message
      * @scope resource
+     * @since 4.0.0
      * @enumDescriptions [
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
@@ -431,6 +439,37 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      * @default true
      */
     trustedWorkspace?: boolean;
+}
+
+export interface SpellCheckerBehaviorSettings {
+    /**
+     * Control how spelling issues are displayed while typing.
+     * See: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.
+     * @title Hide Issues While Typing
+     * @scope machine
+     * @since 4.0.0
+     * @default "Word"
+     * @enumDescriptions [
+     *  "Show issues while typing",
+     *  "Hide issues in the current word",
+     *  "Hide issues on the line",
+     *  "Hide all issues in the document"]
+     */
+    hideIssuesWhileTyping?: 'Off' | 'Word' | 'Line' | 'Document';
+
+    /**
+     * Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.
+     * @title Reveal Issues After a Delay in Milliseconds
+     * @scope machine
+     * @since 4.0.0
+     * @default 1500
+     * @enumDescriptions [
+     *  "Show issues while typing",
+     *  "Hide issues in the current word",
+     *  "Hide issues on the line",
+     *  "Hide all issues in the document"]
+     */
+    revealIssuesAfterDelayMS?: number;
 }
 
 type AutoOrBoolean = boolean | 'auto';

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -7,7 +7,7 @@ import type { AppearanceSettings } from './AppearanceSettings.mjs';
 import type { CSpellSettingsPackageProperties } from './CSpellSettingsPackageProperties.mjs';
 import type { DictionaryDef } from './CustomDictionary.mjs';
 import type { PrefixWithCspell } from './Generics.mjs';
-import type { SpellCheckerSettings } from './SpellCheckerSettings.mjs';
+import type { SpellCheckerBehaviorSettings, SpellCheckerSettings } from './SpellCheckerSettings.mjs';
 
 interface InternalSettings {
     /**
@@ -173,6 +173,7 @@ type _VSConfigReporting = Pick<
     | 'suggestionMenuType'
     | 'suggestionNumChanges'
     | 'validateDirectives'
+    | keyof SpellCheckerBehaviorSettings
 >;
 
 /**

--- a/packages/client/src/configWatcher.mts
+++ b/packages/client/src/configWatcher.mts
@@ -59,7 +59,7 @@ class ConfigWatcherImpl implements ConfigWatcher {
     };
 
     async scanWorkspaceForConfigFiles(cancellationToken?: vscode.CancellationToken): Promise<Uri[]> {
-        console.log('scanWorkspaceForConfigFiles %o', this.#configFileNames);
+        // console.log('scanWorkspaceForConfigFiles %o', this.#configFileNames);
 
         const found = await vscode.workspace.findFiles(
             `**/{${this.#configFileNames.join(',')}}`,

--- a/packages/client/src/extension.mts
+++ b/packages/client/src/extension.mts
@@ -79,7 +79,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi>
     }
 
     const configWatcher = createConfigWatcher();
-    console.log('config files: %o', await configWatcher.scanWorkspaceForConfigFiles());
+    // console.log('config files: %o', await configWatcher.scanWorkspaceForConfigFiles());
     const decorator = new SpellingIssueDecorator(context, issueTracker);
     const decoratorExclusions = new SpellingExclusionsDecorator(context, client);
     activateIssueViewer(context, issueTracker);

--- a/packages/client/src/settings/configFields.mts
+++ b/packages/client/src/settings/configFields.mts
@@ -52,6 +52,10 @@ export const ConfigFields: CSpellUserSettingsFields = {
     useLocallyInstalledCSpellDictionaries: 'useLocallyInstalledCSpellDictionaries',
     workspaceRootPath: 'workspaceRootPath',
     trustedWorkspace: 'trustedWorkspace',
+    // Behavior
+    hideIssuesWhileTyping: 'hideIssuesWhileTyping',
+    revealIssuesAfterDelayMS: 'revealIssuesAfterDelayMS',
+    // Appearance
     decorateIssues: 'decorateIssues',
     textDecoration: 'textDecoration',
     textDecorationLine: 'textDecorationLine',


### PR DESCRIPTION
Because of the custom decorators in v4, it is possible to control when issues are displayed.

v4 comes with a command to show/hide issues. This is different than the enable/disable command. That command turns the spell checker on/off, almost like shutting it down and restarting it.

Added a couple of settings:

```ts
export interface SpellCheckerBehaviorSettings {
    /**
     * Control how spelling issues are displayed while typing.
     * See: `#cSpell.revealIssuesAfterMS#` to control when issues are revealed.
     * @title Hide Issues While Typing
     * @scope machine
     * @since 4.0.0
     * @default "Word"
     * @enumDescriptions [
     *  "Show issues while typing",
     *  "Hide issues in the current word",
     *  "Hide issues on the line",
     *  "Hide all issues in the document"]
     */
    hideIssuesWhileTyping?: 'Off' | 'Word' | 'Line' | 'Document';

    /**
     * Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.
     * @title Reveal Issues After a Delay in Milliseconds
     * @scope machine
     * @since 4.0.0
     * @default 1500
     * @enumDescriptions [
     *  "Show issues while typing",
     *  "Hide issues in the current word",
     *  "Hide issues on the line",
     *  "Hide all issues in the document"]
     */
    revealIssuesAfterDelayMS?: number;
}
```