### PR TITLE
fix: handle opening of settings is better way

### DIFF
--- a/packages/client/src/commands.mts
+++ b/packages/client/src/commands.mts
@@ -147,7 +147,7 @@ export const commandHandlers = {
     'cSpell.editText': handleApplyLsTextEdits,
     'cSpell.logPerfTimeline': dumpPerfTimeline,
 
-    'cSpell.openSettings': callCommand('workbench.action.openSettings', () => [{ query: 'cSpell.' }]),
+    'cSpell.openSettings': callCommand('workbench.action.openSettings', () => [{ query: '@ext:streetsidesoftware.code-spell-checker' }]),
 
     'cSpell.addWordToCSpellConfig': actionAddWordToCSpell,
     'cSpell.addIssuesToDictionary': addAllIssuesFromDocument,


### PR DESCRIPTION
To only show the extension settings user should pass the query in the format: `@ext:<publisher>.<name>`