### PR TITLE
fix: Auto update release notes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -94,6 +94,14 @@ jobs:
       OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}
       VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
 
+  release-notes:
+    needs:
+      - release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    uses: ./.github/workflows/release-notes.yml
+    with:
+      ref: ${{ needs.release-please.outputs.tag_name }}
+
   label:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
This pull request updates the release workflow to automate the creation of release notes after a new release is created. The main change is the addition of a new job to trigger the `release-notes.yml` workflow when a release is published.

Release automation improvements:

* Added a `release-notes` job to `.github/workflows/release-please.yml` that runs after a release is created, triggering the `release-notes.yml` workflow with the new tag as input.