### PR TITLE
Fix the yaml language ID in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ Note, the settings in `cspell.json` will override the equivalent cSpell settings
         "plaintext",
         "typescript",
         "typescriptreact",
-        "yml",
+        "yaml",
         "sql"
     ],
 


### PR DESCRIPTION
"yml" appears to be an invalid ID since https://github.com/streetsidesoftware/vscode-spell-checker/commit/e169d6412c63afc2012c47f44418924c9d65e5f9

Hope it's alright 👌