### PR TITLE
fix: Add usePnP to restrictedConfigurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "supported": "limited",
       "description": "JavaScript configuration files will NOT be loaded.",
       "restrictedConfigurations": [
-        "cSpell.trustedWorkspace"
+        "cSpell.trustedWorkspace",
+        "cSpell.usePnP"
       ]
     }
   },


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` configuration. The change adds `"cSpell.usePnP"` to the list of restricted configurations, ensuring this setting is also restricted in the workspace.

* Added `"cSpell.usePnP"` to the `restrictedConfigurations` array in `package.json` to further restrict unsupported settings.