### PR TITLE
fix: REPL - remove `./` from rel path

### DIFF
--- a/packages/client/src/repl/formatPath.mts
+++ b/packages/client/src/repl/formatPath.mts
@@ -6,7 +6,7 @@ export function relative(uri: Uri | string): string {
     const rel = vscode.workspace.asRelativePath(uri, false);
     if (urlLike.test(rel)) return rel;
 
-    return './' + rel.split('\\').join('/');
+    return rel.split('\\').join('/');
 }
 
 export function formatPath(uri: Uri | string, width: number): string {


### PR DESCRIPTION
Remove the `./` prefix from the file path when reporting. This makes it possible to open links to files from within the REPL terminal.