### PR TITLE
chore: Update inject-markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-plugin-simple-import-sort": "^14.0.0",
         "eslint-plugin-unicorn": "^73.0.0",
         "globals": "^17.11.0",
-        "inject-markdown": "^4.0.0",
+        "inject-markdown": "^5.0.3",
         "jest-mock-vscode": "^4.13.0",
         "ovsx": "^1.1.1",
         "patch-package": "^8.0.1",
@@ -17971,25 +17971,25 @@
       }
     },
     "node_modules/inject-markdown": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/inject-markdown/-/inject-markdown-4.0.0.tgz",
-      "integrity": "sha512-22LnlffSjyDEXWkjHIKLJcLFQXV7CVf/QC58rRkVROQNml7M1MW0L8wfmpQyp8YxgtOOBVDk06ki9n7QeeB4bg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/inject-markdown/-/inject-markdown-5.0.3.tgz",
+      "integrity": "sha512-vuNDXl2xD2PsZZ1QgdnAB0DOAEKgZZTrS5LlNraZpYJrQU48/3LUQBoBksHvLOARwp40BlTgEec5ZFPdKkVOpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^14.0.0",
-        "globby": "^14.1.0",
+        "chalk": "^6.0.0",
+        "commander": "^15.0.0",
+        "globby": "^16.2.4",
         "node-fetch": "^3.3.2",
         "remark": "^15.0.1",
+        "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
-        "remark-mdx": "^3.1.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
         "unified": "^11.0.5",
-        "unist-util-is": "^6.0.0",
+        "unist-util-is": "^6.0.1",
         "unist-util-remove": "^4.0.0",
-        "unist-util-visit": "^5.0.0",
+        "unist-util-visit": "^5.1.0",
         "vfile": "^6.0.3",
         "vfile-reporter": "^8.1.1"
       },
@@ -17997,30 +17997,101 @@
         "inject-markdown": "bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
-    "node_modules/inject-markdown/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+    "node_modules/inject-markdown/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inject-markdown/node_modules/chalk": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/inject-markdown/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/inject-markdown/node_modules/globby": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.4.tgz",
+      "integrity": "sha512-c8B/VNLmxRcmqqenRA9t+9IyOjf9+V6lTxPaUJLqOCONdQkWZ0ETYgX0qbtJqPsgCNusT9MZ5Jeidw8Eb9tn2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "micromatch": "^4.0.8",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inject-markdown/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inject-markdown/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inject-markdown/node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inline-style-parser": {

--- a/package.json
+++ b/package.json
@@ -4652,7 +4652,7 @@
     "eslint-plugin-simple-import-sort": "^14.0.0",
     "eslint-plugin-unicorn": "^73.0.0",
     "globals": "^17.11.0",
-    "inject-markdown": "^4.0.0",
+    "inject-markdown": "^5.0.3",
     "jest-mock-vscode": "^4.13.0",
     "ovsx": "^1.1.1",
     "patch-package": "^8.0.1",

--- a/website/docs/extensions.md
+++ b/website/docs/extensions.md
@@ -3,10 +3,6 @@ title: Dictionary Extensions
 id: extensions
 ---
 
----
-
----
-
 # Extensions
 
 <!--- cspell:disable --->

--- a/website/src/pages/index.md
+++ b/website/src/pages/index.md
@@ -5,10 +5,6 @@ description: 'Spelling Checker for Visual Studio Code'
 permalink: /
 ---
 
----
-
----
-
 <!--- @@inject: ../../../README.md --->
 
 # Spelling Checker for Visual Studio Code


### PR DESCRIPTION
This pull request includes minor updates to dependencies and documentation formatting. The most important changes are:

Dependency updates:

* Updated the `inject-markdown` package from version 4.0.0 to 5.0.3 in `package.json` to ensure compatibility and receive the latest fixes.

Documentation cleanup:

* Removed extra separator lines at the top of `website/docs/extensions.md` for cleaner formatting.
* Removed extra separator lines at the top of `website/src/pages/index.md` for improved formatting.