### PR TITLE
chore: Mark `pre-release` versions

### DIFF
--- a/.github/workflows/release-mark-prerelease.yml
+++ b/.github/workflows/release-mark-prerelease.yml
@@ -1,4 +1,8 @@
-name: '  🚀 Mark Prerelease'
+# This workflow is used to mark an existing release as a prerelease.
+# It reads the `prerelease` property from the `package.json` file.
+# If the property is `true`, it marks the release as a prerelease.
+# If the property is `false`, it does nothing.
+name: ' 🚀 Mark Prerelease'
 
 on:
   workflow_dispatch:
@@ -10,10 +14,6 @@ on:
   release:
     types:
       - published
-  # push:
-  #   # Sequence of patterns matched against refs/tags
-  #   tags:
-  #     - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -74,6 +74,14 @@ jobs:
     with:
       ref: ${{ needs.release-please.outputs.tag_name }}
 
+  mark-prerelease:
+    needs:
+      - release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/release-mark-prerelease.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+
   publish:
     needs:
       - release-please


### PR DESCRIPTION
Make sure published releases are marked as `pre-release` when the `package.json` has `prerelease: true`.

fixes #3974
related to #3775