### PR TITLE
fix: Make sure the disabled status is shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -3814,33 +3814,6 @@
             "title": "Hide Issues While Typing",
             "type": "string"
           },
-          "cSpell.languageStatusFields": {
-            "additionalProperties": false,
-            "default": {
-              "fileType": true,
-              "issues": true,
-              "scheme": true
-            },
-            "markdownDescription": "Select which fields to display in the language status bar.",
-            "properties": {
-              "fileType": {
-                "type": "boolean"
-              },
-              "issues": {
-                "type": "boolean"
-              },
-              "scheme": {
-                "type": "boolean"
-              }
-            },
-            "required": [
-              "fileType",
-              "scheme",
-              "issues"
-            ],
-            "scope": "application",
-            "type": "object"
-          },
           "cSpell.maxDuplicateProblems": {
             "default": 20,
             "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
@@ -3893,6 +3866,8 @@
           },
           "cSpell.showStatusAlignment": {
             "default": "Right",
+            "deprecated": true,
+            "deprecationMessage": "No longer supported.",
             "enum": [
               "Left",
               "Right"

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -3531,34 +3531,6 @@
           "title": "Hide Issues While Typing",
           "type": "string"
         },
-        "cSpell.languageStatusFields": {
-          "additionalProperties": false,
-          "default": {
-            "fileType": true,
-            "issues": true,
-            "scheme": true
-          },
-          "description": "Select which fields to display in the language status bar.",
-          "markdownDescription": "Select which fields to display in the language status bar.",
-          "properties": {
-            "fileType": {
-              "type": "boolean"
-            },
-            "issues": {
-              "type": "boolean"
-            },
-            "scheme": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "fileType",
-            "scheme",
-            "issues"
-          ],
-          "scope": "application",
-          "type": "object"
-        },
         "cSpell.maxDuplicateProblems": {
           "default": 20,
           "description": "The maximum number of times the same word can be flagged as an error in a file.",
@@ -3619,6 +3591,8 @@
         },
         "cSpell.showStatusAlignment": {
           "default": "Right",
+          "deprecated": true,
+          "deprecationMessage": "No longer supported.",
           "description": "The side of the status bar to display the spell checker status.",
           "enum": [
             "Left",

--- a/packages/_server/src/api/apiModels.ts
+++ b/packages/_server/src/api/apiModels.ts
@@ -52,6 +52,16 @@ export interface IsSpellCheckEnabledResult {
     workspaceFolderUri: UriString | undefined;
     languageIdEnabled: boolean | undefined;
     languageId: string | undefined;
+    /**
+     * Is the spell checker enabled for the file.
+     * If false, the file is excluded from spell checking.
+     * It might be disabled for multiple reasons.
+     */
+    enabled: boolean | undefined;
+    /**
+     * Is the spell checker enabled in VS Code.
+     */
+    enabledVSCode: boolean | undefined;
     fileEnabled: boolean;
     fileIsIncluded: boolean;
     fileIsExcluded: boolean;

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -118,15 +118,10 @@ export interface SpellCheckerSettings
      * @enumDescriptions [
      *  "Left Side of Statusbar",
      *  "Right Side of Statusbar"]
+     * @deprecated true
+     * @deprecationMessage No longer supported.
      */
     showStatusAlignment?: 'Left' | 'Right';
-
-    /**
-     * Select which fields to display in the language status bar.
-     * @scope application
-     * @default { "fileType": true, "scheme": true, "issues": true }
-     */
-    languageStatusFields?: LanguageStatusFields;
 
     /**
      * Show CSpell in-document directives as you type.
@@ -493,9 +488,3 @@ export interface AddToTargets extends AddToDictionaryTarget {
 }
 
 export type UnknownWordsReportingLevel = 'all' | 'simple' | 'none';
-
-export interface LanguageStatusFields {
-    fileType: boolean;
-    scheme: boolean;
-    issues: boolean;
-}

--- a/packages/_server/src/config/cspellConfig/configFields.mts
+++ b/packages/_server/src/config/cspellConfig/configFields.mts
@@ -32,7 +32,6 @@ export const ConfigFields: CSpellUserSettingsFields = {
     diagnosticLevelFlaggedWords: 'diagnosticLevelFlaggedWords',
     fixSpellingWithRenameProvider: 'fixSpellingWithRenameProvider',
     hideAddToDictionaryCodeActions: 'hideAddToDictionaryCodeActions',
-    languageStatusFields: 'languageStatusFields',
     logLevel: 'logLevel',
     logFile: 'logFile',
     maxDuplicateProblems: 'maxDuplicateProblems',

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -154,7 +154,6 @@ type _VSConfigReporting = Pick<
     | 'diagnosticLevel'
     | 'diagnosticLevelFlaggedWords'
     | 'hideAddToDictionaryCodeActions'
-    | 'languageStatusFields'
     | 'maxDuplicateProblems'
     | 'maxNumberOfProblems'
     | 'minWordLength'

--- a/packages/_server/src/config/documentSettings.mts
+++ b/packages/_server/src/config/documentSettings.mts
@@ -82,6 +82,10 @@ type GitignoreResultInfo = PromiseType<GitignoreResultP>;
 export interface ExcludeIncludeIgnoreInfo {
     /** The requested uri */
     uri: string;
+    /** True if the spell check is enabled */
+    enabled: boolean;
+    /** True if `cSpell.enabled` is `true | undefined` */
+    enabledVSCode: boolean;
     /** The uri used to calculate the response */
     uriUsed: string;
     /** Is included */
@@ -169,11 +173,15 @@ export class DocumentSettings {
     async calcIncludeExclude(uri: Uri): Promise<ExcludeIncludeIgnoreInfo> {
         const _uri = handleSpecialUri(uri, await this.getRootUri());
         const settings = await this.fetchSettingsForUri(_uri.toString());
+        const enabledVSCode = settings.vscodeSettings.cSpell?.enabled ?? true;
+        const enabled = settings.settings.enabled ?? enabledVSCode;
         const ie = calcIncludeExclude(settings, _uri);
         const ignoredEx = await this._isGitIgnoredEx(settings, _uri);
         const schemaAllowed = settings.settings.enabledSchemes?.[uri.scheme];
         return {
             ...ie,
+            enabled,
+            enabledVSCode,
             ignored: ignoredEx?.matched,
             gitignoreInfo: ignoredEx,
             uri: uri.toString(),

--- a/packages/_server/src/server.mts
+++ b/packages/_server/src/server.mts
@@ -554,6 +554,8 @@ export function run(): void {
         const languageIdEnabled = languageId ? isFileTypeEnabled(languageId, settings) : undefined;
 
         const {
+            enabled = true,
+            enabledVSCode = true,
             include: fileIsIncluded = true,
             exclude: fileIsExcluded = false,
             ignored: gitignored = undefined,
@@ -568,6 +570,8 @@ export function run(): void {
         const workspaceFolder = (uriUsed && (await documentSettings.matchingFoldersForUri(uriUsed))[0]) || undefined;
         log('calcIncludeExcludeInfo done', params.uri);
         return {
+            enabled,
+            enabledVSCode,
             uriUsed,
             workspaceFolderUri: workspaceFolder?.uri,
             excludedBy,

--- a/packages/_server/src/test/test.api.ts
+++ b/packages/_server/src/test/test.api.ts
@@ -38,6 +38,8 @@ export function createMockServerSideApi() {
 
 export function mockHandlers(): ServerSideHandlers {
     const sampleIsSpellCheckEnabledResult: IsSpellCheckEnabledResult = {
+        enabled: undefined,
+        enabledVSCode: undefined,
         uriUsed: undefined,
         workspaceFolderUri: undefined,
         languageIdEnabled: undefined,

--- a/packages/client/src/client/client.mts
+++ b/packages/client/src/client/client.mts
@@ -200,6 +200,8 @@ export class CSpellClient implements Disposable {
         const { uri, languageId } = document || {};
 
         const emptyResult: GetConfigurationForDocumentResult<ConfigurationFields> = {
+            enabled: undefined,
+            enabledVSCode: undefined,
             configFiles: [],
             configTargets: [],
             fileEnabled: false,

--- a/packages/client/src/client/server/server.mts
+++ b/packages/client/src/client/server/server.mts
@@ -42,7 +42,10 @@ export type {
 } from 'code-spell-checker-server/api';
 
 export type GetConfigurationForDocumentResult<F extends ConfigurationFields> = Partial<APIGetConfigurationForDocumentResult<F>> &
-    Pick<APIGetConfigurationForDocumentResult<F>, 'configFiles' | 'configTargets' | 'fileEnabled' | 'fileIsIncluded' | 'fileIsExcluded'>;
+    Pick<
+        APIGetConfigurationForDocumentResult<F>,
+        'enabled' | 'enabledVSCode' | 'configFiles' | 'configTargets' | 'fileEnabled' | 'fileIsIncluded' | 'fileIsExcluded'
+    >;
 
 interface ServerSide {
     getConfigurationForDocument: ClientSideApi['serverRequest']['getConfigurationForDocument'];

--- a/packages/client/src/infoViewer/infoHelper.mts
+++ b/packages/client/src/infoViewer/infoHelper.mts
@@ -175,6 +175,8 @@ function extractFileConfig(
     if (!doc) return undefined;
     const { uri, fileName, languageId, isUntitled } = doc;
     const {
+        enabled,
+        enabledVSCode,
         languageIdEnabled,
         docSettings,
         fileEnabled,
@@ -209,6 +211,8 @@ function extractFileConfig(
     }
 
     const cfg: FileConfig = {
+        enabled,
+        enabledVSCode,
         uri: uri.toString(),
         uriActual: uriToUse.toString(),
         fileName,

--- a/packages/client/src/languageStatus.mts
+++ b/packages/client/src/languageStatus.mts
@@ -46,8 +46,8 @@ export function createLanguageStatus(options: LanguageStatusOptions): Disposable
 
     function updateIssues(response: ServerResponseIsSpellCheckEnabledForFile | undefined) {
         const id = 'cspell-issues';
-        const { fileEnabled, languageIdEnabled, languageId = '' } = response || {};
-        const enabled = fileEnabled && languageIdEnabled;
+        const { enabled: checkEnabled, fileEnabled, languageIdEnabled, languageId = '' } = response || {};
+        const enabled = checkEnabled && fileEnabled && languageIdEnabled;
         const document = vscode.window.activeTextEditor?.document;
         const issues = document ? getIssueTracker().getSpellingIssues(document.uri) : undefined;
         const stats: Partial<IssuesStats> = issues?.getStats() || {};

--- a/packages/webview-api/src/models/settings.ts
+++ b/packages/webview-api/src/models/settings.ts
@@ -79,6 +79,10 @@ export interface BlockedFileReason {
 }
 
 export interface IsSpellCheckEnabledResult {
+    /** Is the spell checker enabled for file? */
+    enabled?: boolean | undefined;
+    /** cSpell.enabled setting */
+    enabledVSCode?: boolean | undefined;
     languageIdEnabled?: boolean | undefined;
     fileEnabled: boolean;
     fileIsIncluded: boolean;

--- a/packages/webview-ui/src/views/CSpellInfo.svelte
+++ b/packages/webview-ui/src/views/CSpellInfo.svelte
@@ -67,13 +67,15 @@
     const uriActual = fileConfig?.uriActual || fileConfig?.uri;
     const fileUrl = uriActual ? new URL(uriActual) : undefined;
     const blocked = fileConfig?.blockedReason;
-    const enabled = fileConfig?.fileEnabled && fileConfig?.languageIdEnabled && !fileConfig?.fileIsExcluded;
+    const enabled = fileConfig?.enabled && fileConfig?.fileEnabled && fileConfig?.languageIdEnabled && !fileConfig?.fileIsExcluded;
+    const enabledInVSCode = fileConfig?.enabled ?? true;
     const fileIsIncluded = fileConfig?.fileIsIncluded;
     const fileIsExcluded = fileConfig?.fileIsExcluded;
 
     info.push(
       { key: 'Name', value: name },
       { key: 'Enabled', value: (enabled === undefined && 'n/a') || (enabled && 'Yes') || 'No' },
+      enabledInVSCode ? undefined : { key: 'Enabled in VSCode', value: 'No, disabled in settings.' },
       (!fileIsIncluded && { key: 'In Files', value: 'No' }) || undefined,
       (fileIsExcluded && { key: 'Excluded', value: 'Yes' }) || undefined,
       // { key: 'Version', value: $currentDoc?.version ?? 'n/a' },


### PR DESCRIPTION
The spell checker incorrectly showed that the spell checker was enabled for a file when it actually was not.