### PR TITLE
fix: Make sure VS Code files are not spell checked

### DIFF
--- a/package.json
+++ b/package.json
@@ -640,6 +640,12 @@
         "category": "Spell",
         "title": "Rate the Spell Checker",
         "icon": "$(star)"
+      },
+      {
+        "command": "cSpell.openSettings",
+        "category": "Spell",
+        "title": "Open Spell Checker Settings",
+        "icon": "$(gear)"
       }
     ],
     "languages": [
@@ -1922,6 +1928,12 @@
             "markdownDescription": "By default, the spell checker checks only enabled file types. Use `#cSpell.enableFiletypes#`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`.\nSee `#cSpell.enableFiletypes#` on how to disable a file type.",
             "scope": "resource",
             "title": "Check Only Enabled File Types",
+            "type": "boolean"
+          },
+          "cSpell.checkVSCodeSystemFiles": {
+            "default": false,
+            "markdownDescription": "Spell check VS Code system files.\nThese include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+            "scope": "application",
             "type": "boolean"
           },
           "cSpell.enableFiletypes": {

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1389,6 +1389,13 @@
           "title": "Check Only Enabled File Types",
           "type": "boolean"
         },
+        "cSpell.checkVSCodeSystemFiles": {
+          "default": false,
+          "description": "Spell check VS Code system files. These include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+          "markdownDescription": "Spell check VS Code system files.\nThese include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+          "scope": "application",
+          "type": "boolean"
+        },
         "cSpell.enableFiletypes": {
           "deprecated": true,
           "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",

--- a/packages/_server/src/DocumentValidationController.mts
+++ b/packages/_server/src/DocumentValidationController.mts
@@ -4,14 +4,14 @@ import type { TextDocumentChangeEvent, TextDocuments } from 'vscode-languageserv
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import type { TextDocumentInfoWithText, TextDocumentRef } from './api.js';
-import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './config/cspellConfig/index.mjs';
 import type { DocumentSettings } from './config/documentSettings.mjs';
 import { defaultCheckLimit } from './constants.mjs';
 import { breakTextAtLimit } from './utils/breakTextAtLimit.mjs';
 
 interface DocValEntry {
     uri: string;
-    settings: Promise<CSpellUserSettings>;
+    settings: Promise<CSpellUserAndExtensionSettings>;
     docVal: Promise<DocumentValidator>;
 }
 
@@ -97,7 +97,7 @@ export class DocumentValidationController {
 
 export async function createDocumentValidator(
     textDocument: TextDocument | TextDocumentInfoWithText,
-    pSettings: Promise<CSpellUserSettings> | CSpellUserSettings,
+    pSettings: Promise<CSpellUserAndExtensionSettings> | CSpellUserAndExtensionSettings,
 ): Promise<DocumentValidator> {
     const settings = await pSettings;
     const limit = (settings.checkLimit || defaultCheckLimit) * 1024;

--- a/packages/_server/src/SuggestionsGenerator.mts
+++ b/packages/_server/src/SuggestionsGenerator.mts
@@ -1,7 +1,7 @@
 import { CompoundWordsMethod, type SpellingDictionaryCollection, type SuggestionResult, type SuggestOptions } from 'cspell-lib';
 
 import type { Suggestion } from './api.js';
-import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './config/cspellConfig/index.mjs';
 
 const defaultNumSuggestions = 10;
 
@@ -13,7 +13,7 @@ export const maxNumberOfSuggestionsForLongWords = 1;
 const maxEdits = 3;
 
 export interface GetSettingsResult {
-    settings: CSpellUserSettings;
+    settings: CSpellUserAndExtensionSettings;
     dictionary: SpellingDictionaryCollection;
 }
 

--- a/packages/_server/src/api/apiModels.ts
+++ b/packages/_server/src/api/apiModels.ts
@@ -1,7 +1,7 @@
 import type { PublishDiagnosticsParams } from 'vscode-languageserver';
 
 import type { ConfigScopeVScode, ConfigTarget } from '../config/configTargets.mjs';
-import type { CSpellUserSettings } from '../config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from '../config/cspellConfig/index.mjs';
 import type { CheckDocumentIssue } from './models/Diagnostic.mjs';
 import type { Suggestion } from './models/Suggestion.mjs';
 import type { ExtensionId } from './models/types.mjs';
@@ -92,14 +92,16 @@ export interface GetSpellCheckingOffsetsResult {
     offsets: number[];
 }
 
-export type ConfigurationFields = keyof CSpellUserSettings;
+export type ConfigurationFields = keyof CSpellUserAndExtensionSettings;
 export type ConfigFieldSelector<T extends ConfigurationFields> = Readonly<Record<T, true>>;
 
 export type AllowUndefined<T> = {
     [P in keyof T]: T[P] | undefined;
 };
 
-export type PartialCSpellUserSettings<T extends ConfigurationFields> = Pick<CSpellUserSettings, T> & { _fields?: ConfigFieldSelector<T> };
+export type PartialCSpellUserSettings<T extends ConfigurationFields> = Pick<CSpellUserAndExtensionSettings, T> & {
+    _fields?: ConfigFieldSelector<T>;
+};
 
 export interface GetConfigurationForDocumentRequest<Fields extends ConfigurationFields> extends Partial<TextDocumentInfo> {
     /** used to calculate configTargets, configTargets will be empty if undefined. */
@@ -234,7 +236,7 @@ export type FieldExistsInTarget = Partial<Record<ConfigurationTarget, boolean>>;
 export type ConfigurationTarget = ConfigScopeVScode;
 
 export type {
-    CSpellUserSettings,
+    CSpellUserAndExtensionSettings as CSpellUserSettings,
     CustomDictionaries,
     CustomDictionary,
     CustomDictionaryEntry,
@@ -248,7 +250,7 @@ export type {
     SpellCheckerSettingsProperties,
 } from '../config/cspellConfig/index.mjs';
 
-export type VSCodeSettingsCspell = Partial<Record<ExtensionId, CSpellUserSettings>>;
+export type VSCodeSettingsCspell = Partial<Record<ExtensionId, CSpellUserAndExtensionSettings>>;
 
 export type PublishDiagnostics = Required<PublishDiagnosticsParams>;
 

--- a/packages/_server/src/codeActions.mts
+++ b/packages/_server/src/codeActions.mts
@@ -14,7 +14,7 @@ import { clientCommands as cc } from './commands.mjs';
 import type { ConfigScope, ConfigTarget, ConfigTargetCSpell, ConfigTargetDictionary, ConfigTargetVSCode } from './config/configTargets.mjs';
 import { ConfigKinds, ConfigScopes } from './config/configTargets.mjs';
 import { calculateConfigTargets } from './config/configTargetsHelper.mjs';
-import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './config/cspellConfig/index.mjs';
 import { isUriAllowedBySettings } from './config/documentSettings.mjs';
 import type { GetSettingsResult } from './SuggestionsGenerator.mjs';
 import { SuggestionGenerator } from './SuggestionsGenerator.mjs';
@@ -37,7 +37,7 @@ function extractDiagnosticData(diag: Diagnostic): SpellCheckerDiagnosticData {
 }
 
 export interface CodeActionHandlerDependencies {
-    fetchSettings: (doc: TextDocument) => Promise<CSpellUserSettings>;
+    fetchSettings: (doc: TextDocument) => Promise<CSpellUserAndExtensionSettings>;
     getSettingsVersion: (doc: TextDocument) => number;
     fetchWorkspaceConfigForDocument: (uri: UriString) => Promise<WorkspaceConfigForDocument>;
 }

--- a/packages/_server/src/config/WorkspacePathResolver.test.mts
+++ b/packages/_server/src/config/WorkspacePathResolver.test.mts
@@ -7,7 +7,7 @@ import { describe, expect, type Mock, test, vi } from 'vitest';
 import type { WorkspaceFolder } from 'vscode-languageserver/node.js';
 import { URI as Uri } from 'vscode-uri';
 
-import type { CSpellUserSettings, CustomDictionaries } from './cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings, CustomDictionaries } from './cspellConfig/index.mjs';
 import { normalizeWindowsRoot, normalizeWindowsUrl, toDirURL, uriToGlobRoot } from './urlUtil.mjs';
 import { createWorkspaceNamesResolver, debugExports, resolveSettings } from './WorkspacePathResolver.mjs';
 
@@ -17,7 +17,7 @@ vi.mock('@internal/common-utils/log');
 
 const mockLogError = logError as Mock;
 
-const cspellConfigInVsCode: CSpellUserSettings = {
+const cspellConfigInVsCode: CSpellUserAndExtensionSettings = {
     ignorePaths: ['${workspaceFolder:_server}/**/*.json'],
     import: [
         '${workspaceFolder:_server}/sampleSourceFiles/overrides/cspell.json',
@@ -26,7 +26,7 @@ const cspellConfigInVsCode: CSpellUserSettings = {
     enabledLanguageIds: ['typescript', 'javascript', 'php', 'json', 'jsonc'],
 };
 
-const cspellConfigCustomUserDictionary: CSpellUserSettings = {
+const cspellConfigCustomUserDictionary: CSpellUserAndExtensionSettings = {
     customUserDictionaries: [
         {
             name: 'Global Dictionary',
@@ -36,7 +36,7 @@ const cspellConfigCustomUserDictionary: CSpellUserSettings = {
     ],
 };
 
-const cspellConfigCustomWorkspaceDictionary: CSpellUserSettings = {
+const cspellConfigCustomWorkspaceDictionary: CSpellUserAndExtensionSettings = {
     customWorkspaceDictionaries: [
         {
             name: 'Workspace Dictionary',
@@ -50,7 +50,7 @@ const cspellConfigCustomWorkspaceDictionary: CSpellUserSettings = {
     ],
 };
 
-const cspellConfigCustomFolderDictionary: CSpellUserSettings = {
+const cspellConfigCustomFolderDictionary: CSpellUserAndExtensionSettings = {
     customFolderDictionaries: [
         {
             name: 'Folder Dictionary',
@@ -121,7 +121,7 @@ describe('Validate workspace substitution resolver', () => {
 
     const workspaces: WorkspaceFolder[] = [workspaceFolders.root, workspaceFolders.client, workspaceFolders.server, workspaceFolders.test];
 
-    const settingsImports: CSpellUserSettings = Object.freeze({
+    const settingsImports: CSpellUserAndExtensionSettings = Object.freeze({
         import: [
             'cspell.json',
             '${workspaceFolder}/cspell.json',
@@ -133,7 +133,7 @@ describe('Validate workspace substitution resolver', () => {
         ],
     });
 
-    const settingsIgnorePaths: CSpellUserSettings = Object.freeze({
+    const settingsIgnorePaths: CSpellUserAndExtensionSettings = Object.freeze({
         ignorePaths: [
             '**/node_modules/**',
             '${workspaceFolder}/node_modules/**',
@@ -146,7 +146,7 @@ describe('Validate workspace substitution resolver', () => {
         ],
     });
 
-    const settingsDictionaryDefinitions: CSpellUserSettings = Object.freeze({
+    const settingsDictionaryDefinitions: CSpellUserAndExtensionSettings = Object.freeze({
         dictionaryDefinitions: [
             {
                 name: 'My Dictionary',
@@ -163,7 +163,7 @@ describe('Validate workspace substitution resolver', () => {
         ].map((f) => Object.freeze(f)),
     });
 
-    const settingsDictionaryDefinitions2: CSpellUserSettings = Object.freeze({
+    const settingsDictionaryDefinitions2: CSpellUserAndExtensionSettings = Object.freeze({
         dictionaryDefinitions: (settingsDictionaryDefinitions.dictionaryDefinitions || [])
             .concat([
                 {
@@ -183,7 +183,7 @@ describe('Validate workspace substitution resolver', () => {
             .map((f) => Object.freeze(f)),
     });
 
-    const settingsLanguageSettings: CSpellUserSettings = Object.freeze({
+    const settingsLanguageSettings: CSpellUserAndExtensionSettings = Object.freeze({
         languageSettings: [
             {
                 languageId: 'typescript',
@@ -192,7 +192,7 @@ describe('Validate workspace substitution resolver', () => {
         ].map((f) => Object.freeze(f)),
     });
 
-    const overrides: CSpellUserSettings['overrides'] = [
+    const overrides: CSpellUserAndExtensionSettings['overrides'] = [
         {
             filename: ['*.md', '**/*.ts', '**/*.js'],
             languageSettings: settingsLanguageSettings.languageSettings,
@@ -225,7 +225,7 @@ describe('Validate workspace substitution resolver', () => {
         html: false,
     } as const;
 
-    const settingsOverride: CSpellUserSettings = {
+    const settingsOverride: CSpellUserAndExtensionSettings = {
         overrides: overrides.map((f) => Object.freeze(f)),
     };
 
@@ -280,7 +280,7 @@ describe('Validate workspace substitution resolver', () => {
     `('resolveSettings files $files $globRoot', ({ files, globRoot, expected }) => {
         const root = '/config root';
         const resolver = createWorkspaceNamesResolver(workspaceFolders.client, workspaces, root);
-        const settings: CSpellUserSettings = { globRoot, files };
+        const settings: CSpellUserAndExtensionSettings = { globRoot, files };
         const result = resolveSettings(settings, resolver);
         expect(result.files).toEqual(expected);
     });
@@ -357,7 +357,7 @@ describe('Validate workspace substitution resolver', () => {
     });
 
     test('resolve custom dictionaries', () => {
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             ...cspellConfigInVsCode,
             ...settingsDictionaryDefinitions2,
             ...cspellConfigCustomFolderDictionary,
@@ -421,7 +421,7 @@ describe('Validate workspace substitution resolver', () => {
     });
 
     test('resolve custom dictionaries by name', () => {
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             ...cspellConfigInVsCode,
             ...settingsDictionaryDefinitions,
             customWorkspaceDictionaries: ['Project Dictionary'],
@@ -451,7 +451,7 @@ describe('Validate workspace substitution resolver', () => {
 
     test('Unresolved workspaceFolder', () => {
         mockLogError.mockReset();
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             ...cspellConfigInVsCode,
             ...settingsDictionaryDefinitions,
             customWorkspaceDictionaries: [{ name: 'Unknown Dictionary' }],

--- a/packages/_server/src/config/configTargetsHelper.mts
+++ b/packages/_server/src/config/configTargetsHelper.mts
@@ -12,12 +12,12 @@ import type {
     ConfigTargetVSCode,
 } from './configTargets.mjs';
 import { ConfigKinds, ConfigScopes, weight } from './configTargets.mjs';
-import type { CSpellUserSettings } from './cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
 import type { CSpellSettingsWithFileSource } from './documentSettings.mjs';
 import { extractCSpellFileConfigurations, extractTargetDictionaries, filterExistingCSpellFileConfigurations } from './documentSettings.mjs';
 
 export async function calculateConfigTargets(
-    settings: CSpellUserSettings,
+    settings: CSpellUserAndExtensionSettings,
     workspaceConfig: WorkspaceConfigForDocument,
     configFilesFound?: string[],
 ): Promise<ConfigTarget[]> {

--- a/packages/_server/src/config/cspellConfig.test.mts
+++ b/packages/_server/src/config/cspellConfig.test.mts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import type {
     AllSpellCheckerSettingsInVSCode,
     AllSpellCheckerSettingsInVSCodeWithPrefix,
-    CSpellUserSettings,
+    CSpellUserAndExtensionSettings,
     SpellCheckerSettingsVSCode,
 } from './cspellConfig/index.mjs';
 
@@ -87,7 +87,7 @@ describe('cspellConfig', () => {
         // The idea is to use features of the configuration and make sure it compiles.
         expect(sampleSettings).toBeDefined();
 
-        const moreSettings: CSpellUserSettings[] = sampleSettings;
+        const moreSettings: CSpellUserAndExtensionSettings[] = sampleSettings;
 
         expect(moreSettings).toBeDefined();
 

--- a/packages/_server/src/config/cspellConfig/SpellCheckerShouldCheckDocSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerShouldCheckDocSettings.mts
@@ -55,4 +55,14 @@ export interface SpellCheckerShouldCheckDocSettings {
      * @default 80
      */
     blockCheckingWhenAverageChunkSizeGreaterThan?: number;
+
+    /**
+     * Spell check VS Code system files.
+     * These include:
+     * - `vscode-userdata:/**​/settings.json`
+     * - `vscode-userdata:/**​/keybindings.json`
+     * @scope application
+     * @default false
+     */
+    checkVSCodeSystemFiles?: boolean;
 }

--- a/packages/_server/src/config/cspellConfig/SpellCheckerShouldCheckDocSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerShouldCheckDocSettings.mts
@@ -1,3 +1,4 @@
+/* eslint-disable no-irregular-whitespace */
 export interface SpellCheckerShouldCheckDocSettings {
     /**
      * The maximum line length.

--- a/packages/_server/src/config/cspellConfig/configFields.mts
+++ b/packages/_server/src/config/cspellConfig/configFields.mts
@@ -1,11 +1,11 @@
 import { ConfigFields as CSpellConfigFields } from '@cspell/cspell-types';
 
-import type { CSpellUserSettings } from './cspellConfig.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig.mjs';
 
 export { ConfigFields as CSpellConfigFields } from '@cspell/cspell-types';
 
 export type ConfigKeys = Exclude<
-    keyof CSpellUserSettings,
+    keyof CSpellUserAndExtensionSettings,
     '$schema' | 'version' | 'id' | 'experimental.enableRegexpView' | 'experimental.enableSettingsViewerV2'
 >;
 
@@ -24,6 +24,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     blockCheckingWhenTextChunkSizeGreaterThan: 'blockCheckingWhenTextChunkSizeGreaterThan',
     checkLimit: 'checkLimit',
     checkOnlyEnabledFileTypes: 'checkOnlyEnabledFileTypes',
+    checkVSCodeSystemFiles: 'checkVSCodeSystemFiles',
     customDictionaries: 'customDictionaries',
     customFolderDictionaries: 'customFolderDictionaries',
     customUserDictionaries: 'customUserDictionaries',

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -17,10 +17,10 @@ import type {
 
 type InternalSettings = object;
 
-export interface CSpellUserSettings extends SpellCheckerSettings, CSpellSettingsPackageProperties, InternalSettings {}
+export interface CSpellUserAndExtensionSettings extends SpellCheckerSettings, CSpellSettingsPackageProperties, InternalSettings {}
 
 export type SpellCheckerSettingsProperties = keyof SpellCheckerSettings;
-export type SpellCheckerSettingsVSCodePropertyKeys = `cspell.${keyof CSpellUserSettings}`;
+export type SpellCheckerSettingsVSCodePropertyKeys = `cspell.${keyof CSpellUserAndExtensionSettings}`;
 
 interface DictionaryDefinitions {
     /**
@@ -108,7 +108,7 @@ type CSpellOmitFieldsFromExtensionContributesInPackageJson =
 
 export interface SpellCheckerSettingsVSCodeBase
     extends Omit<
-            CSpellUserSettings,
+            CSpellUserAndExtensionSettings,
             CSpellOmitFieldsFromExtensionContributesInPackageJson | keyof DictionaryDefinitions | keyof LanguageSettings | keyof Overrides
         >,
         DictionaryDefinitions,
@@ -221,6 +221,7 @@ type _VSConfigFilesAndFolders = Pick<
     SpellCheckerSettingsVSCodeBase,
     | 'allowedSchemas'
     | 'checkOnlyEnabledFileTypes'
+    | 'checkVSCodeSystemFiles'
     | 'enableFiletypes'
     | 'files'
     | 'globRoot'

--- a/packages/_server/src/config/cspellConfig/cspellMergeFields.mts
+++ b/packages/_server/src/config/cspellConfig/cspellMergeFields.mts
@@ -1,4 +1,4 @@
-import type { CSpellUserSettings } from './cspellConfig.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig.mjs';
 import type { CSpellMergeFields, CSpellMergeFieldsKeys } from './CSpellSettingsPackageProperties.mjs';
 
 export const cspellMergeFields: Required<CSpellMergeFields> = {
@@ -46,10 +46,10 @@ const fields = Object.keys(cspellMergeFields) as CSpellMergeFieldsKeys[];
  * @returns filtered settings
  */
 export function filterMergeFields(
-    settings: Readonly<CSpellUserSettings>,
-    mergeCSpellSettings: CSpellUserSettings['mergeCSpellSettings'],
-    mergeCSpellSettingsFields: CSpellUserSettings['mergeCSpellSettingsFields'],
-): CSpellUserSettings {
+    settings: Readonly<CSpellUserAndExtensionSettings>,
+    mergeCSpellSettings: CSpellUserAndExtensionSettings['mergeCSpellSettings'],
+    mergeCSpellSettingsFields: CSpellUserAndExtensionSettings['mergeCSpellSettingsFields'],
+): CSpellUserAndExtensionSettings {
     mergeCSpellSettings ??= false;
     if (mergeCSpellSettings === true && !mergeCSpellSettingsFields) return settings;
     const copy = { ...settings };

--- a/packages/_server/src/config/cspellConfig/index.mts
+++ b/packages/_server/src/config/cspellConfig/index.mts
@@ -2,7 +2,7 @@ export { ConfigFields } from './configFields.mjs';
 export type {
     AllSpellCheckerSettingsInVSCode,
     AllSpellCheckerSettingsInVSCodeWithPrefix,
-    CSpellUserSettings,
+    CSpellUserAndExtensionSettings,
     SpellCheckerSettingsProperties,
     SpellCheckerSettingsVSCode,
     SpellCheckerSettingsVSCodeBase,

--- a/packages/_server/src/config/customDictionaries.mts
+++ b/packages/_server/src/config/customDictionaries.mts
@@ -1,7 +1,12 @@
 import { isDefined } from '@internal/common-utils/util';
 import type { DictionaryDefinitionCustom, DictionaryDefinitionInline, DictionaryDefinitionPreferred } from 'cspell-lib';
 
-import type { CSpellUserSettings, CustomDictionaries, CustomDictionaryEntry, DictionaryDefinition } from './cspellConfig/index.mjs';
+import type {
+    CSpellUserAndExtensionSettings,
+    CustomDictionaries,
+    CustomDictionaryEntry,
+    DictionaryDefinition,
+} from './cspellConfig/index.mjs';
 
 export function mapCustomDictionaryEntryToCustomDictionaries(
     entries: CustomDictionaryEntry[] | undefined,
@@ -16,7 +21,7 @@ export function mapCustomDictionaryEntryToCustomDictionaries(
     return customDict;
 }
 
-export function extractCustomDictionaries(settings: CSpellUserSettings): CustomDictionaries {
+export function extractCustomDictionaries(settings: CSpellUserAndExtensionSettings): CustomDictionaries {
     const dicts = Object.assign(
         {} as CustomDictionaries,
         mapCustomDictionaryEntryToCustomDictionaries(settings.customUserDictionaries, 'user'),
@@ -27,7 +32,7 @@ export function extractCustomDictionaries(settings: CSpellUserSettings): CustomD
     return dicts;
 }
 
-export function extractDictionaryDefinitions(settings: CSpellUserSettings): NormalizedDictionaryDefinition[] {
+export function extractDictionaryDefinitions(settings: CSpellUserAndExtensionSettings): NormalizedDictionaryDefinition[] {
     const customDicts = extractCustomDictionaries(settings);
 
     const dicts = new Map(
@@ -61,7 +66,7 @@ export function extractDictionaryDefinitions(settings: CSpellUserSettings): Norm
     return [...dicts.values()];
 }
 
-export function extractDictionaryList(settings: CSpellUserSettings): string[] {
+export function extractDictionaryList(settings: CSpellUserAndExtensionSettings): string[] {
     const customDicts = extractCustomDictionaries(settings);
     const dicts = (settings.dictionaries || []).concat(extractNamesFromCustomDictionaries(customDicts));
     return dicts;

--- a/packages/_server/src/config/customDictionaries.test.mts
+++ b/packages/_server/src/config/customDictionaries.test.mts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
-import type { CSpellUserSettings, CustomDictionaries, CustomDictionariesDictionary, DictionaryDefinition } from './cspellConfig/index.mjs';
+import type {
+    CSpellUserAndExtensionSettings,
+    CustomDictionaries,
+    CustomDictionariesDictionary,
+    DictionaryDefinition,
+} from './cspellConfig/index.mjs';
 import { extractDictionaryDefinitions } from './customDictionaries.mjs';
 
 describe('customDictionaries', () => {
@@ -20,7 +25,7 @@ describe('customDictionaries', () => {
         ${cd('my-terms', { name: 'company-terms', noSuggest: true })} | ${dictionaryDefinitions.map((d) => ({ ...d, noSuggest: true }))}
         ${cd('company-terms', { path: 'new/path', addWords: true })}  | ${[{ name: 'company-terms', path: 'new/path', addWords: true }]}
     `('extractDictionaryDefinitions $customDictionaries', ({ customDictionaries, expected }) => {
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             dictionaryDefinitions,
             customDictionaries,
         };

--- a/packages/_server/src/config/documentSettings.test.mts
+++ b/packages/_server/src/config/documentSettings.test.mts
@@ -8,7 +8,7 @@ import { URI as Uri } from 'vscode-uri';
 
 import { createMockServerSideApi } from '../test/test.api.js';
 import { extendExpect } from '../test/test.matchers.js';
-import type { CSpellUserSettings } from './cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
 import type { ExcludedByMatch } from './documentSettings.mjs';
 import {
     __testing__,
@@ -45,7 +45,7 @@ const workspaceFolderClient: WorkspaceFolder = {
     name: 'client',
 };
 
-const cspellConfigInVsCode: CSpellUserSettings = {
+const cspellConfigInVsCode: CSpellUserAndExtensionSettings = {
     name: 'Mock VS Code Config',
     ignorePaths: ['${workspaceFolder:_server}/**/*.json'],
     import: [
@@ -194,7 +194,7 @@ describe('Validate DocumentSettings', () => {
     });
 
     test('applyEnableFiletypes', () => {
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             enabledLanguageIds: ['typescript', 'markdown', 'plaintext', 'json'],
             enableFiletypes: ['!json', '!!!javascript'],
             enabledFileTypes: { typescript: true, plaintext: false, FreeFormFortran: true, json: true },
@@ -451,7 +451,7 @@ describe('Validate DocumentSettings', () => {
         expect(result.map((f) => f.toString().toLowerCase())).toEqual(expected.map((u) => filePathToUri(u).toString().toLowerCase()));
     });
 
-    function newDocumentSettings(defaultSettings: CSpellUserSettings = {}) {
+    function newDocumentSettings(defaultSettings: CSpellUserAndExtensionSettings = {}) {
         const connection = createMockConnection();
         const mockWorkspaceGetConfiguration = vi.mocked(connection.workspace.getConfiguration);
         mockWorkspaceGetConfiguration.mockImplementation(implGetConfiguration);
@@ -496,7 +496,7 @@ describe('Validate RegExp corrections', () => {
         // Make sure it doesn't change the defaults.
         expect(correctBadSettings(defaultSettings)).toEqual(defaultSettings);
 
-        const settings: CSpellUserSettings = {
+        const settings: CSpellUserAndExtensionSettings = {
             patterns: [
                 {
                     name: 'strings',
@@ -504,7 +504,7 @@ describe('Validate RegExp corrections', () => {
                 },
             ],
         };
-        const expectedSettings: CSpellUserSettings = {
+        const expectedSettings: CSpellUserAndExtensionSettings = {
             patterns: [
                 {
                     name: 'strings',

--- a/packages/_server/src/config/extractEnabledFileTypes.mts
+++ b/packages/_server/src/config/extractEnabledFileTypes.mts
@@ -1,5 +1,5 @@
 import type { EnabledFileTypes, EnabledSchemes } from './cspellConfig/FileTypesAndSchemeSettings.mjs';
-import type { CSpellUserSettings } from './cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
 
 const schemeBlockList: EnabledSchemes = {
     git: false, // blocked by default
@@ -21,7 +21,7 @@ const defaultAllowedSchemes: EnabledSchemes = {
 
 const defaultCheckOnlyEnabledFileTypes = true;
 
-function reduceExtractEnabledSchemes(schemes: EnabledSchemes, settings: CSpellUserSettings): EnabledSchemes {
+function reduceExtractEnabledSchemes(schemes: EnabledSchemes, settings: CSpellUserAndExtensionSettings): EnabledSchemes {
     if (settings.allowedSchemas) {
         const changes = Object.fromEntries(settings.allowedSchemas.map((schema) => [schema, true]));
         schemes = { ...schemes, ...changes };
@@ -33,7 +33,7 @@ function reduceExtractEnabledSchemes(schemes: EnabledSchemes, settings: CSpellUs
     return schemes;
 }
 
-export function extractEnabledSchemes(...settings: CSpellUserSettings[]): EnabledSchemes {
+export function extractEnabledSchemes(...settings: CSpellUserAndExtensionSettings[]): EnabledSchemes {
     const schemes: Record<string, boolean> = {
         ...defaultAllowedSchemes,
     };
@@ -41,14 +41,17 @@ export function extractEnabledSchemes(...settings: CSpellUserSettings[]): Enable
     return settings.reduce(reduceExtractEnabledSchemes, schemes);
 }
 
-export function extractEnabledSchemeList(...settings: CSpellUserSettings[]): string[] {
+export function extractEnabledSchemeList(...settings: CSpellUserAndExtensionSettings[]): string[] {
     const schemes = extractEnabledSchemes(...settings);
     return Object.entries(schemes)
         .filter(([, enabled]) => enabled)
         .map(([schema]) => schema);
 }
 
-export function applyEnabledSchemes(settings: CSpellUserSettings, enabledSchemes: EnabledSchemes = {}): CSpellUserSettings {
+export function applyEnabledSchemes(
+    settings: CSpellUserAndExtensionSettings,
+    enabledSchemes: EnabledSchemes = {},
+): CSpellUserAndExtensionSettings {
     enabledSchemes = extractEnabledSchemes(settings, enabledSchemes);
     const { allowedSchemas: _, ...rest } = settings;
     return { ...rest, enabledSchemes };
@@ -67,22 +70,28 @@ function reduceEnabledFileTypes(filetypes: EnabledFileTypes, changes: EnabledFil
     return changes ? { ...filetypes, ...changes } : filetypes;
 }
 
-function reduceEnabledFileTypesInSettings(filetypes: EnabledFileTypes, settings: CSpellUserSettings): EnabledFileTypes {
+function reduceEnabledFileTypesInSettings(filetypes: EnabledFileTypes, settings: CSpellUserAndExtensionSettings): EnabledFileTypes {
     filetypes = reduceLangIdsToEnabledFileTypes(filetypes, settings.enabledLanguageIds);
     filetypes = reduceLangIdsToEnabledFileTypes(filetypes, settings.enableFiletypes);
     filetypes = reduceEnabledFileTypes(filetypes, settings.enabledFileTypes);
     return filetypes;
 }
 
-export function extractEnabledFileTypes(settings: CSpellUserSettings, enabledFileTypes: EnabledFileTypes = {}): EnabledFileTypes {
+export function extractEnabledFileTypes(
+    settings: CSpellUserAndExtensionSettings,
+    enabledFileTypes: EnabledFileTypes = {},
+): EnabledFileTypes {
     return reduceEnabledFileTypesInSettings(enabledFileTypes, settings);
 }
 
-export function extractKnownFileTypeIds(settings: CSpellUserSettings): string[] {
+export function extractKnownFileTypeIds(settings: CSpellUserAndExtensionSettings): string[] {
     return Object.keys(extractEnabledFileTypes(settings)).sort();
 }
 
-export function applyEnabledFileTypes(settings: CSpellUserSettings, enabledFileTypes: EnabledFileTypes = {}): CSpellUserSettings {
+export function applyEnabledFileTypes(
+    settings: CSpellUserAndExtensionSettings,
+    enabledFileTypes: EnabledFileTypes = {},
+): CSpellUserAndExtensionSettings {
     enabledFileTypes = reduceEnabledFileTypesInSettings(enabledFileTypes, settings);
     const { enableFiletypes: _, enabledLanguageIds: __, ...rest } = settings;
     return { ...rest, enabledFileTypes };
@@ -98,7 +107,7 @@ export function normalizeEnableFiletypes(enableFiletypes: string[]): string[] {
     return ids;
 }
 
-export function isFileTypeEnabled(languageId: string, settings: CSpellUserSettings): boolean {
+export function isFileTypeEnabled(languageId: string, settings: CSpellUserAndExtensionSettings): boolean {
     const enabledFileTypes = extractEnabledFileTypes(settings);
     const enabled = enabledFileTypes[languageId];
     if (enabled !== undefined) return enabled;

--- a/packages/_server/src/config/sanitizeSettings.mts
+++ b/packages/_server/src/config/sanitizeSettings.mts
@@ -1,15 +1,21 @@
 import { isDefined } from '@internal/common-utils';
 import type { DictionaryDefinition, DictionaryDefinitionCustom } from 'cspell-lib';
 
-import type { CSpellUserSettings } from './cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
 import { ConfigFields } from './cspellConfig/index.mjs';
 
-type ConfigFieldKeys = keyof CSpellUserSettings;
+type ConfigFieldKeys = keyof CSpellUserAndExtensionSettings;
 type ConfigFieldFilter = Record<ConfigFieldKeys, boolean | undefined>;
 
-export function sanitizeSettings(settings: CSpellUserSettings, fields: ConfigFieldFilter): CSpellUserSettings;
-export function sanitizeSettings(settings: CSpellUserSettings | undefined, fields: ConfigFieldFilter): CSpellUserSettings | undefined;
-export function sanitizeSettings(settings: CSpellUserSettings | undefined, fields: ConfigFieldFilter): CSpellUserSettings | undefined {
+export function sanitizeSettings(settings: CSpellUserAndExtensionSettings, fields: ConfigFieldFilter): CSpellUserAndExtensionSettings;
+export function sanitizeSettings(
+    settings: CSpellUserAndExtensionSettings | undefined,
+    fields: ConfigFieldFilter,
+): CSpellUserAndExtensionSettings | undefined;
+export function sanitizeSettings(
+    settings: CSpellUserAndExtensionSettings | undefined,
+    fields: ConfigFieldFilter,
+): CSpellUserAndExtensionSettings | undefined {
     if (!settings) return settings;
     const includeKeys = new Set<string>(
         Object.entries(fields)
@@ -26,7 +32,9 @@ export function sanitizeSettings(settings: CSpellUserSettings | undefined, field
     return s;
 }
 
-function sanitizeDictionaryDefinitions(defs: CSpellUserSettings['dictionaryDefinitions']): CSpellUserSettings['dictionaryDefinitions'] {
+function sanitizeDictionaryDefinitions(
+    defs: CSpellUserAndExtensionSettings['dictionaryDefinitions'],
+): CSpellUserAndExtensionSettings['dictionaryDefinitions'] {
     if (!defs) return defs;
     return defs.map((def) => sanitizeDictionaryDefinition(def)).filter(isDefined);
 }

--- a/packages/_server/src/config/vscode.config.test.mts
+++ b/packages/_server/src/config/vscode.config.test.mts
@@ -17,12 +17,12 @@ describe('Validate vscode config', () => {
         expect(mockedWorkspace.getConfiguration).toHaveBeenLastCalledWith(items);
     });
 
-    test('getWorkspaceFolders', () => {
+    test('getWorkspaceFolders', async () => {
         const connection = sampleConnection();
         const mockedWorkspace = vi.mocked(connection.workspace);
         const folders: WorkspaceFolder[] = [];
         mockedWorkspace.getWorkspaceFolders.mockResolvedValue(folders);
-        expect(getWorkspaceFolders(connection)).resolves.toBe(folders);
+        await expect(getWorkspaceFolders(connection)).resolves.toBe(folders);
     });
 });
 

--- a/packages/_server/src/suggestionsServer.mts
+++ b/packages/_server/src/suggestionsServer.mts
@@ -3,12 +3,12 @@ import type { TextDocuments } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import type { SpellingSuggestionsResult, TextDocumentInfo } from './api.js';
-import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './config/cspellConfig/index.mjs';
 import type { GetSettingsResult } from './SuggestionsGenerator.mjs';
 import { SuggestionGenerator } from './SuggestionsGenerator.mjs';
 
 export interface SuggestionsServerDependencies {
-    fetchSettings: (doc?: TextDocumentInfo) => Promise<CSpellUserSettings>;
+    fetchSettings: (doc?: TextDocumentInfo) => Promise<CSpellUserAndExtensionSettings>;
     getSettingsVersion: (doc?: TextDocumentInfo) => number;
 }
 

--- a/packages/_server/src/validator.mts
+++ b/packages/_server/src/validator.mts
@@ -4,7 +4,7 @@ import type { Diagnostic } from 'vscode-languageserver-types';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';
 
 import type { SpellCheckerDiagnosticData, SpellingDiagnostic, Suggestion } from './api.js';
-import type { CSpellUserSettings } from './config/cspellConfig/index.mjs';
+import type { CSpellUserAndExtensionSettings } from './config/cspellConfig/index.mjs';
 import { diagnosticSource } from './constants.mjs';
 import { createDocumentValidator } from './DocumentValidationController.mjs';
 
@@ -21,7 +21,7 @@ const diagSeverityMap = new Map<string, DiagnosticSeverity | undefined>([
     ['off', undefined],
 ]);
 
-export async function validateTextDocument(textDocument: TextDocument, options: CSpellUserSettings): Promise<Diagnostic[]> {
+export async function validateTextDocument(textDocument: TextDocument, options: CSpellUserAndExtensionSettings): Promise<Diagnostic[]> {
     const { severity, severityFlaggedWords } = calcSeverity(textDocument.uri, options);
     const docVal = await createDocumentValidator(textDocument, options);
     const r = await docVal.checkDocumentAsync(true);
@@ -75,7 +75,7 @@ function haveSuggestionsMatchCase(example: string, suggestions: Suggestion[] | u
     return suggestions.map((sug) => (TextUtil.isLowerCase(sug.word) ? { ...sug, word: TextUtil.matchCase(example, sug.word) } : sug));
 }
 
-type SeverityOptions = Pick<CSpellUserSettings, 'diagnosticLevel' | 'diagnosticLevelFlaggedWords'>;
+type SeverityOptions = Pick<CSpellUserAndExtensionSettings, 'diagnosticLevel' | 'diagnosticLevelFlaggedWords'>;
 
 interface Severity {
     severity: DiagnosticSeverity | undefined;

--- a/packages/_server/src/vfs/CSpellFileSystemProvider.mts
+++ b/packages/_server/src/vfs/CSpellFileSystemProvider.mts
@@ -40,7 +40,7 @@ class CSpellFileSystemProvider implements VFileSystemProvider {
     private async _updateWorkspaceFolders() {
         try {
             const folders = await this.connection.workspace.getWorkspaceFolders();
-            logDebug(`Workspace folders: ${JSON.stringify(folders)}`);
+            // logDebug(`Workspace folders: ${JSON.stringify(folders)}`);
             this.folders = folders ?? [];
             this.pFolders = undefined;
             return this.folders;
@@ -79,7 +79,7 @@ class CSpellFileSystemProvider implements VFileSystemProvider {
                 const folder = findMatchingFolderForUri(folders, href);
                 // Do not read directories outside of the workspace.
                 if (!folder) {
-                    logDebug(`readDirectory: ${url.href} not in workspace: ${JSON.stringify(folders)}`);
+                    // logDebug(`readDirectory: ${url.href} not in workspace: ${JSON.stringify(folders)}`);
                     logDebug(`readDirectory: ${url.href} not in workspace`);
                     return [];
                 }

--- a/packages/client/src/commands.mts
+++ b/packages/client/src/commands.mts
@@ -146,6 +146,8 @@ export const commandHandlers = {
     'cSpell.editText': handleApplyLsTextEdits,
     'cSpell.logPerfTimeline': dumpPerfTimeline,
 
+    'cSpell.openSettings': callCommand('workbench.action.openSettings', () => [{ query: 'cSpell.' }]),
+
     'cSpell.addWordToCSpellConfig': actionAddWordToCSpell,
     'cSpell.addIssuesToDictionary': addAllIssuesFromDocument,
     'cSpell.createCustomDictionary': createCustomDictionary,


### PR DESCRIPTION
A while ago, VS Code changed editor and schema for editing `settings.json` and `keybindings.json` files. This change has caused the spell checker to report on issues it did not in the past.

This PR will ignore files of the form:
- `vscode-userdata:/**/settings.json`
- `vscode-userdata:/**/keybindings.json`

Related to #3581, #3542, https://github.com/streetsidesoftware/vscode-spell-checker/issues/3542#issuecomment-2511826418 , #3158.