### PR TITLE
chore: Prevent pnpm and yarn from being used.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,9 @@
       },
       "engines": {
         "node": "^20.18.1",
-        "vscode": "^1.90.0"
+        "pnpm": "0",
+        "vscode": "^1.90.0",
+        "yarn": "0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {

--- a/package.json
+++ b/package.json
@@ -4054,8 +4054,7 @@
     "update-packages": "npm run update:packages:root && npm run update:packages:website",
     "update:packages:root": "npx npm-check-updates --root -ws --target semver -u && npm i",
     "update:packages:website": "cd website && npm run update-packages",
-    "postinstall": "patch-package",
-    "preinstall": "npx only-allow npm"
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
     "url": "https://github.com/streetsidesoftware/vscode-spell-checker/issues"
   },
   "homepage": "https://streetsidesoftware.github.io/vscode-spell-checker",
+  "packageManager": "npm@10.8.2",
   "engineStrict": true,
   "engines": {
     "node": "^20.18.1",
+    "pnpm": "0",
+    "yarn": "0",
     "vscode": "^1.90.0"
   },
   "sponsor": {


### PR DESCRIPTION
Accidentally running `pnpm` or `yarn` can lead to unexpected results.