### PR TITLE
fix: reportUnknownWords caused reporting issues

### DIFF
--- a/fixtures/workspaces/unknown-words/.vscode/settings.json
+++ b/fixtures/workspaces/unknown-words/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cSpell.reportUnknownWords": false
+    "cSpell.reportUnknownWords": "typos"
 }

--- a/package.json
+++ b/package.json
@@ -2030,16 +2030,16 @@
             "type": "boolean"
           },
           "cSpell.reportUnknownWords": {
-            "default": "undefined",
+            "deprecated": true,
+            "deprecationMessage": "Use Unknown Words settings instead.",
             "enum": [
               "all",
               "simple",
               "typos",
               "flagged"
             ],
-            "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled",
+            "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
             "scope": "language-overridable",
-            "since": "4.0.2",
             "title": "Strict Spell Checking",
             "type": "string"
           }
@@ -3239,7 +3239,7 @@
                 "type": "string"
               },
               "textDecorationColorSuggestion": {
-                "default": "#8884",
+                "default": "#cf88",
                 "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
                 "since": "4.0.2",
@@ -3328,7 +3328,7 @@
                 "type": "string"
               },
               "textDecorationColorSuggestion": {
-                "default": "#8884",
+                "default": "#cf88",
                 "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
                 "since": "4.0.2",
@@ -3407,7 +3407,7 @@
             "type": "string"
           },
           "cSpell.textDecorationColorSuggestion": {
-            "default": "#8884",
+            "default": "#cf88",
             "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
             "scope": "application",
             "since": "4.0.2",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1474,17 +1474,17 @@
           "type": "boolean"
         },
         "cSpell.reportUnknownWords": {
-          "default": "undefined",
-          "description": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only reporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled",
+          "deprecated": true,
+          "deprecationMessage": "Use Unknown Words settings instead.",
+          "description": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only reporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
           "enum": [
             "all",
             "simple",
             "typos",
             "flagged"
           ],
-          "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled",
+          "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
           "scope": "language-overridable",
-          "since": "4.0.2",
           "title": "Strict Spell Checking",
           "type": "string"
         }
@@ -2828,7 +2828,7 @@
               "type": "string"
             },
             "textDecorationColorSuggestion": {
-              "default": "#8884",
+              "default": "#cf88",
               "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
@@ -2927,7 +2927,7 @@
               "type": "string"
             },
             "textDecorationColorSuggestion": {
-              "default": "#8884",
+              "default": "#cf88",
               "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
@@ -3015,7 +3015,7 @@
           "type": "string"
         },
         "cSpell.textDecorationColorSuggestion": {
-          "default": "#8884",
+          "default": "#cf88",
           "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "scope": "application",

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -149,7 +149,7 @@ interface Decoration {
      *
      * @scope application
      * @since 4.0.2
-     * @default "#8884"
+     * @default "#cf88"
      */
     textDecorationColorSuggestion?: string;
 }

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -363,10 +363,13 @@ export interface SpellCheckerSettings
      * - `simple` - report unknown words with simple fixes and the rest as suggestions
      * - `typos` - report on known typo words and the rest as suggestions
      * - `flagged` - report only flagged words as misspelled
+     *
+     * **Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.
+     *
      * @title Strict Spell Checking
      * @scope language-overridable
-     * @since 4.0.2
-     * @default undefined
+     * @deprecated true
+     * @deprecationMessage  Use Unknown Words settings instead.
      */
     reportUnknownWords?: UnknownWordsReportingLevel | undefined;
 }

--- a/packages/_server/src/validator.mts
+++ b/packages/_server/src/validator.mts
@@ -73,11 +73,18 @@ function calcIssueReportingLevel(issue: ValidationIssue, reportUnknownWords: Unk
     return false;
 }
 
+const keysUnknownWordsReportingLevel: Record<UnknownWordsReportingLevel, true> = {
+    all: true,
+    simple: true,
+    typos: true,
+    flagged: true,
+};
+
 function calcReportingLevel(
     reportUnknownWords: UnknownWordsReportingLevel | undefined,
     reportOptions: UnknownWordsConfiguration,
 ): UnknownWordsReportingLevel {
-    if (reportUnknownWords) {
+    if (reportUnknownWords && reportUnknownWords in keysUnknownWordsReportingLevel) {
         return reportUnknownWords;
     }
     if (!reportOptions.unknownWords || reportOptions.unknownWords === unknownWordsChoices.ReportAll) {


### PR DESCRIPTION
The default of `undefined` got turned into a string causing issues with the reporting.