### PR TITLE
fix: add al to default enabledLanguageIds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1945,6 +1945,7 @@
               "type": "boolean"
             },
             "default": {
+              "al": true,
               "asciidoc": true,
               "bat": true,
               "c": true,

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1411,6 +1411,7 @@
             "type": "boolean"
           },
           "default": {
+            "al": true,
             "asciidoc": true,
             "bat": true,
             "c": true,

--- a/packages/_server/src/config/cspellConfig/FileTypesAndSchemeSettings.mts
+++ b/packages/_server/src/config/cspellConfig/FileTypesAndSchemeSettings.mts
@@ -89,7 +89,7 @@ export interface FileTypesAndSchemeSettings {
      *
      * @title Enabled File Types to Check
      * @scope resource
-     * @default { "asciidoc": true, "bat": true, "c": true, "clojure": true, "coffeescript": true, "cpp": true, "csharp": true, "css": true,
+     * @default { "al": true, "asciidoc": true, "bat": true, "c": true, "clojure": true, "coffeescript": true, "cpp": true, "csharp": true, "css": true,
      *      "dart": true, "diff": true, "dockerfile": true, "elixir": true, "erlang": true, "fsharp": true, "git-commit": true,
      *      "git-rebase": true, "github-actions-workflow": true, "go": true, "graphql": true, "groovy": true, "handlebars": true,
      *      "haskell": true, "html": true, "ini": true, "jade": true, "java": true, "javascript": true, "javascriptreact": true,

--- a/packages/client/src/settings/languageIds.ts
+++ b/packages/client/src/settings/languageIds.ts
@@ -1,4 +1,5 @@
 export const languageIds: string[] = [
+    'al',
     'asciidoc',
     'bat',
     'c',

--- a/website/docs/configuration/auto_files-folders-and-workspaces.md
+++ b/website/docs/configuration/auto_files-folders-and-workspaces.md
@@ -167,7 +167,7 @@ Default
 
 ```json5
 {
-"asciidoc": true, "bat": true, "c": true, "clojure": true, "coffeescript":
+"al": true, "asciidoc": true, "bat": true, "c": true, "clojure": true, "coffeescript":
 true, "cpp": true, "csharp": true, "css": true, "dart": true, "diff": true,
 "dockerfile": true, "elixir": true, "erlang": true, "fsharp": true,
 "git-commit": true, "git-rebase": true, "github-actions-workflow": true, "go":


### PR DESCRIPTION
This is an attempt to fix #2409, following the example changes from pull request: #2133.

Now, the `al` language has been added to the list of enabledLanguageIds. 

 