### PR TITLE
feat: Require VSCode 1.104.0 or newer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
         "@eslint/js": "~9.38.0",
-        "@tsconfig/node20": "^20.1.6",
+        "@tsconfig/node22": "^22.0.2",
         "@types/node": "^20.19.24",
         "@types/vscode": "1.104.0",
         "@types/vscode-webview": "^1.57.5",
@@ -7983,10 +7983,10 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
-      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.2.tgz",
+      "integrity": "sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -4256,7 +4256,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
     "@eslint/js": "~9.38.0",
-    "@tsconfig/node20": "^20.1.6",
+    "@tsconfig/node22": "^22.0.2",
     "@types/node": "^20.19.24",
     "@types/vscode": "1.104.0",
     "@types/vscode-webview": "^1.57.5",

--- a/packages/__utils/tsconfig.json
+++ b/packages/__utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./dist",
         "lib": ["es2023", "dom"],

--- a/packages/_integrationTests/tsconfig.json
+++ b/packages/_integrationTests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./out",
         "esModuleInterop": true,

--- a/packages/_server/tsdown.config.ts
+++ b/packages/_server/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig([
         // splitting: false,
         noExternal: [/.*/],
         clean: true,
+        target: 'node22',
     },
     {
         // This is the non-bundled version used for the API to the client.
@@ -20,5 +21,6 @@ export default defineConfig([
         dts: true,
         sourcemap: true,
         clean: true,
+        target: 'node22',
     },
 ]);

--- a/packages/_serverPatternMatcher/tsdown.config.ts
+++ b/packages/_serverPatternMatcher/tsdown.config.ts
@@ -9,5 +9,6 @@ export default defineConfig([
         dts: true,
         sourcemap: true,
         clean: true,
+        target: 'node22',
     },
 ]);

--- a/packages/client/build.mjs
+++ b/packages/client/build.mjs
@@ -40,6 +40,7 @@ const optionsBase = {
     platform: 'node',
     sourcemap: true,
     external: ['vscode'],
+    target: 'node22',
 };
 
 async function buildAll() {

--- a/packages/json-rpc-api/sampleApi/tsconfig.json
+++ b/packages/json-rpc-api/sampleApi/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./dist",
         "target": "es2022",

--- a/packages/json-rpc-api/tsconfig.json
+++ b/packages/json-rpc-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./dist",
         "target": "es2022",

--- a/packages/utils-disposables/tsconfig.json
+++ b/packages/utils-disposables/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./dist/",
         "target": "es2022",

--- a/packages/utils-logger/tsconfig.json
+++ b/packages/utils-logger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "./dist",
         "target": "es2022",

--- a/packages/webview-api/tsconfig.json
+++ b/packages/webview-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "dist",
         "lib": ["es2022", "dom"],

--- a/packages/webview-rpc/tsconfig.json
+++ b/packages/webview-rpc/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20",
+    "extends": "@tsconfig/node22",
     "compilerOptions": {
         "outDir": "dist/esm",
         "target": "es2022",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "Spell Checker Base Config",
-    "extends": "@tsconfig/node20/tsconfig.json",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "compilerOptions": {
         "strict": true,
         "strictFunctionTypes": true,


### PR DESCRIPTION
This is needed to get node 22.18.0 runtime.