### PR TITLE
fix: change the approach to custom decorations

### DIFF
--- a/docs/_includes/generated-docs/configuration.md
+++ b/docs/_includes/generated-docs/configuration.md
@@ -443,7 +443,7 @@ Scope
 
 Description
 : The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
-Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`
 to control how issues are displayed in the document.
 
     See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
@@ -1591,18 +1591,18 @@ Since Version
 
 # Appearance
 
-| Setting                                                                  | Scope   | Description                                                                               |
-| ------------------------------------------------------------------------ | ------- | ----------------------------------------------------------------------------------------- |
-| [`cSpell.dark`](#cspelldark)                                             | machine | Decoration for dark themes.                                                               |
-| [`cSpell.decorateIssues`](#cspelldecorateissues)                         | machine | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`. |
-| [`cSpell.light`](#cspelllight)                                           | machine | Decoration for light themes.                                                              |
-| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor)                 | machine | The CSS color used to show issues in the ruler.                                           |
-| [`cSpell.textDecoration`](#cspelltextdecoration)                         | machine | The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.   |
-| [`cSpell.textDecorationColor`](#cspelltextdecorationcolor)               | machine | The decoration color for normal spelling issues.                                          |
-| [`cSpell.textDecorationColorFlagged`](#cspelltextdecorationcolorflagged) | machine | The decoration color for flagged issues.                                                  |
-| [`cSpell.textDecorationLine`](#cspelltextdecorationline)                 | machine | The CSS line type used to decorate issues.                                                |
-| [`cSpell.textDecorationStyle`](#cspelltextdecorationstyle)               | machine | The CSS line style used to decorate issues.                                               |
-| [`cSpell.textDecorationThickness`](#cspelltextdecorationthickness)       | machine | The CSS line thickness used to decorate issues.                                           |
+| Setting                                                                  | Scope   | Description                                                                                   |
+| ------------------------------------------------------------------------ | ------- | --------------------------------------------------------------------------------------------- |
+| [`cSpell.dark`](#cspelldark)                                             | machine | Decoration for dark themes.                                                                   |
+| [`cSpell.useCustomDecorations`](#cspelldecorateissues)                   | machine | Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.     |
+| [`cSpell.light`](#cspelllight)                                           | machine | Decoration for light themes.                                                                  |
+| [`cSpell.overviewRulerColor`](#cspelloverviewrulercolor)                 | machine | The CSS color used to show issues in the ruler.                                               |
+| [`cSpell.textDecoration`](#cspelltextdecoration)                         | machine | The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`. |
+| [`cSpell.textDecorationColor`](#cspelltextdecorationcolor)               | machine | The decoration color for normal spelling issues.                                              |
+| [`cSpell.textDecorationColorFlagged`](#cspelltextdecorationcolorflagged) | machine | The decoration color for flagged issues.                                                      |
+| [`cSpell.textDecorationLine`](#cspelltextdecorationline)                 | machine | The CSS line type used to decorate issues.                                                    |
+| [`cSpell.textDecorationStyle`](#cspelltextdecorationstyle)               | machine | The CSS line style used to decorate issues.                                                   |
+| [`cSpell.textDecorationThickness`](#cspelltextdecorationthickness)       | machine | The CSS line thickness used to decorate issues.                                               |
 
 ## Definitions
 
@@ -1632,10 +1632,10 @@ Since Version
 
 ---
 
-### `cSpell.decorateIssues`
+### `cSpell.useCustomDecorations`
 
 Name
-: `cSpell.decorateIssues`
+: `cSpell.useCustomDecorations`
 
 Type
 : `boolean`
@@ -1726,7 +1726,7 @@ Scope
 : machine
 
 Description
-: The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.
+: The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.
 
     This setting is used to manually configure the text decoration. If it is not set, the following settings are used:
     - `#cSpell.textDecorationLine#` to pick the line type

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "editor/context": [
         {
           "command": "cSpell.suggestSpellingCorrections",
-          "when": "!editorReadonly && editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions && (!config.cSpell.decorateIssues || cSpell.showDecorations)",
+          "when": "!editorReadonly && editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions && cSpell.showDecorations",
           "group": "A_cspell@000"
         },
         {
@@ -70,12 +70,12 @@
         },
         {
           "command": "cSpell.show",
-          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && config.cSpell.decorateIssues && !cSpell.showDecorations",
+          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && !cSpell.showDecorations",
           "group": "A_cspell@002"
         },
         {
           "command": "cSpell.hide",
-          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && config.cSpell.decorateIssues && cSpell.showDecorations",
+          "when": "editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && cSpell.showDecorations",
           "group": "A_cspell@002"
         }
       ],
@@ -539,25 +539,24 @@
       {
         "command": "cSpell.toggleVisible",
         "category": "Spell",
-        "title": "Toggle Show Decorations",
-        "shortTitle": "Toggle Decorations",
-        "when": "config.cSpell.decorateIssues",
+        "title": "Toggle Show Spelling Issues",
+        "shortTitle": "Toggle Spelling Issues",
         "icon": "$(eye)"
       },
       {
         "command": "cSpell.show",
         "category": "Spell",
-        "title": "Show Spelling Decorations",
+        "title": "Show Spelling Issues",
         "shortTitle": "Show",
-        "when": "config.cSpell.decorateIssues && !cSpell.showDecorations",
+        "when": "!cSpell.showDecorations",
         "icon": "$(eye)"
       },
       {
         "command": "cSpell.hide",
         "category": "Spell",
-        "title": "Hide Spelling Decorations",
+        "title": "Hide Spelling Issues",
         "shortTitle": "Hide",
-        "when": "config.cSpell.decorateIssues && cSpell.showDecorations",
+        "when": "cSpell.showDecorations",
         "icon": "$(eye-closed)"
       },
       {
@@ -822,22 +821,20 @@
                   "type": "string"
                 },
                 "diagnosticLevel": {
-                  "default": "Hint",
+                  "default": "Information",
                   "enum": [
                     "Error",
                     "Warning",
                     "Information",
-                    "Hint",
-                    "Off"
+                    "Hint"
                   ],
                   "enumDescriptions": [
                     "Report Spelling Issues as Errors",
                     "Report Spelling Issues as Warnings",
                     "Report Spelling Issues as Information",
-                    "Report Spelling Issues as Hints, will not show up in Problems",
-                    "Do not Report Spelling Issues"
+                    "Report Spelling Issues as Hints, will not show up in Problems"
                   ],
-                  "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                  "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                   "scope": "resource",
                   "title": "Set Diagnostic Reporting Level",
                   "type": "string"
@@ -847,15 +844,13 @@
                     "Error",
                     "Warning",
                     "Information",
-                    "Hint",
-                    "Off"
+                    "Hint"
                   ],
                   "enumDescriptions": [
                     "Report Spelling Issues as Errors",
                     "Report Spelling Issues as Warnings",
                     "Report Spelling Issues as Information",
-                    "Report Spelling Issues as Hints, will not show up in Problems",
-                    "Do not Report Spelling Issues"
+                    "Report Spelling Issues as Hints, will not show up in Problems"
                   ],
                   "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                   "scope": "resource",
@@ -2974,7 +2969,7 @@
                 "type": "string"
               },
               "textDecoration": {
-                "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+                "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
                 "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
@@ -3031,12 +3026,18 @@
             "since": "4.0.0",
             "type": "object"
           },
-          "cSpell.decorateIssues": {
-            "default": true,
-            "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
+          "cSpell.doNotUseCustomDecorationForScheme": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "default": {
+              "vscode-scm": true
+            },
+            "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
             "scope": "machine",
             "since": "4.0.0",
-            "type": "boolean"
+            "title": "Use VS Code to Render Spelling Issues",
+            "type": "object"
           },
           "cSpell.light": {
             "additionalProperties": false,
@@ -3050,7 +3051,7 @@
                 "type": "string"
               },
               "textDecoration": {
-                "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+                "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
                 "scope": "machine",
                 "since": "4.0.0",
                 "type": "string"
@@ -3115,7 +3116,7 @@
             "type": "string"
           },
           "cSpell.textDecoration": {
-            "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+            "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
             "scope": "machine",
             "since": "4.0.0",
             "type": "string"
@@ -3166,6 +3167,13 @@
             "scope": "machine",
             "since": "4.0.0",
             "type": "string"
+          },
+          "cSpell.useCustomDecorations": {
+            "default": true,
+            "markdownDescription": "Draw custom decorations on Spelling Issues.",
+            "scope": "machine",
+            "since": "4.0.0",
+            "type": "boolean"
           }
         },
         "title": "Appearance",
@@ -3744,22 +3752,20 @@
             "type": "boolean"
           },
           "cSpell.diagnosticLevel": {
-            "default": "Hint",
+            "default": "Information",
             "enum": [
               "Error",
               "Warning",
               "Information",
-              "Hint",
-              "Off"
+              "Hint"
             ],
             "enumDescriptions": [
               "Report Spelling Issues as Errors",
               "Report Spelling Issues as Warnings",
               "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems",
-              "Do not Report Spelling Issues"
+              "Report Spelling Issues as Hints, will not show up in Problems"
             ],
-            "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+            "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
             "title": "Set Diagnostic Reporting Level",
             "type": "string"
@@ -3769,41 +3775,18 @@
               "Error",
               "Warning",
               "Information",
-              "Hint",
-              "Off"
+              "Hint"
             ],
             "enumDescriptions": [
               "Report Spelling Issues as Errors",
               "Report Spelling Issues as Warnings",
               "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems",
-              "Do not Report Spelling Issues"
+              "Report Spelling Issues as Hints, will not show up in Problems"
             ],
             "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
             "since": "4.0.0",
             "title": "Set Diagnostic Reporting Level for Flagged Words",
-            "type": "string"
-          },
-          "cSpell.diagnosticLevelSCM": {
-            "enum": [
-              "Error",
-              "Warning",
-              "Information",
-              "Hint",
-              "Off"
-            ],
-            "enumDescriptions": [
-              "Report Spelling Issues as Errors",
-              "Report Spelling Issues as Warnings",
-              "Report Spelling Issues as Information",
-              "Report Spelling Issues as Hints, will not show up in Problems",
-              "Do not Report Spelling Issues"
-            ],
-            "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-            "scope": "resource",
-            "since": "4.0.0",
-            "title": "Set Diagnostic Reporting Level in SCM Commit Message",
             "type": "string"
           },
           "cSpell.hideAddToDictionaryCodeActions": {

--- a/packages/_integrationTests/src/extension.test.mts
+++ b/packages/_integrationTests/src/extension.test.mts
@@ -8,7 +8,7 @@ import { createRequire } from 'node:module';
 import { expect } from 'chai';
 import type { Stream } from 'kefir';
 import { stream } from 'kefir';
-import type { Diagnostic, languages as vscodeLanguages, Position, Uri, window as vscodeWindow } from 'vscode';
+import { type Diagnostic, type languages as vscodeLanguages, type Position, type Uri, type window as vscodeWindow } from 'vscode';
 
 import type { CSpellClient, ExtensionApi, OnSpellCheckDocumentStep } from './ExtensionApi.mjs';
 import {
@@ -111,8 +111,9 @@ describe('Launch code spell extension', function () {
         logYellow('Verifies that some spelling errors were found');
         await loadFolder(getDocUri('.'));
         const uri = getDocUri('example.md');
-        await getVscodeWorkspace().getConfiguration(undefined, uri).update('cSpell.diagnosticLevel', 'Information');
-        await getVscodeWorkspace().getConfiguration().update('cSpell.useCustomDecorations', false);
+        const config = getVscodeWorkspace().getConfiguration(undefined, uri);
+        await config.update('cSpell.diagnosticLevel', 'Information');
+        await config.update('cSpell.useCustomDecorations', false, 1);
         const docContextMaybe = await loadDocument(uri);
         await sleep(500);
         // Force a spell check by making an edit.

--- a/packages/_integrationTests/src/extension.test.mts
+++ b/packages/_integrationTests/src/extension.test.mts
@@ -111,9 +111,8 @@ describe('Launch code spell extension', function () {
         logYellow('Verifies that some spelling errors were found');
         await loadFolder(getDocUri('.'));
         const uri = getDocUri('example.md');
-        const config = getVscodeWorkspace().getConfiguration(undefined, uri);
-        await config.update('cSpell.diagnosticLevel', 'Information');
-        await config.update('cSpell.useCustomDecorations', false);
+        await getVscodeWorkspace().getConfiguration(undefined, uri).update('cSpell.diagnosticLevel', 'Information');
+        await getVscodeWorkspace().getConfiguration().update('cSpell.useCustomDecorations', false);
         const docContextMaybe = await loadDocument(uri);
         await sleep(500);
         // Force a spell check by making an edit.

--- a/packages/_integrationTests/src/extension.test.mts
+++ b/packages/_integrationTests/src/extension.test.mts
@@ -111,7 +111,9 @@ describe('Launch code spell extension', function () {
         logYellow('Verifies that some spelling errors were found');
         await loadFolder(getDocUri('.'));
         const uri = getDocUri('example.md');
-        await getVscodeWorkspace().getConfiguration(undefined, uri).update('cSpell.diagnosticLevel', 'Information');
+        const config = getVscodeWorkspace().getConfiguration(undefined, uri);
+        await config.update('cSpell.diagnosticLevel', 'Information');
+        await config.update('cSpell.useCustomDecorations', false);
         const docContextMaybe = await loadDocument(uri);
         await sleep(500);
         // Force a spell check by making an edit.

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -217,23 +217,21 @@
                 "type": "string"
               },
               "diagnosticLevel": {
-                "default": "Hint",
-                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "default": "Information",
+                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "enum": [
                   "Error",
                   "Warning",
                   "Information",
-                  "Hint",
-                  "Off"
+                  "Hint"
                 ],
                 "enumDescriptions": [
                   "Report Spelling Issues as Errors",
                   "Report Spelling Issues as Warnings",
                   "Report Spelling Issues as Information",
-                  "Report Spelling Issues as Hints, will not show up in Problems",
-                  "Do not Report Spelling Issues"
+                  "Report Spelling Issues as Hints, will not show up in Problems"
                 ],
-                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "scope": "resource",
                 "title": "Set Diagnostic Reporting Level",
                 "type": "string"
@@ -244,15 +242,13 @@
                   "Error",
                   "Warning",
                   "Information",
-                  "Hint",
-                  "Off"
+                  "Hint"
                 ],
                 "enumDescriptions": [
                   "Report Spelling Issues as Errors",
                   "Report Spelling Issues as Warnings",
                   "Report Spelling Issues as Information",
-                  "Report Spelling Issues as Hints, will not show up in Problems",
-                  "Do not Report Spelling Issues"
+                  "Report Spelling Issues as Hints, will not show up in Problems"
                 ],
                 "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "scope": "resource",
@@ -2636,8 +2632,8 @@
               "type": "string"
             },
             "textDecoration": {
-              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
               "scope": "machine",
               "since": "4.0.0",
               "type": "string"
@@ -2699,13 +2695,19 @@
           "since": "4.0.0",
           "type": "object"
         },
-        "cSpell.decorateIssues": {
-          "default": true,
-          "description": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
-          "markdownDescription": "Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.",
+        "cSpell.doNotUseCustomDecorationForScheme": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {
+            "vscode-scm": true
+          },
+          "description": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up. This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
+          "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
           "scope": "machine",
           "since": "4.0.0",
-          "type": "boolean"
+          "title": "Use VS Code to Render Spelling Issues",
+          "type": "object"
         },
         "cSpell.light": {
           "additionalProperties": false,
@@ -2721,8 +2723,8 @@
               "type": "string"
             },
             "textDecoration": {
-              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
               "scope": "machine",
               "since": "4.0.0",
               "type": "string"
@@ -2793,8 +2795,8 @@
           "type": "string"
         },
         "cSpell.textDecoration": {
-          "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
-          "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+          "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
+          "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.",
           "scope": "machine",
           "since": "4.0.0",
           "type": "string"
@@ -2850,6 +2852,14 @@
           "scope": "machine",
           "since": "4.0.0",
           "type": "string"
+        },
+        "cSpell.useCustomDecorations": {
+          "default": true,
+          "description": "Draw custom decorations on Spelling Issues.",
+          "markdownDescription": "Draw custom decorations on Spelling Issues.",
+          "scope": "machine",
+          "since": "4.0.0",
+          "type": "boolean"
         }
       },
       "title": "Appearance",
@@ -3492,23 +3502,21 @@
           "type": "boolean"
         },
         "cSpell.diagnosticLevel": {
-          "default": "Hint",
-          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "default": "Information",
+          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#` to control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "enum": [
             "Error",
             "Warning",
             "Information",
-            "Hint",
-            "Off"
+            "Hint"
           ],
           "enumDescriptions": [
             "Report Spelling Issues as Errors",
             "Report Spelling Issues as Warnings",
             "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems",
-            "Do not Report Spelling Issues"
+            "Report Spelling Issues as Hints, will not show up in Problems"
           ],
-          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`\nto control how issues are displayed in the document.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "scope": "resource",
           "title": "Set Diagnostic Reporting Level",
           "type": "string"
@@ -3519,42 +3527,18 @@
             "Error",
             "Warning",
             "Information",
-            "Hint",
-            "Off"
+            "Hint"
           ],
           "enumDescriptions": [
             "Report Spelling Issues as Errors",
             "Report Spelling Issues as Warnings",
             "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems",
-            "Do not Report Spelling Issues"
+            "Report Spelling Issues as Hints, will not show up in Problems"
           ],
           "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "scope": "resource",
           "since": "4.0.0",
           "title": "Set Diagnostic Reporting Level for Flagged Words",
-          "type": "string"
-        },
-        "cSpell.diagnosticLevelSCM": {
-          "description": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-          "enum": [
-            "Error",
-            "Warning",
-            "Information",
-            "Hint",
-            "Off"
-          ],
-          "enumDescriptions": [
-            "Report Spelling Issues as Errors",
-            "Report Spelling Issues as Warnings",
-            "Report Spelling Issues as Information",
-            "Report Spelling Issues as Hints, will not show up in Problems",
-            "Do not Report Spelling Issues"
-          ],
-          "markdownDescription": "Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.\nThis affects the color of the squiggle.\n\nBy default, this setting will match `#cSpell.diagnosticLevel#`.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-          "scope": "resource",
-          "since": "4.0.0",
-          "title": "Set Diagnostic Reporting Level in SCM Commit Message",
           "type": "string"
         },
         "cSpell.hideAddToDictionaryCodeActions": {

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -1,5 +1,5 @@
 /**
- * Text Decoration Settings used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.
+ * Text Decoration Settings used to decorate spelling issues.
  */
 interface Decoration {
     /**
@@ -24,7 +24,7 @@ interface Decoration {
     overviewRulerColor?: string;
 
     /**
-     * The CSS Style used to decorate spelling issues. Depends upon `#cSpell.decorateIssues#`.
+     * The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.
      *
      * This setting is used to manually configure the text decoration. If it is not set, the following settings are used:
      * - `#cSpell.textDecorationLine#` to pick the line type
@@ -148,7 +148,7 @@ interface Decoration {
 }
 
 /**
- * Text Decoration Settings used to decorate spelling issues when `#cSpell.diagnosticLevel#` is `Hint`.
+ * Text Decoration Settings used to decorate spelling issues.
  */
 interface Appearance extends Decoration {
     /**
@@ -176,11 +176,24 @@ interface Appearance extends Decoration {
 
 export interface AppearanceSettings extends Appearance {
     /**
-     * Draw custom decorations on Spelling Issues when the `#cSpell.diagnosticLevel#` is `Hint`.
+     * Draw custom decorations on Spelling Issues.
      *
      * @scope machine
      * @since 4.0.0
      * @default true
      */
-    decorateIssues?: boolean;
+    useCustomDecorations?: boolean;
+
+    /**
+     * Use the VS Code Diagnostic Collection to render spelling issues.
+     *
+     * With some edit boxes, like the source control message box, the custom decorations do not show up.
+     * This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.
+     *
+     * @title Use VS Code to Render Spelling Issues
+     * @scope machine
+     * @since 4.0.0
+     * @default { "vscode-scm": true }
+     */
+    doNotUseCustomDecorationForScheme?: Record<string, boolean>;
 }

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -5,7 +5,26 @@ import type { CustomDictionaries, CustomDictionaryEntry } from './CustomDictiona
 import type { SpellCheckerShouldCheckDocSettings } from './SpellCheckerShouldCheckDocSettings.mjs';
 
 export type DiagnosticLevel = 'Error' | 'Warning' | 'Information' | 'Hint';
+
+/**
+ * Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.
+ * This affects the color of the squiggle.
+ *
+ * By default, this setting will match `#cSpell.diagnosticLevel#`.
+ *
+ * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
+ * @title Set Diagnostic Reporting Level
+ * @since 4.0.0
+ * @enumDescriptions [
+ *  "Report Spelling Issues as Errors",
+ *  "Report Spelling Issues as Warnings",
+ *  "Report Spelling Issues as Information",
+ *  "Report Spelling Issues as Hints, will not show up in Problems"
+ *  "Do not Report Spelling Issues"]
+ */
 export type DiagnosticLevelExt = 'Error' | 'Warning' | 'Information' | 'Hint' | 'Off';
+
+export type UseVSCodeDiagnosticSeverity = Record<string, DiagnosticLevelExt>;
 
 export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings, SpellCheckerBehaviorSettings, AppearanceSettings {
     /**
@@ -28,21 +47,20 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
 
     /**
      * The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.
-     * Set the level to `Hint` or `Off` to hide the issues from the Problems Pane. Use the `#cSpell.decorateIssues#`
+     * Set the level to `Hint` to hide the issues from the Problems Pane. Use the `#cSpell.useCustomDecorations#`
      * to control how issues are displayed in the document.
      *
      * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
      * @title Set Diagnostic Reporting Level
      * @scope resource
-     * @default "Hint"
+     * @default "Information"
      * @enumDescriptions [
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
      *  "Report Spelling Issues as Information",
-     *  "Report Spelling Issues as Hints, will not show up in Problems",
-     *  "Do not Report Spelling Issues"]
+     *  "Report Spelling Issues as Hints, will not show up in Problems"]
      */
-    diagnosticLevel?: DiagnosticLevelExt;
+    diagnosticLevel?: DiagnosticLevel;
 
     /**
      * Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.
@@ -56,29 +74,9 @@ export interface SpellCheckerSettings extends SpellCheckerShouldCheckDocSettings
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
      *  "Report Spelling Issues as Information",
-     *  "Report Spelling Issues as Hints, will not show up in Problems",
-     *  "Do not Report Spelling Issues"]
+     *  "Report Spelling Issues as Hints, will not show up in Problems"]
      */
-    diagnosticLevelFlaggedWords?: DiagnosticLevelExt;
-
-    /**
-     * Diagnostic level for source control _commit_ messages. Issues found by the spell checker are marked with a Diagnostic Severity Level.
-     * This affects the color of the squiggle.
-     *
-     * By default, this setting will match `#cSpell.diagnosticLevel#`.
-     *
-     * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
-     * @title Set Diagnostic Reporting Level in SCM Commit Message
-     * @scope resource
-     * @since 4.0.0
-     * @enumDescriptions [
-     *  "Report Spelling Issues as Errors",
-     *  "Report Spelling Issues as Warnings",
-     *  "Report Spelling Issues as Information",
-     *  "Report Spelling Issues as Hints, will not show up in Problems",
-     *  "Do not Report Spelling Issues"]
-     */
-    diagnosticLevelSCM?: DiagnosticLevelExt;
+    diagnosticLevelFlaggedWords?: DiagnosticLevel;
 
     /**
      * Control which file schemas will be checked for spelling (VS Code must be restarted for this setting to take effect).

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -159,7 +159,6 @@ type _VSConfigReporting = Pick<
     | 'autoFormatConfigFile'
     | 'diagnosticLevel'
     | 'diagnosticLevelFlaggedWords'
-    | 'diagnosticLevelSCM'
     | 'hideAddToDictionaryCodeActions'
     | 'maxDuplicateProblems'
     | 'maxNumberOfProblems'

--- a/packages/_server/src/config/docUriHelper.mts
+++ b/packages/_server/src/config/docUriHelper.mts
@@ -73,8 +73,14 @@ function getHandler(uri: Uri): SpecialHandlingFunction {
 }
 
 export function isScmUri(uri: Uri | string): boolean {
+    return usesScheme(uri, schemasWithSpecialHandling.vscodeScm);
+}
+
+export function usesScheme(uri: Uri | string, scheme: string): boolean {
+    const schemeColon = scheme.endsWith(':') ? scheme : scheme + ':';
+    scheme = scheme.endsWith(':') ? scheme.slice(0, -1) : scheme;
     if (typeof uri === 'string') {
-        return uri.startsWith(schemasWithSpecialHandling.vscodeScm + ':');
+        return uri.startsWith(schemeColon);
     }
-    return uri.scheme === schemasWithSpecialHandling.vscodeScm;
+    return uri.scheme === scheme;
 }

--- a/packages/_server/src/validator.mts
+++ b/packages/_server/src/validator.mts
@@ -5,7 +5,6 @@ import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import type { SpellCheckerDiagnosticData, SpellingDiagnostic, Suggestion } from './api.js';
 import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
-import { isScmUri } from './config/docUriHelper.mjs';
 import { diagnosticSource } from './constants.mjs';
 import { createDocumentValidator } from './DocumentValidationController.mjs';
 
@@ -61,17 +60,16 @@ function haveSuggestionsMatchCase(example: string, suggestions: Suggestion[] | u
     return suggestions.map((sug) => (TextUtil.isLowerCase(sug.word) ? { ...sug, word: TextUtil.matchCase(example, sug.word) } : sug));
 }
 
-type SeverityOptions = Pick<CSpellUserSettings, 'diagnosticLevel' | 'diagnosticLevelFlaggedWords' | 'diagnosticLevelSCM'>;
+type SeverityOptions = Pick<CSpellUserSettings, 'diagnosticLevel' | 'diagnosticLevelFlaggedWords'>;
 
 interface Severity {
     severity: DiagnosticSeverity | undefined;
     severityFlaggedWords: DiagnosticSeverity | undefined;
 }
 
-function calcSeverity(docUri: string, options: SeverityOptions): Severity {
-    const { diagnosticLevel = 'Information', diagnosticLevelFlaggedWords, diagnosticLevelSCM } = options;
-    const scmLevel = isScmUri(docUri) ? diagnosticLevelSCM : undefined;
-    const severity = diagSeverityMap.get((scmLevel || diagnosticLevel).toLowerCase());
-    const severityFlaggedWords = diagSeverityMap.get((scmLevel || diagnosticLevelFlaggedWords || diagnosticLevel).toLowerCase());
+function calcSeverity(_docUri: string, options: SeverityOptions): Severity {
+    const { diagnosticLevel = 'Information', diagnosticLevelFlaggedWords } = options;
+    const severity = diagSeverityMap.get(diagnosticLevel.toLowerCase());
+    const severityFlaggedWords = diagSeverityMap.get((diagnosticLevelFlaggedWords || diagnosticLevel).toLowerCase());
     return { severity, severityFlaggedWords };
 }

--- a/packages/client/src/extension.mts
+++ b/packages/client/src/extension.mts
@@ -14,11 +14,13 @@ import { createConfigWatcher } from './configWatcher.mjs';
 import { updateDocumentRelatedContext } from './context.mjs';
 import { SpellingExclusionsDecorator, SpellingIssueDecorator } from './decorate.mjs';
 import * as di from './di.mjs';
+import { registerDiagWatcher } from './diags.mjs';
 import type { ExtensionApi } from './extensionApi.mjs';
 import * as ExtensionRegEx from './extensionRegEx/index.mjs';
 import * as settingsViewer from './infoViewer/infoView.mjs';
 import { IssueTracker } from './issueTracker.mjs';
 import { activateFileIssuesViewer, activateIssueViewer } from './issueViewer/index.mjs';
+import { createLanguageStatus } from './languageStatus.mjs';
 import * as modules from './modules.mjs';
 import { createTerminal, registerTerminalProfileProvider } from './repl/index.mjs';
 import type { ConfigTargetLegacy, CSpellSettings } from './settings/index.mjs';
@@ -111,6 +113,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi>
         decorator,
         decoratorExclusions,
         registerSpellCheckerCodeActionProvider(issueTracker),
+        registerDiagWatcher(decorator.visible, decorator.onDidChangeVisibility),
         await registerTerminalProfileProvider(),
 
         ...commands.registerCommands(extensionCommand),
@@ -123,6 +126,7 @@ export async function activate(context: ExtensionContext): Promise<ExtensionApi>
          * adding a word to be ignored for the first time.
          */
         vscode.workspace.onDidChangeConfiguration(handleOnDidChangeConfiguration),
+        createLanguageStatus(),
     );
 
     await registerCspellInlineCompletionProviders(context.subscriptions).catch(() => undefined);

--- a/packages/client/src/languageStatus.mts
+++ b/packages/client/src/languageStatus.mts
@@ -1,0 +1,20 @@
+import { createDisposableList } from 'utils-disposables';
+import type { Disposable } from 'vscode';
+import vscode from 'vscode';
+
+const showLanguageStatus = false;
+
+export function createLanguageStatus(): Disposable {
+    const dList = createDisposableList();
+    if (!showLanguageStatus) return dList;
+
+    const item = vscode.languages.createLanguageStatusItem('cspell', { language: '*' });
+    item.text = '$(check) CSpell';
+    item.severity = vscode.LanguageStatusSeverity.Information;
+    // item.command = 'cspell.showOutput';
+    item.detail = '$(gear~spin) CSpell is **`active`**';
+
+    dList.push(item);
+
+    return dList;
+}

--- a/packages/client/src/quickMenu.mts
+++ b/packages/client/src/quickMenu.mts
@@ -1,0 +1,46 @@
+import { createDisposableList } from 'utils-disposables';
+import type { Disposable, QuickPickItem, Uri } from 'vscode';
+import vscode from 'vscode';
+
+export function registerQuickMenu(): Disposable {
+    const dList = createDisposableList();
+    dList.push(vscode.commands.registerCommand('cspell.quickMenu.show', quickPickMenu));
+    return dList;
+}
+
+export class MessageItem implements QuickPickItem {
+    label: string;
+    description = '';
+    detail: string;
+
+    constructor(
+        public base: Uri,
+        public message: string,
+    ) {
+        this.label = message.replace(/\r?\n/g, ' ');
+        this.detail = base.fsPath;
+    }
+}
+
+async function quickPickMenu() {
+    // const items: QuickPickItem[] = [
+    //     { label: 'Item 1', description: 'Description for Item 1' },
+    //     { label: 'Item 2', description: 'Description for Item 2' },
+    //     { label: 'Item 3', description: 'Description for Item 3' },
+    // ];
+    // const quickPick = vscode.window.createQuickPick<QuickPickItem>();
+    // quickPick.items = items;
+    // quickPick.onDidChangeSelection((selection) => {
+    //     console.log('onDidChangeSelection', selection);
+    // });
+    // quickPick.onDidChangeActive((active) => {
+    //     console.log('onDidChangeActive', active);
+    // });
+    // quickPick.onDidAccept(() => {
+    //     console.log('onDidAccept');
+    // });
+    // quickPick.onDidHide(() => {
+    //     console.log('onDidHide');
+    // });
+    // quickPick.show();
+}

--- a/packages/client/src/settings/configFields.mts
+++ b/packages/client/src/settings/configFields.mts
@@ -28,7 +28,6 @@ export const ConfigFields: CSpellUserSettingsFields = {
     customWorkspaceDictionaries: 'customWorkspaceDictionaries',
     diagnosticLevel: 'diagnosticLevel',
     diagnosticLevelFlaggedWords: 'diagnosticLevelFlaggedWords',
-    diagnosticLevelSCM: 'diagnosticLevelSCM',
     fixSpellingWithRenameProvider: 'fixSpellingWithRenameProvider',
     hideAddToDictionaryCodeActions: 'hideAddToDictionaryCodeActions',
     logLevel: 'logLevel',
@@ -56,7 +55,8 @@ export const ConfigFields: CSpellUserSettingsFields = {
     hideIssuesWhileTyping: 'hideIssuesWhileTyping',
     revealIssuesAfterDelayMS: 'revealIssuesAfterDelayMS',
     // Appearance
-    decorateIssues: 'decorateIssues',
+    useCustomDecorations: 'useCustomDecorations',
+    doNotUseCustomDecorationForScheme: 'doNotUseCustomDecorationForScheme',
     textDecoration: 'textDecoration',
     textDecorationLine: 'textDecorationLine',
     textDecorationStyle: 'textDecorationStyle',
@@ -67,6 +67,6 @@ export const ConfigFields: CSpellUserSettingsFields = {
     overviewRulerColor: 'overviewRulerColor',
     dark: 'dark',
     light: 'light',
-};
+} as const;
 
 // export const ConfigKeysNames = Object.values(ConfigKeysByField);

--- a/packages/client/src/statusbar.mts
+++ b/packages/client/src/statusbar.mts
@@ -108,8 +108,10 @@ export function initStatusBar(context: ExtensionContext, client: CSpellClient): 
             toolTip.appendMarkdown(`**\`\`\`\`${fileName}\`\`\`\`**\n`);
             !isChecked && toolTip.appendMarkdown(`- ${isCheckedText} spell checked.\n`);
             langReason && toolTip.appendMarkdown(`- ${langReason}\n`);
+            toolTip.appendMarkdown(`- Scheme: \`${response.uri.scheme}\`.\n`);
             fileReason && toolTip.appendMarkdown(`- ${fileReason}\n`);
             isChecked && toolTip.appendMarkdown(`- ${issuesText}\n`);
+            response.blockedReason && toolTip.appendMarkdown(`- ${response.blockedReason.message}\n`);
             toolTip.isTrusted = true;
             sbCheck.tooltip = toolTip;
             sbCheck.command = infoViewer.commandDisplayCSpellInfo;


### PR DESCRIPTION
- All issues are now collected on the client side.
- The client controls if issues are shown by VS Code or custom.
- It is possible to force VS Code rendering by scheme
- It is possible to toggle the spelling display by command.
- Rename `decorateIssues` to `useCustomDecorations`
- Remove `diagnosticLevelSCM` replaced with `doNotUseCustomDecorationForScheme`
- Added `doNotUseCustomDecorationForScheme` to control rendering by scheme.
