### PR TITLE
fix: Use `@sinceVersion` instead of `@since`

### DIFF
--- a/package.json
+++ b/package.json
@@ -799,7 +799,7 @@
             "default": true,
             "markdownDescription": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace,\nbut a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
             "scope": "window",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "boolean"
           }
         },
@@ -897,7 +897,7 @@
                   ],
                   "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                   "scope": "resource",
-                  "since": "4.0.0",
+                  "sinceVersion": "4.0.0",
                   "title": "Set Diagnostic Reporting Level for Flagged Words",
                   "type": "string"
                 },
@@ -2189,7 +2189,7 @@
             "default": true,
             "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
             "scope": "resource",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "boolean"
           },
           "cSpell.mergeCSpellSettingsFields": {
@@ -2332,7 +2332,7 @@
               }
             },
             "scope": "resource",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "object"
           },
           "cSpell.noConfigSearch": {
@@ -3195,7 +3195,7 @@
             "default": true,
             "markdownDescription": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
             "scope": "resource",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "boolean"
           },
           "cSpell.userWords": {
@@ -3231,34 +3231,34 @@
                 "default": "#348feb80",
                 "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecoration": {
                 "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColor": {
                 "default": "#348feb",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorFlagged": {
                 "default": "#f44",
                 "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorSuggestion": {
                 "default": "#cf88",
                 "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.2",
+                "sinceVersion": "4.0.2",
                 "type": "string"
               },
               "textDecorationLine": {
@@ -3270,7 +3270,7 @@
                 ],
                 "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationStyle": {
@@ -3284,19 +3284,19 @@
                 ],
                 "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationThickness": {
                 "default": "auto",
                 "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               }
             },
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "object"
           },
           "cSpell.doNotUseCustomDecorationForScheme": {
@@ -3308,7 +3308,7 @@
             },
             "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "title": "Use VS Code to Render Spelling Issues",
             "type": "object"
           },
@@ -3320,34 +3320,34 @@
                 "default": "#348feb80",
                 "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecoration": {
                 "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColor": {
                 "default": "#348feb",
                 "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorFlagged": {
                 "default": "#f44",
                 "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationColorSuggestion": {
                 "default": "#cf88",
                 "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
                 "scope": "application",
-                "since": "4.0.2",
+                "sinceVersion": "4.0.2",
                 "type": "string"
               },
               "textDecorationLine": {
@@ -3359,7 +3359,7 @@
                 ],
                 "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationStyle": {
@@ -3373,60 +3373,60 @@
                 ],
                 "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               },
               "textDecorationThickness": {
                 "default": "auto",
                 "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
                 "scope": "application",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "type": "string"
               }
             },
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "object"
           },
           "cSpell.overviewRulerColor": {
             "default": "#348feb80",
             "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.showInRuler": {
             "default": true,
             "markdownDescription": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
             "scope": "application",
-            "since": "4.0.35",
+            "sinceVersion": "4.0.35",
             "type": "boolean"
           },
           "cSpell.textDecoration": {
             "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationColor": {
             "default": "#348feb",
             "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationColorFlagged": {
             "default": "#f44",
             "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationColorSuggestion": {
             "default": "#cf88",
             "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
             "scope": "application",
-            "since": "4.0.2",
+            "sinceVersion": "4.0.2",
             "type": "string"
           },
           "cSpell.textDecorationLine": {
@@ -3438,7 +3438,7 @@
             ],
             "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationStyle": {
@@ -3452,21 +3452,21 @@
             ],
             "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.textDecorationThickness": {
             "default": "auto",
             "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "string"
           },
           "cSpell.useCustomDecorations": {
             "default": false,
             "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "type": "boolean"
           }
         },
@@ -4073,7 +4073,7 @@
             ],
             "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
             "scope": "resource",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "title": "Set Diagnostic Reporting Level for Flagged Words",
             "type": "string"
           },
@@ -4100,7 +4100,7 @@
               }
             },
             "scope": "resource",
-            "since": "4.0.41",
+            "sinceVersion": "4.0.41",
             "title": "Enabled Notifications",
             "type": "object"
           },
@@ -4126,7 +4126,7 @@
             ],
             "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "title": "Hide Issues While Typing",
             "type": "string"
           },
@@ -4158,7 +4158,7 @@
             "default": 1500,
             "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
             "scope": "application",
-            "since": "4.0.0",
+            "sinceVersion": "4.0.0",
             "title": "Reveal Issues After a Delay in Milliseconds",
             "type": "number"
           },

--- a/packages/_server/scripts/build-schema.mjs
+++ b/packages/_server/scripts/build-schema.mjs
@@ -43,6 +43,7 @@ const config = defConfig({
         'deprecated',
         'order',
         'since',
+        'sinceVersion'
     ],
 });
 
@@ -52,6 +53,11 @@ const schema = tsj.createGenerator(config).createSchema(config.type);
 const schemaString = stringify(schema, null, 2) + '\n';
 await fs.writeFile(outputPath, cleanJson(schemaString));
 
+/**
+ *
+ * @param {string} filePath
+ * @returns
+ */
 function p(filePath) {
     return path.resolve(rootDir, filePath);
 }
@@ -65,6 +71,11 @@ function defConfig(a) {
     return a;
 }
 
+/**
+ *
+ * @param {string} json
+ * @returns
+ */
 function cleanJson(json) {
     /** Remove zero width space */
     return json.replaceAll(/\u200B/g, '');

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -79,7 +79,7 @@
           "description": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace, but a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
           "markdownDescription": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace,\nbut a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
           "scope": "window",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "boolean"
         }
       },
@@ -188,7 +188,7 @@
                 ],
                 "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
                 "scope": "resource",
-                "since": "4.0.0",
+                "sinceVersion": "4.0.0",
                 "title": "Set Diagnostic Reporting Level for Flagged Words",
                 "type": "string"
               },
@@ -1651,7 +1651,7 @@
           "description": "Specify if fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
           "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
           "scope": "resource",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "boolean"
         },
         "cSpell.mergeCSpellSettingsFields": {
@@ -1795,7 +1795,7 @@
             }
           },
           "scope": "resource",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "object"
         },
         "cSpell.noConfigSearch": {
@@ -2779,7 +2779,7 @@
           "description": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
           "markdownDescription": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
           "scope": "resource",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "boolean"
         },
         "cSpell.userWords": {
@@ -2819,14 +2819,14 @@
               "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecoration": {
               "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColor": {
@@ -2834,7 +2834,7 @@
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColorFlagged": {
@@ -2842,7 +2842,7 @@
               "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColorSuggestion": {
@@ -2850,7 +2850,7 @@
               "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.2",
+              "sinceVersion": "4.0.2",
               "type": "string"
             },
             "textDecorationLine": {
@@ -2863,7 +2863,7 @@
               ],
               "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationStyle": {
@@ -2878,7 +2878,7 @@
               ],
               "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationThickness": {
@@ -2886,12 +2886,12 @@
               "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             }
           },
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "object"
         },
         "cSpell.doNotUseCustomDecorationForScheme": {
@@ -2904,7 +2904,7 @@
           "description": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up. This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
           "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "title": "Use VS Code to Render Spelling Issues",
           "type": "object"
         },
@@ -2918,14 +2918,14 @@
               "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecoration": {
               "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColor": {
@@ -2933,7 +2933,7 @@
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColorFlagged": {
@@ -2941,7 +2941,7 @@
               "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationColorSuggestion": {
@@ -2949,7 +2949,7 @@
               "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "scope": "application",
-              "since": "4.0.2",
+              "sinceVersion": "4.0.2",
               "type": "string"
             },
             "textDecorationLine": {
@@ -2962,7 +2962,7 @@
               ],
               "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationStyle": {
@@ -2977,7 +2977,7 @@
               ],
               "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             },
             "textDecorationThickness": {
@@ -2985,12 +2985,12 @@
               "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "scope": "application",
-              "since": "4.0.0",
+              "sinceVersion": "4.0.0",
               "type": "string"
             }
           },
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "object"
         },
         "cSpell.overviewRulerColor": {
@@ -2998,7 +2998,7 @@
           "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
           "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.showInRuler": {
@@ -3006,14 +3006,14 @@
           "description": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
           "markdownDescription": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
           "scope": "application",
-          "since": "4.0.35",
+          "sinceVersion": "4.0.35",
           "type": "boolean"
         },
         "cSpell.textDecoration": {
           "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
           "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecorationColor": {
@@ -3021,7 +3021,7 @@
           "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecorationColorFlagged": {
@@ -3029,7 +3029,7 @@
           "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecorationColorSuggestion": {
@@ -3037,7 +3037,7 @@
           "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
           "scope": "application",
-          "since": "4.0.2",
+          "sinceVersion": "4.0.2",
           "type": "string"
         },
         "cSpell.textDecorationLine": {
@@ -3050,7 +3050,7 @@
           ],
           "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecorationStyle": {
@@ -3065,7 +3065,7 @@
           ],
           "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.textDecorationThickness": {
@@ -3073,7 +3073,7 @@
           "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
           "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "string"
         },
         "cSpell.useCustomDecorations": {
@@ -3081,7 +3081,7 @@
           "description": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
           "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "type": "boolean"
         }
       },
@@ -3763,7 +3763,7 @@
           ],
           "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
           "scope": "resource",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "title": "Set Diagnostic Reporting Level for Flagged Words",
           "type": "string"
         },
@@ -3794,7 +3794,7 @@
             }
           },
           "scope": "resource",
-          "since": "4.0.41",
+          "sinceVersion": "4.0.41",
           "title": "Enabled Notifications",
           "type": "object"
         },
@@ -3822,7 +3822,7 @@
           ],
           "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "title": "Hide Issues While Typing",
           "type": "string"
         },
@@ -3859,7 +3859,7 @@
           "description": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
           "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
           "scope": "application",
-          "since": "4.0.0",
+          "sinceVersion": "4.0.0",
           "title": "Reveal Issues After a Delay in Milliseconds",
           "type": "number"
         },

--- a/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
+++ b/packages/_server/src/config/cspellConfig/AppearanceSettings.mts
@@ -20,7 +20,7 @@ interface Decoration {
      * - `rgb(255 153 0 / 80%)`
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "#348feb80"
      */
     overviewRulerColor?: string;
@@ -51,7 +51,7 @@ interface Decoration {
      * To change the ruler color, use `#cSpell.overviewRulerColor#`.
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      */
     textDecoration?: string;
 
@@ -62,7 +62,7 @@ interface Decoration {
      * - line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "underline"
      */
     textDecorationLine?: 'underline' | 'overline' | 'line-through';
@@ -74,7 +74,7 @@ interface Decoration {
      * - style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "dashed"
      */
     textDecorationStyle?: 'solid' | 'wavy' | 'dotted' | 'dashed' | 'double';
@@ -93,7 +93,7 @@ interface Decoration {
      * - `10%`
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "auto"
      */
     textDecorationThickness?: 'auto' | 'from-font' | string;
@@ -112,7 +112,7 @@ interface Decoration {
      * - `#ff0c`
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "#348feb"
      */
     textDecorationColor?: string;
@@ -129,7 +129,7 @@ interface Decoration {
      * - `#ff0c`
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "#f44"
      */
     textDecorationColorFlagged?: string;
@@ -148,7 +148,7 @@ interface Decoration {
      * - `#ff0c`
      *
      * @scope application
-     * @since 4.0.2
+     * @sinceVersion 4.0.2
      * @default "#cf88"
      */
     textDecorationColorSuggestion?: string;
@@ -165,7 +165,7 @@ interface Appearance extends Decoration {
      * - `#cSpell.overviewRulerColor#`
      * - `#cSpell.textDecoration#`
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      */
     light?: Decoration;
 
@@ -176,7 +176,7 @@ interface Appearance extends Decoration {
      * - `#cSpell.overviewRulerColor#`
      * - `#cSpell.textDecoration#`
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      */
     dark?: Decoration;
 }
@@ -190,7 +190,7 @@ export interface AppearanceSettings extends Appearance {
      * Note: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.
      *
      * @scope application
-     * @since 4.0.35
+     * @sinceVersion 4.0.35
      * @default true
      */
     showInRuler?: boolean;
@@ -203,7 +203,7 @@ export interface AppearanceSettings extends Appearance {
      * Note: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.
      *
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default false
      */
     useCustomDecorations?: boolean;
@@ -216,7 +216,7 @@ export interface AppearanceSettings extends Appearance {
      *
      * @title Use VS Code to Render Spelling Issues
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default { "vscode-scm": true }
      */
     doNotUseCustomDecorationForScheme?: Record<string, boolean>;

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -15,7 +15,7 @@ export type DiagnosticLevel = 'Error' | 'Warning' | 'Information' | 'Hint';
  *
  * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
  * @title Set Diagnostic Reporting Level
- * @since 4.0.0
+ * @sinceVersion 4.0.0
  * @enumDescriptions [
  *  "Report Spelling Issues as Errors",
  *  "Report Spelling Issues as Warnings",
@@ -86,7 +86,7 @@ export interface SpellCheckerSettings
      * See: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)
      * @title Set Diagnostic Reporting Level for Flagged Words
      * @scope resource
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @enumDescriptions [
      *  "Report Spelling Issues as Errors",
      *  "Report Spelling Issues as Warnings",
@@ -309,7 +309,7 @@ export interface SpellCheckerSettings
      * Note: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.
      *
      * @scope resource
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default true
      */
     mergeCSpellSettings?: boolean;
@@ -328,7 +328,7 @@ export interface SpellCheckerSettings
      * ```
      *
      * @scope resource
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default {
      * "allowCompoundWords":true,"caseSensitive":true,"dictionaries":true,"dictionaryDefinitions":true,
      * "enableGlobDot":true,"features":true,"files":true,"flagWords":true,"gitignoreRoot":true,"globRoot":true,
@@ -344,7 +344,7 @@ export interface SpellCheckerSettings
     /**
      * Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.
      * @scope resource
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default true
      */
     useLocallyInstalledCSpellDictionaries?: boolean;
@@ -359,7 +359,7 @@ export interface SpellCheckerSettings
      * - [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)
      * - [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)
      * @scope window
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default true
      */
     trustedWorkspace?: boolean;
@@ -434,7 +434,7 @@ export interface SpellCheckerBehaviorSettings {
      * See: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.
      * @title Hide Issues While Typing
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default "Word"
      * @enumDescriptions [
      *  "Show issues while typing",
@@ -448,7 +448,7 @@ export interface SpellCheckerBehaviorSettings {
      * Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.
      * @title Reveal Issues After a Delay in Milliseconds
      * @scope application
-     * @since 4.0.0
+     * @sinceVersion 4.0.0
      * @default 1500
      */
     revealIssuesAfterDelayMS?: number;
@@ -464,7 +464,7 @@ export interface SpellCheckerBehaviorSettings {
      *
      * @title Enabled Notifications
      * @scope resource
-     * @since 4.0.41
+     * @sinceVersion 4.0.41
      * @default { "Lines too Long": true, "Average Word Length too Long": true, "Maximum Word Length Exceeded": true }
      */
     enabledNotifications?: EnabledNotifications;
@@ -524,7 +524,7 @@ export type UnknownWordsReportingLevel = 'all' | 'simple' | 'typos' | 'flagged';
  * Control which notifications are displayed.
  * @title Enabled Notifications
  * @scope resource
- * @since 4.0.41
+ * @sinceVersion 4.0.41
  */
 export interface EnabledNotifications {
     /**

--- a/website/_scripts/extract-config.mjs
+++ b/website/_scripts/extract-config.mjs
@@ -228,7 +228,8 @@ function configDefinitions(entries, refs) {
 function definition(entry, refs) {
     const [key, value] = entry;
     const description = value.markdownDescription || value.description || value.title || '';
-    const since = value.since || '';
+    const since = value.sinceVersion || '';
+    const sinceCSpellVersion = value.since || '';
     const defaultValue = formatDefaultValue(value.default);
 
     const title = value.title ? `-- ${value.title}` : '';
@@ -256,7 +257,9 @@ function definition(entry, refs) {
 
         ${singleDef('Default', defaultValue, true)}
 
-        ${since ? singleDef('Since Version', since) : ''}
+        ${since ? singleDef('Since Extension Version', since) : ''}
+
+        ${sinceCSpellVersion ? singleDef('CSpell Version', sinceCSpellVersion) : ''}
 
         </dl>
 


### PR DESCRIPTION
`@since` collided with cspell api versioning. This is to make sure they are not the same.

BEGIN_COMMIT_OVERRIDE
fix: Use `sinceVersion` instead of `since` to avoid collisions.
END_COMMIT_OVERRIDE