### PR TITLE
Remove ellipse from "No issues found."

### DIFF
--- a/packages/client/src/issueViewer/issuesViewerByFile.mts
+++ b/packages/client/src/issueViewer/issuesViewerByFile.mts
@@ -243,7 +243,7 @@ class IssuesTreeDataProvider implements TreeDataProvider<IssueTreeItemBase> {
             requestSuggestions: (item) => this.issueTracker?.getSuggestionsForIssue(item) || Promise.resolve([]),
         };
         this.children = collectIssuesByFile(context);
-        this.updateMessage(this.children.length ? undefined : 'No issues found...');
+        this.updateMessage(this.children.length ? undefined : 'No issues found.');
         setTimeout(() => this.options.onDidUpdate(), 10);
         return this.children;
     }

--- a/packages/client/src/issueViewer/unknownWordsViewer.mts
+++ b/packages/client/src/issueViewer/unknownWordsViewer.mts
@@ -155,7 +155,7 @@ class UnknownWordsTreeDataProvider implements TreeDataProvider<IssueTreeItemBase
         };
         const issues = collectIssues(context);
         this.children = issues;
-        this.updateMessage(issues.length ? undefined : 'No issues found...');
+        this.updateMessage(issues.length ? undefined : 'No issues found.');
         return issues;
     }
 


### PR DESCRIPTION
The ellipse implied an ongoing action, as if spell check had not completed, even when it had.