### PR TITLE
fix: Regexp Checker blows up on large docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28339,10 +28339,9 @@
       "name": "@internal/server-pattern-matcher",
       "version": "2.0.0",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@cspell/cspell-types": "^9.1.5",
         "@internal/common-utils": "file:../__utils",
-        "cspell-lib": "^9.1.5",
         "regexp-worker": "^4.1.8",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/_integrationTests/src/logger.mts
+++ b/packages/_integrationTests/src/logger.mts
@@ -1,5 +1,6 @@
+import { format } from 'node:util';
+
 import { Chalk } from 'chalk';
-import { format } from 'util';
 
 export const chalk = new Chalk({ level: 1 });
 

--- a/packages/_server/src/codeActions.mts
+++ b/packages/_server/src/codeActions.mts
@@ -1,8 +1,9 @@
+import { format } from 'node:util';
+
 import { log, logDebug, logError } from '@internal/common-utils/log';
 import { capitalize } from '@internal/common-utils/util';
 import type { SpellingDictionary } from 'cspell-lib';
 import { constructSettingsForText, getDictionary, IssueType, Text } from 'cspell-lib';
-import { format } from 'util';
 import type { CodeActionParams, Range as LangServerRange, TextDocuments } from 'vscode-languageserver/node.js';
 import { Command as LangServerCommand } from 'vscode-languageserver/node.js';
 import type { TextDocument } from 'vscode-languageserver-textdocument';

--- a/packages/_server/src/utils/debounce.test.mts
+++ b/packages/_server/src/utils/debounce.test.mts
@@ -1,4 +1,5 @@
-import { promisify } from 'util';
+import { promisify } from 'node:util';
+
 import { describe, expect, test } from 'vitest';
 
 import { debounce } from './debounce.mjs';

--- a/packages/_server/src/utils/fileWatcher.mts
+++ b/packages/_server/src/utils/fileWatcher.mts
@@ -1,5 +1,6 @@
+import { format } from 'node:util';
+
 import { logError } from '@internal/common-utils/log';
-import { format } from 'util';
 import type { Disposable } from 'vscode-languageserver/node.js';
 
 import type { EventType, Listener, Watcher } from './watchFile.mjs';

--- a/packages/_serverPatternMatcher/package.json
+++ b/packages/_serverPatternMatcher/package.json
@@ -22,10 +22,9 @@
       "require": "./dist/api.cjs"
     }
   },
-  "dependencies": {
+  "devDependencies": {
     "@cspell/cspell-types": "^9.1.5",
     "@internal/common-utils": "file:../__utils",
-    "cspell-lib": "^9.1.5",
     "regexp-worker": "^4.1.8",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/_serverPatternMatcher/tsdown.config.ts
+++ b/packages/_serverPatternMatcher/tsdown.config.ts
@@ -7,7 +7,6 @@ export default defineConfig([
         outDir: 'dist',
         format: ['esm', 'cjs'],
         dts: true,
-        noExternal: [/.*/],
         sourcemap: true,
         clean: true,
     },

--- a/packages/client/src/commands.mts
+++ b/packages/client/src/commands.mts
@@ -1,5 +1,6 @@
+import { format } from 'node:util';
+
 import { logError } from '@internal/common-utils/log';
-import { format } from 'util';
 import type { Command, ConfigurationScope, Diagnostic, Disposable, TextEdit, TextEditor, TextEditorEdit } from 'vscode';
 import { commands, NotebookRange, Position, Range, Selection, SnippetString, TextEditorRevealType, Uri, window } from 'vscode';
 

--- a/packages/client/src/extensionRegEx/extensionRegEx.mts
+++ b/packages/client/src/extensionRegEx/extensionRegEx.mts
@@ -1,5 +1,6 @@
+import { format } from 'node:util';
+
 import type { PartialCSpellUserSettings } from 'code-spell-checker-server/api';
-import { format } from 'util';
 import * as vscode from 'vscode';
 
 import type { CSpellClient } from '../client/index.mjs';

--- a/packages/client/src/settings/DictionaryTarget.mts
+++ b/packages/client/src/settings/DictionaryTarget.mts
@@ -1,6 +1,7 @@
+import { format } from 'node:util';
+
 import { isErrnoException } from '@internal/common-utils';
 import { uriToFilePathOrHref, uriToName } from '@internal/common-utils/uriHelper';
-import { format } from 'util';
 import type { Uri } from 'vscode';
 import { window, workspace } from 'vscode';
 import { Utils as UriUtils } from 'vscode-uri';

--- a/packages/client/src/util/errors.ts
+++ b/packages/client/src/util/errors.ts
@@ -1,4 +1,5 @@
-import { format } from 'util';
+import { format } from 'node:util';
+
 import { window } from 'vscode';
 
 export function isError(e: unknown): e is Error {


### PR DESCRIPTION
The regexp checker fails on large documents.

This is caused by how data is moved between worker threads.

fixes #4615 