### PR TITLE
fix: Remove eye icon from title bars

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,16 +182,6 @@
           "command": "cSpell.hide",
           "when": "cSpell.context.showDecorations && view == cSpellIssuesViewByFile",
           "group": "navigation"
-        },
-        {
-          "command": "cSpell.show",
-          "when": "!cSpell.context.showDecorations && activePanel == 'workbench.panel.markers'",
-          "group": "navigation"
-        },
-        {
-          "command": "cSpell.hide",
-          "when": "cSpell.context.showDecorations && activePanel == 'workbench.panel.markers'",
-          "group": "navigation"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
The purpose of the command was to show on the problems panel, but filter doesn't work as expected. Remove for now.

fixes #4288