### PR TITLE
docs: Add config folder precedence for cspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Order of precedence:
 
 1. Workspace Folder `cspell.json`
 1. Workspace Folder `.vscode/cspell.json`
+1. Config Folder `.config/cspell.json`
 1. VS Code Preferences `cSpell` section.
 
 ### Adding words to the Workspace Dictionary


### PR DESCRIPTION
This pull request updates the documentation to clarify the order of configuration file precedence for CSpell. It adds `.config/cspell.json` to the list of recognized configuration file locations.

Documentation update:

* Added `.config/cspell.json` as a recognized configuration file in the "Order of precedence" list in `README.md`.