### PR TITLE
fix: Support vscode-notebook-cell in containers

### DIFF
--- a/packages/_server/src/config/docUriHelper.mts
+++ b/packages/_server/src/config/docUriHelper.mts
@@ -26,10 +26,8 @@ export function handleSpecialUri(uri: Uri, rootUri: Uri): Uri {
 export function forceToFileUri(uri: Uri, rootUri: Uri): Uri {
     if (uri.scheme === 'file') return uri;
 
-    return uri.with({
-        scheme: rootUri.scheme,
-        query: '',
-        fragment: '',
+    return rootUri.with({
+        path: uri.path,
     });
 }
 

--- a/packages/client/src/storage/mementoFile.mts
+++ b/packages/client/src/storage/mementoFile.mts
@@ -90,7 +90,9 @@ export class MementoFile<T> implements Memento<T>, Disposable {
     #handleFileChange(uri: Uri) {
         const a = uri.path;
         const b = this.uri.path;
-        assert(a === b, `Invalid file change: ${a} !== ${b}`);
+        if (a !== b) {
+            console.error(`Invalid file change: '${a}' !== '${b}'`);
+        }
         this.#loadData().catch(() => undefined);
     }
 


### PR DESCRIPTION
Change the way vscode-notebook-cell scheme is converted to a file scheme.

fixes #3787
fixes #3819