### PR TITLE
Adjust default color and style for spelling error decorations

### DIFF
--- a/package.json
+++ b/package.json
@@ -3062,7 +3062,7 @@
                 "type": "string"
               },
               "textDecorationColor": {
-                "default": "#fc4",
+                "default": "#348feb",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
                 "since": "4.0.0",
@@ -3095,7 +3095,7 @@
                 "type": "string"
               },
               "textDecorationStyle": {
-                "default": "wavy",
+                "default": "dotted",
                 "enum": [
                   "solid",
                   "wavy",
@@ -3151,7 +3151,7 @@
                 "type": "string"
               },
               "textDecorationColor": {
-                "default": "#fc4",
+                "default": "#348feb",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
                 "since": "4.0.0",
@@ -3184,7 +3184,7 @@
                 "type": "string"
               },
               "textDecorationStyle": {
-                "default": "wavy",
+                "default": "dotted",
                 "enum": [
                   "solid",
                   "wavy",
@@ -3223,7 +3223,7 @@
             "type": "string"
           },
           "cSpell.textDecorationColor": {
-            "default": "#fc4",
+            "default": "#348feb",
             "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
             "scope": "application",
             "since": "4.0.0",
@@ -3256,7 +3256,7 @@
             "type": "string"
           },
           "cSpell.textDecorationStyle": {
-            "default": "wavy",
+            "default": "dotted",
             "enum": [
               "solid",
               "wavy",

--- a/package.json
+++ b/package.json
@@ -3095,7 +3095,7 @@
                 "type": "string"
               },
               "textDecorationStyle": {
-                "default": "dotted",
+                "default": "wavy",
                 "enum": [
                   "solid",
                   "wavy",
@@ -3184,7 +3184,7 @@
                 "type": "string"
               },
               "textDecorationStyle": {
-                "default": "dotted",
+                "default": "wavy",
                 "enum": [
                   "solid",
                   "wavy",
@@ -3256,7 +3256,7 @@
             "type": "string"
           },
           "cSpell.textDecorationStyle": {
-            "default": "dotted",
+            "default": "wavy",
             "enum": [
               "solid",
               "wavy",
@@ -3277,7 +3277,7 @@
             "type": "string"
           },
           "cSpell.useCustomDecorations": {
-            "default": true,
+            "default": false,
             "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.",
             "scope": "application",
             "since": "4.0.0",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -2688,7 +2688,7 @@
               "type": "string"
             },
             "textDecorationStyle": {
-              "default": "dotted",
+              "default": "wavy",
               "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "enum": [
                 "solid",
@@ -2787,7 +2787,7 @@
               "type": "string"
             },
             "textDecorationStyle": {
-              "default": "dotted",
+              "default": "wavy",
               "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "enum": [
                 "solid",
@@ -2867,7 +2867,7 @@
           "type": "string"
         },
         "cSpell.textDecorationStyle": {
-          "default": "dotted",
+          "default": "wavy",
           "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
           "enum": [
             "solid",
@@ -2890,7 +2890,7 @@
           "type": "string"
         },
         "cSpell.useCustomDecorations": {
-          "default": true,
+          "default": false,
           "description": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.",
           "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.",
           "scope": "application",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -2651,7 +2651,7 @@
               "type": "string"
             },
             "textDecorationColor": {
-              "default": "#fc4",
+              "default": "#348feb",
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
@@ -2688,7 +2688,7 @@
               "type": "string"
             },
             "textDecorationStyle": {
-              "default": "wavy",
+              "default": "dotted",
               "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "enum": [
                 "solid",
@@ -2750,7 +2750,7 @@
               "type": "string"
             },
             "textDecorationColor": {
-              "default": "#fc4",
+              "default": "#348feb",
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
@@ -2787,7 +2787,7 @@
               "type": "string"
             },
             "textDecorationStyle": {
-              "default": "wavy",
+              "default": "dotted",
               "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "enum": [
                 "solid",
@@ -2830,7 +2830,7 @@
           "type": "string"
         },
         "cSpell.textDecorationColor": {
-          "default": "#fc4",
+          "default": "#348feb",
           "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "scope": "application",
@@ -2867,7 +2867,7 @@
           "type": "string"
         },
         "cSpell.textDecorationStyle": {
-          "default": "wavy",
+          "default": "dotted",
           "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
           "enum": [
             "solid",

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -71,7 +71,7 @@ interface Decoration {
      *
      * @scope application
      * @since 4.0.0
-     * @default "wavy"
+     * @default "dotted"
      */
     textDecorationStyle?: 'solid' | 'wavy' | 'dotted' | 'dashed' | 'double';
 
@@ -107,7 +107,7 @@ interface Decoration {
      *
      * @scope application
      * @since 4.0.0
-     * @default "#fc4"
+     * @default "#348feb"
      */
     textDecorationColor?: string;
 

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -71,7 +71,7 @@ interface Decoration {
      *
      * @scope application
      * @since 4.0.0
-     * @default "dotted"
+     * @default "wavy"
      */
     textDecorationStyle?: 'solid' | 'wavy' | 'dotted' | 'dashed' | 'double';
 
@@ -183,7 +183,7 @@ export interface AppearanceSettings extends Appearance {
      *
      * @scope application
      * @since 4.0.0
-     * @default true
+     * @default false
      */
     useCustomDecorations?: boolean;
 


### PR DESCRIPTION
The transition to custom decorations has led to feedback that the yellow squiggly is too intrusive and can be mistaken for actual code diagnostics (#3798).

Proposing less intrusive defaults that are similar to the prior appearance and also leverage the new "dotted" appearance to clearly distinguish this from other diagnostics.  These values should look fine in either light or dark mode.

Light mode example:
![image](https://github.com/user-attachments/assets/f3aa2ce5-f012-4762-9515-f5e8725acd85)

Dark mode example:
![image](https://github.com/user-attachments/assets/c3938a3b-f6b6-4855-9dc7-363a9e59f6cc)

