### PR TITLE
fix: Log word replacements

### DIFF
--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -80,8 +80,8 @@ quotemark
 readonly
 restructuredtext
 rfdc
-rmwc
 RGBA
+rmwc
 RRGGBB
 RRGGBBAA
 scminput
@@ -92,6 +92,7 @@ sirv
 sourcemap
 squigglies
 streetsidesoftware
+stringifyable
 stylesheets
 subfolder
 subpath

--- a/packages/__utils/src/EventEmitter/index.mts
+++ b/packages/__utils/src/EventEmitter/index.mts
@@ -1,4 +1,4 @@
 export { createEmitter, isEventEmitter } from './createEmitter.mjs';
 export * from './operators/index.mjs';
 export { pipe } from './pipe.mjs';
-export type { EventEmitter } from './types.mjs';
+export type { EmitterEvent, EventEmitter, EventListener, EventOperator } from './types.mjs';

--- a/packages/__utils/src/EventEmitter/pipe.mts
+++ b/packages/__utils/src/EventEmitter/pipe.mts
@@ -1,22 +1,22 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
-import type { Event, EventListener, EventOperator } from './types.mjs';
+import type { EmitterEvent, EventListener, EventOperator } from './types.mjs';
 
-export type Subscribable<T> = Event<T> | { event: Event<T> };
+export type Subscribable<T> = EmitterEvent<T> | { event: EmitterEvent<T> };
 
-export function pipe<T>(subscribable: Subscribable<T>): Event<T>;
-export function pipe<T, U0>(subscribable: Subscribable<T>, op0: EventOperator<T, U0>): Event<U0>;
-export function pipe<T, U0, U1>(subscribable: Subscribable<T>, op0: EventOperator<T, U0>, op1: EventOperator<U0, U1>): Event<U1>;
+export function pipe<T>(subscribable: Subscribable<T>): EmitterEvent<T>;
+export function pipe<T, U0>(subscribable: Subscribable<T>, op0: EventOperator<T, U0>): EmitterEvent<U0>;
+export function pipe<T, U0, U1>(subscribable: Subscribable<T>, op0: EventOperator<T, U0>, op1: EventOperator<U0, U1>): EmitterEvent<U1>;
 export function pipe<T, U0, U1, U2>(
     subscribable: Subscribable<T>,
     op0: EventOperator<T, U0>,
     op1: EventOperator<U0, U1>,
     op2: EventOperator<U1, U2>,
-): Event<U2>;
-export function pipe<T>(subscribable: Subscribable<T>, ...ops: EventOperator<T, T>[]): Event<T>;
-export function pipe<T>(subscribable: Subscribable<T>, ...ops: EventOperator<T, T>[]): Event<T> {
+): EmitterEvent<U2>;
+export function pipe<T>(subscribable: Subscribable<T>, ...ops: EventOperator<T, T>[]): EmitterEvent<T>;
+export function pipe<T>(subscribable: Subscribable<T>, ...ops: EventOperator<T, T>[]): EmitterEvent<T> {
     const subscribeFn = 'event' in subscribable ? (fn: EventListener<T>) => subscribable.event(fn) : subscribable;
 
-    let finalEventFn: Event<T> | undefined;
+    let finalEventFn: EmitterEvent<T> | undefined;
 
     /**
      * Late binding of the final event function

--- a/packages/__utils/src/EventEmitter/types.mts
+++ b/packages/__utils/src/EventEmitter/types.mts
@@ -4,7 +4,7 @@ export interface Disposable {
 
 export type EventListener<T> = (data: T) => unknown;
 
-export type Event<T> = (listener: EventListener<T>) => Disposable;
+export type EmitterEvent<T> = (listener: EventListener<T>) => Disposable;
 
 export interface EventEmitter<T> {
     /**
@@ -15,7 +15,7 @@ export interface EventEmitter<T> {
     /**
      * The event listeners can subscribe to.
      */
-    event: Event<T>;
+    event: EmitterEvent<T>;
 
     /**
      * Notify all subscribers of the {@link EventEmitter.event event}. Failure
@@ -31,4 +31,4 @@ export interface EventEmitter<T> {
     dispose(): void;
 }
 
-export type EventOperator<T, U> = (source: Event<T>) => Event<U>;
+export type EventOperator<T, U> = (source: EmitterEvent<T>) => EmitterEvent<U>;

--- a/packages/client/src/applyCorrections.mts
+++ b/packages/client/src/applyCorrections.mts
@@ -296,6 +296,15 @@ async function calcWorkspaceEditsForDocument(doc: TextDocument, edits: TextEdit[
 }
 
 async function applyTextEditsToDocumentWithRename(doc: TextDocument, edits: TextEdit[], refInfo: UseRefInfo): Promise<boolean | undefined> {
+    const eventLogger = di.get('eventLogger');
+
+    for (const edit of edits) {
+        const word = doc.getText(edit.range);
+        if (word !== edit.newText && word && edit.newText) {
+            eventLogger.logReplace(word, edit.newText);
+        }
+    }
+
     const wsEdit = await calcWorkspaceEditsForDocument(doc, edits, refInfo);
     return applyWorkspaceEdit(wsEdit, 'applyTextEditsToDocumentWithRename');
 }

--- a/packages/client/src/decorators/decorateIssues.mts
+++ b/packages/client/src/decorators/decorateIssues.mts
@@ -5,11 +5,11 @@ import vscode, { ColorThemeKind, MarkdownString, Range, window, workspace } from
 
 import type { PartialCSpellUserSettings } from '../client/index.mjs';
 import { commandUri, createTextEditCommand } from '../commands.mjs';
-import { setContext } from '../context.mjs';
 import type { Disposable } from '../disposable.js';
 import type { IssueTracker, SpellingCheckerIssue } from '../issueTracker.mjs';
 import type { CSpellSettings } from '../settings/index.mjs';
 import { ConfigFields } from '../settings/index.mjs';
+import { setContext } from '../storage/context.mjs';
 import { findEditor } from '../util/findEditor.js';
 
 const defaultHideIssuesWhileTyping: Required<PartialCSpellUserSettings<'hideIssuesWhileTyping'>>['hideIssuesWhileTyping'] = 'Word';

--- a/packages/client/src/di.mts
+++ b/packages/client/src/di.mts
@@ -3,6 +3,7 @@ import type { ExtensionContext } from 'vscode';
 import type { CSpellClient } from './client/index.mjs';
 import type { IssueTracker } from './issueTracker.mjs';
 import type { DictionaryHelper } from './settings/DictionaryHelper.mjs';
+import type { EventLogger } from './storage/index.mjs';
 
 export interface GlobalDependencies {
     name: string;
@@ -10,6 +11,7 @@ export interface GlobalDependencies {
     client: CSpellClient;
     issueTracker: IssueTracker;
     dictionaryHelper: DictionaryHelper;
+    eventLogger: EventLogger;
 }
 
 type KeysForGlobalDependencies = {
@@ -22,6 +24,7 @@ const definedDependencyKeys: KeysForGlobalDependencies = {
     client: undefined,
     dictionaryHelper: undefined,
     issueTracker: undefined,
+    eventLogger: undefined,
 };
 
 type GlobalDependenciesKeys = keyof GlobalDependencies;

--- a/packages/client/src/statusbar/languageStatus.mts
+++ b/packages/client/src/statusbar/languageStatus.mts
@@ -3,11 +3,11 @@ import { createDisposableList } from 'utils-disposables';
 import type { Disposable } from 'vscode';
 import vscode from 'vscode';
 
-import type { ServerResponseIsSpellCheckEnabledForFile } from './client/client.mjs';
-import { knownCommands } from './commands.mjs';
-import { getClient, getIssueTracker } from './di.mjs';
-import type { IssuesStats } from './issueTracker.mjs';
-import { handleErrors } from './util/errors.js';
+import type { ServerResponseIsSpellCheckEnabledForFile } from '../client/client.mjs';
+import { knownCommands } from '../commands.mjs';
+import { getClient, getIssueTracker } from '../di.mjs';
+import type { IssuesStats } from '../issueTracker.mjs';
+import { handleErrors } from '../util/errors.js';
 
 const showLanguageStatus = true;
 

--- a/packages/client/src/storage/EventLog.mts
+++ b/packages/client/src/storage/EventLog.mts
@@ -1,0 +1,43 @@
+export type MachineId = string;
+export type Timestamp = number;
+
+export type Events = 'replace' | 'activate';
+
+/**
+ * A log entry.
+ * - ts - The timestamp of the event.
+ * - range - The timestamp of the end of the event range. (this is used to group events).
+ * - event - The event that occurred.
+ * - count - The number of times the event occurred. (this is used to group events).
+ * - args - Additional arguments for the event.
+ */
+export type LogEntryBase = [ts: Timestamp, range: Timestamp | 0, event: string, count: number, ...args: unknown[]];
+
+/** Replace a word with a suggestion. */
+export type LogEntryReplace = [ts: Timestamp, range: Timestamp | 0, 'replace', count: number, word: string, suggestion: string];
+
+/** Indicates that the extension was activated. */
+export type LogEntryActivate = [ts: Timestamp, range: Timestamp | 0, 'activate', count: number];
+
+export type LogEntry = LogEntryReplace | LogEntryActivate;
+
+export interface EventLog {
+    /**
+     * The log of events that have occurred.
+     */
+    log: LogEntryBase[];
+
+    /**
+     * The synchronization timestamp of each machine.
+     * The timestamp is the timestamp of the last event added to the log for a given machine id.
+     */
+    sync: Record<MachineId, Timestamp>;
+}
+
+export function isLogEntryReplace(entry: LogEntryBase): entry is LogEntryReplace {
+    return entry[2] === 'replace';
+}
+
+export function isLogEntryActivate(entry: LogEntryBase): entry is LogEntryActivate {
+    return entry[2] === 'activate';
+}

--- a/packages/client/src/storage/EventLogger.mts
+++ b/packages/client/src/storage/EventLogger.mts
@@ -1,0 +1,97 @@
+import type { Disposable } from 'vscode';
+import { env, Uri } from 'vscode';
+
+import { logErrors } from '../util/errors.js';
+import type { LogEntry, LogEntryBase } from './EventLog.mjs';
+import { MementoFile } from './mementoFile.mjs';
+
+export interface EventLogger {
+    readonly eventLog: readonly LogEntryBase[];
+    log(event: LogEntry): void;
+    logActivate(): void;
+    logReplace(word: string, suggestion: string): void;
+    flush(): Promise<void>;
+}
+
+export function createReplaceEvent(word: string, suggestion: string): LogEntry {
+    return [Date.now(), 0, 'replace', 1, word, suggestion];
+}
+
+export function createActivateEvent(): LogEntry {
+    return [Date.now(), 0, 'activate', 1];
+}
+
+interface LocalEventLogData {
+    machineId: string;
+    ts: number;
+    log: LogEntry[];
+}
+
+class EventLoggerImpl implements EventLogger, Disposable {
+    #data: MementoFile<LocalEventLogData> | undefined;
+    #pData: Promise<MementoFile<LocalEventLogData>>;
+    #pending: LogEntry[] = [];
+    #pFlush: Promise<void> | undefined = undefined;
+    #timeout: NodeJS.Timeout | undefined = undefined;
+
+    constructor(readonly uriStorageDir: Uri) {
+        this.#pData = MementoFile.createMemento<LocalEventLogData>(Uri.joinPath(uriStorageDir, 'eventLog.json'));
+        this.#pData.then((data) => (this.#data = data));
+    }
+
+    log(event: LogEntry): void {
+        this.#pending.push(event);
+        this.queueFlush();
+    }
+
+    logActivate(): void {
+        this.log(createActivateEvent());
+    }
+
+    logReplace(word: string, suggestion: string): void {
+        this.log(createReplaceEvent(word, suggestion));
+    }
+
+    get eventLog(): readonly LogEntryBase[] {
+        if (!this.#data) return [];
+        return this.#data.get('log', []);
+    }
+
+    queueFlush(): void {
+        if (this.#timeout) return;
+        this.#timeout = setTimeout(() => {
+            this.#timeout = undefined;
+            logErrors(this.flush(), 'EventLogger.flush');
+        }, 10);
+    }
+
+    flush(): Promise<void> {
+        const doFlush = async () => {
+            if (!this.#pending.length) return;
+            const memo = this.#data ?? (await this.#pData);
+            const machineId = memo.get('machineId', env.machineId);
+            const ts = Date.now();
+            const log = [...memo.get('log', []), ...this.#pending];
+            this.#pending = [];
+            await memo.update({ machineId, ts, log });
+        };
+        const pFlush = this.#pFlush ? this.#pFlush.then(doFlush) : doFlush();
+        this.#pFlush = pFlush;
+        pFlush.finally(() => {
+            if (this.#pFlush === pFlush) this.#pFlush = undefined;
+        });
+        return pFlush;
+    }
+
+    dispose(): void {
+        if (this.#data) {
+            this.#data.dispose();
+        } else {
+            this.#pData.then((data) => data.dispose());
+        }
+    }
+}
+
+export function createEventLogger(uriStorageDir: Uri): EventLogger {
+    return new EventLoggerImpl(uriStorageDir);
+}

--- a/packages/client/src/storage/context.mts
+++ b/packages/client/src/storage/context.mts
@@ -3,10 +3,10 @@ import assert from 'node:assert';
 import type { TextDocument } from 'vscode';
 import { commands, workspace } from 'vscode';
 
-import type { ConfigKind, ConfigScope, ConfigTarget, CSpellClient } from './client/index.mjs';
-import { extensionId } from './constants.js';
-import { getCSpellDiags } from './diags.mjs';
-import { toUri } from './util/uriHelper.mjs';
+import type { ConfigKind, ConfigScope, ConfigTarget, CSpellClient } from '../client/index.mjs';
+import { extensionId } from '../constants.js';
+import { getCSpellDiags } from '../diags.mjs';
+import { toUri } from '../util/uriHelper.mjs';
 
 const prefix = extensionId;
 

--- a/packages/client/src/storage/globalState.mts
+++ b/packages/client/src/storage/globalState.mts
@@ -1,0 +1,24 @@
+import type { EventLog, Timestamp } from './EventLog.mjs';
+import type { Memento } from './memento.mjs';
+
+export interface GlobalStateData {
+    eventLog: EventLog;
+}
+
+export interface GlobalStateControl extends Memento<GlobalStateData> {
+    /**
+     * List of fields that are synced across machines.
+     */
+    readonly syncFields: string[];
+
+    /**
+     * This field is used to store the signature of last time the global state was updated on this machine.
+     * It is used to detect changes to the global state.
+     */
+    readonly signature: string;
+
+    /**
+     * The timestamp of the last time the global state was updated on this machine.
+     */
+    readonly ts: Timestamp;
+}

--- a/packages/client/src/storage/index.mts
+++ b/packages/client/src/storage/index.mts
@@ -1,0 +1,4 @@
+export type { ContextTypes } from './context.mjs';
+export { setContext, updateDocumentRelatedContext } from './context.mjs';
+export type { EventLogger } from './EventLogger.mjs';
+export { createActivateEvent, createEventLogger, createReplaceEvent } from './EventLogger.mjs';

--- a/packages/client/src/storage/memento.mts
+++ b/packages/client/src/storage/memento.mts
@@ -1,0 +1,61 @@
+import type { EmitterEvent } from '@internal/common-utils';
+
+/**
+ * A memento represents a storage utility. It can store and retrieve
+ * values.
+ */
+export interface Memento<T> {
+    /**
+     * Returns the stored keys.
+     *
+     * @returns The stored keys.
+     */
+    keys(): readonly (keyof T)[];
+
+    /**
+     * Return a value.
+     *
+     * @param key A string.
+     * @returns The stored value or `undefined`.
+     */
+    get<K extends keyof T>(key: K): T[K] | undefined;
+
+    /**
+     * Return a value.
+     *
+     * @param key A string.
+     * @param defaultValue A value that should be returned when there is no
+     * value (`undefined`) with the given key.
+     * @returns The stored value or the defaultValue.
+     */
+    get<K extends keyof T>(key: K, defaultValue: T[K]): T[K];
+
+    /**
+     * Store a value. The value must be JSON-stringifyable.
+     *
+     * *Note* that using `undefined` as value removes the key from the underlying
+     * storage.
+     *
+     * @param key A string.
+     * @param value A value. MUST not contain cyclic references.
+     */
+    update<K extends keyof T>(key: K, value: T[K] | undefined): Promise<void>;
+
+    /**
+     * Store values. The values must be JSON-stringifyable.
+     * @param data Partial data to update.
+     */
+    update(data: Partial<T>): Promise<void>;
+
+    /**
+     * Add a listener to be called when the memento has changed.
+     * If the memento has changed, the listener will be called with an array of keys that have changed.
+     * If the backing storage has been updated, the listener will be called with `undefined`.
+     */
+    onDidChange: EmitterEvent<readonly (keyof T)[] | undefined>;
+
+    /**
+     * Dispose of the memento.
+     */
+    dispose?(): void;
+}

--- a/packages/client/src/storage/mementoFile.mts
+++ b/packages/client/src/storage/mementoFile.mts
@@ -1,0 +1,139 @@
+import assert from 'node:assert';
+
+import type { EmitterEvent, EventEmitter, EventListener } from '@internal/common-utils';
+import { createEmitter } from '@internal/common-utils';
+import type { Disposable, FileSystemWatcher } from 'vscode';
+import { RelativePattern, Uri, workspace } from 'vscode';
+
+import type { Memento } from './memento.mjs';
+
+interface MementoFileData<T> {
+    id: 'memento';
+    /** the file format version */
+    v: 'v1';
+    /** the timestamp */
+    ts: number;
+    /** a signature used to check changes. */
+    signature: string;
+    data: T;
+}
+
+export class MementoFile<T> implements Memento<T>, Disposable {
+    #data: T | undefined;
+    #emitter: EventEmitter<readonly (keyof T)[] | undefined>;
+    /**
+     * The signature of the memento. It is changed when the memento is updated.
+     * It is used to check if the memento has changed.
+     */
+    #signature: string | undefined;
+    #watcher: FileSystemWatcher;
+
+    constructor(
+        readonly uri: Uri,
+        data: MementoFileData<T> | undefined,
+    ) {
+        this.#data = data?.data;
+        this.#signature = data?.signature;
+        assert(!data || data.id === 'memento', 'Invalid memento data');
+        this.#emitter = createEmitter();
+        this.#watcher = watchFile(uri, this.#handleFileChange.bind(this));
+    }
+
+    keys(): readonly (keyof T)[] {
+        return this.#data ? (Object.keys(this.#data) as (keyof T)[]) : [];
+    }
+
+    get<K extends keyof T>(key: K): T[K] | undefined;
+    get<K extends keyof T>(key: K, defaultValue: T[K]): T[K];
+    get<K extends keyof T>(key: K, defaultValue?: T[K]): T[K] | undefined {
+        return (this.#data ? this.#data[key] : undefined) ?? defaultValue;
+    }
+
+    async update<K extends keyof T>(key: K, value: T[K] | undefined): Promise<void>;
+    async update(data: Partial<T>): Promise<void>;
+    async update<K extends keyof T>(keyOrData: K | Partial<T>, value?: T[K] | undefined): Promise<void> {
+        const keys: (keyof T)[] = [];
+        if (typeof keyOrData === 'string') {
+            const key: K = keyOrData;
+            this.#data = this.#data ?? ({} as T);
+            if (value === undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete this.#data[key];
+            } else {
+                this.#data[key] = value;
+            }
+            keys.push(key);
+        } else {
+            const data = keyOrData as Partial<T>;
+            keys.push(...(Object.keys(data) as K[]));
+            this.#data = { ...this.#data, ...data } as T;
+        }
+        this.#signature = `s${performance.now()}/${performance.now()}`;
+        await MementoFile.#save(this.uri, {
+            id: 'memento',
+            v: 'v1',
+            ts: Date.now(),
+            signature: this.#signature,
+            data: this.#data,
+        });
+        this.#emitter.fire(keys);
+    }
+
+    onDidChange(listener: EventListener<readonly (keyof T)[] | undefined>): ReturnType<EmitterEvent<unknown>> {
+        return this.#emitter.event(listener);
+    }
+
+    dispose = () => {
+        this.#watcher.dispose();
+    };
+
+    #handleFileChange(uri: Uri) {
+        assert(uri.toString() === this.uri.toString(), 'Invalid file change');
+        this.#loadData().catch(() => undefined);
+    }
+
+    async #loadData() {
+        const data = await MementoFile.#load<T>(this.uri);
+        if (!data) {
+            this.#data = undefined;
+            return;
+        }
+        if (data.signature === this.#signature) return;
+
+        this.#data = data.data;
+        this.#signature = data.signature;
+        this.#emitter.fire(undefined);
+    }
+
+    static async #save<T>(uri: Uri, data: MementoFileData<T>): Promise<void> {
+        const content = JSON.stringify(data, null, 2);
+        await workspace.fs.createDirectory(Uri.joinPath(uri, '..'));
+        await workspace.fs.writeFile(uri, Buffer.from(content));
+    }
+
+    static async #load<T>(uri: Uri): Promise<MementoFileData<T> | undefined> {
+        try {
+            const buffer = await workspace.fs.readFile(uri);
+            const dc = new TextDecoder();
+            const content = dc.decode(buffer);
+            return JSON.parse(content);
+        } catch {
+            return undefined;
+        }
+    }
+
+    static async createMemento<T>(uri: Uri): Promise<MementoFile<T>> {
+        const data = await MementoFile.#load<T>(uri);
+        return new MementoFile<T>(uri, data);
+    }
+}
+
+function watchFile(uri: Uri, listener: (uri: Uri) => void): FileSystemWatcher {
+    const dir = Uri.joinPath(uri, '..');
+    const base = uri.path.split('/').slice(-1).join('');
+    const watcher = workspace.createFileSystemWatcher(new RelativePattern(dir, base));
+    watcher.onDidChange(listener);
+    watcher.onDidCreate(listener);
+    watcher.onDidDelete(listener);
+    return watcher;
+}

--- a/packages/client/src/storage/mementoMem.mts
+++ b/packages/client/src/storage/mementoMem.mts
@@ -1,0 +1,49 @@
+import type { EmitterEvent, EventEmitter, EventListener } from '@internal/common-utils';
+import { createEmitter } from '@internal/common-utils';
+
+import type { Memento } from './memento.mjs';
+
+export class MementoMem<T> implements Memento<T> {
+    #data: T | undefined;
+    #emitter: EventEmitter<readonly (keyof T)[] | undefined>;
+    constructor(data?: T | undefined) {
+        this.#data = data;
+        this.#emitter = createEmitter();
+    }
+
+    keys(): readonly (keyof T)[] {
+        return this.#data ? (Object.keys(this.#data) as (keyof T)[]) : [];
+    }
+
+    get<K extends keyof T>(key: K): T[K] | undefined;
+    get<K extends keyof T>(key: K, defaultValue: T[K]): T[K];
+    get<K extends keyof T>(key: K, defaultValue?: T[K]): T[K] | undefined {
+        return (this.#data ? this.#data[key] : undefined) ?? defaultValue;
+    }
+
+    async update<K extends keyof T>(key: K, value: T[K] | undefined): Promise<void>;
+    async update(data: Partial<T>): Promise<void>;
+    async update<K extends keyof T>(keyOrData: K | Partial<T>, value?: T[K] | undefined): Promise<void> {
+        const keys: (keyof T)[] = [];
+        if (typeof keyOrData === 'string') {
+            const key: K = keyOrData;
+            this.#data = this.#data ?? ({} as T);
+            if (value === undefined) {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete this.#data[key];
+            } else {
+                this.#data[key] = value;
+            }
+            keys.push(key);
+        } else {
+            const data = keyOrData as Partial<T>;
+            keys.push(...(Object.keys(data) as K[]));
+            this.#data = { ...this.#data, ...data } as T;
+        }
+        this.#emitter.fire(keys);
+    }
+
+    onDidChange(listener: EventListener<readonly (keyof T)[] | undefined>): ReturnType<EmitterEvent<unknown>> {
+        return this.#emitter.event(listener);
+    }
+}

--- a/packages/client/src/storage/storage.mts
+++ b/packages/client/src/storage/storage.mts
@@ -1,0 +1,5 @@
+import type { ExtensionContext } from 'vscode';
+
+export class Storage {
+    constructor(readonly extensionContext: ExtensionContext) {}
+}


### PR DESCRIPTION
To improve the user experience, we want to start logging word replacements.

The idea is to move more recently used words to the top of the list.

This PR only logs the event. The code to apply the logic will come later.
