### PR TITLE
Add configurable spell-check trigger characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.playwright-mcp
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -4395,6 +4395,16 @@
             "scope": "application",
             "type": "number"
           },
+          "cSpell.spellCheckTriggerCharacters": {
+            "default": [],
+            "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+            "scope": "application",
+            "type": "array"
+          },
           "cSpell.suggestionsTimeout": {
             "default": 400,
             "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",

--- a/package.json
+++ b/package.json
@@ -4397,11 +4397,10 @@
           },
           "cSpell.spellCheckTriggerCharacters": {
             "default": [],
-            "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+            "markdownDescription": "Characters that trigger spell checking after a document change.\nWhen set, changes that do not contain one of these characters are not checked.\n\n **Example:** check after spaces or new lines\n ```json\n \"cSpell.spellCheckTriggerCharacters\": [\" \", \"\\n\"]\n ```\n\n Letter-only edits use the configured spell-check delay; matching characters trigger an immediate check.",
             "scope": "application",
             "type": "array"
           },

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1710,15 +1710,6 @@
           "scope": "resource",
           "type": "array"
         },
-        "cSpell.spellCheckTriggerCharacters": {
-          "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Characters that trigger spell checking after a document change.\nWhen set, changes that do not contain one of these characters are not checked.",
-          "scope": "application",
-          "type": "array"
-        },
         "cSpell.substitutionDefinitions": {
           "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
           "items": {
@@ -4247,6 +4238,16 @@
           "markdownDescription": "Delay in ms after a document has changed before checking it for spelling errors.",
           "scope": "application",
           "type": "number"
+        },
+        "cSpell.spellCheckTriggerCharacters": {
+          "default": [],
+          "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.\n\n **Example:** check after spaces or new lines  ```json  \"cSpell.spellCheckTriggerCharacters\": [\" \", \"\\n\"]  ```\n\n Letter-only edits use the configured spell-check delay; matching characters trigger an immediate check.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Characters that trigger spell checking after a document change.\nWhen set, changes that do not contain one of these characters are not checked.\n\n **Example:** check after spaces or new lines\n ```json\n \"cSpell.spellCheckTriggerCharacters\": [\" \", \"\\n\"]\n ```\n\n Letter-only edits use the configured spell-check delay; matching characters trigger an immediate check.",
+          "scope": "application",
+          "type": "array"
         },
         "cSpell.suggestionsTimeout": {
           "default": 400,

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -4248,16 +4248,6 @@
           "scope": "application",
           "type": "number"
         },
-        "cSpell.spellCheckTriggerCharacters": {
-          "default": [],
-          "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
-          "scope": "application",
-          "type": "array"
-        },
         "cSpell.suggestionsTimeout": {
           "default": 400,
           "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -1710,6 +1710,15 @@
           "scope": "resource",
           "type": "array"
         },
+        "cSpell.spellCheckTriggerCharacters": {
+          "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Characters that trigger spell checking after a document change.\nWhen set, changes that do not contain one of these characters are not checked.",
+          "scope": "application",
+          "type": "array"
+        },
         "cSpell.substitutionDefinitions": {
           "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
           "items": {
@@ -4238,6 +4247,16 @@
           "markdownDescription": "Delay in ms after a document has changed before checking it for spelling errors.",
           "scope": "application",
           "type": "number"
+        },
+        "cSpell.spellCheckTriggerCharacters": {
+          "default": [],
+          "description": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Characters that trigger spell checking after a document change. When set, changes that do not contain one of these characters are not checked.",
+          "scope": "application",
+          "type": "array"
         },
         "cSpell.suggestionsTimeout": {
           "default": 400,

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -153,6 +153,13 @@ export interface SpellCheckerSettings
     spellCheckDelayMs?: number;
 
     /**
+     * Characters that trigger spell checking after a document change.
+     * When set, changes that do not contain one of these characters are not checked.
+     * @scope application
+     */
+    spellCheckTriggerCharacters?: string[];
+
+    /**
      * Use Rename Provider when fixing spelling issues.
      * @scope language-overridable
      * @default true

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -155,7 +155,15 @@ export interface SpellCheckerSettings
     /**
      * Characters that trigger spell checking after a document change.
      * When set, changes that do not contain one of these characters are not checked.
+     *
+     * **Example:** check after spaces or new lines
+     * ```json
+     * "cSpell.spellCheckTriggerCharacters": [" ", "\n"]
+     * ```
+     *
+     * Letter-only edits use the configured spell-check delay; matching characters trigger an immediate check.
      * @scope application
+     * @default []
      */
     spellCheckTriggerCharacters?: string[];
 

--- a/packages/_server/src/config/cspellConfig/configFields.mts
+++ b/packages/_server/src/config/cspellConfig/configFields.mts
@@ -48,6 +48,7 @@ export const ConfigFields: CSpellUserSettingsFields = {
     showStatusAlignment: 'showStatusAlignment',
     showSuggestionsLinkInEditorContextMenu: 'showSuggestionsLinkInEditorContextMenu',
     spellCheckDelayMs: 'spellCheckDelayMs',
+    spellCheckTriggerCharacters: 'spellCheckTriggerCharacters',
     spellCheckOnlyWorkspaceFiles: 'spellCheckOnlyWorkspaceFiles',
     suggestionMenuType: 'suggestionMenuType',
     suggestionNumChanges: 'suggestionNumChanges',

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -191,6 +191,7 @@ type _VSConfigPerf = Pick<
     | 'blockCheckingWhenTextChunkSizeGreaterThan'
     | 'checkLimit'
     | 'spellCheckDelayMs'
+    | 'spellCheckTriggerCharacters'
     | 'suggestionsTimeout'
 >;
 

--- a/packages/_server/src/server.mts
+++ b/packages/_server/src/server.mts
@@ -6,7 +6,7 @@ import * as CSpell from 'cspell-lib';
 import { extractImportErrors, getDefaultSettings, refreshDictionaryCache } from 'cspell-lib';
 import type { Subscription } from 'rxjs';
 import { interval, ReplaySubject } from 'rxjs';
-import { debounceTime, filter, mergeMap, take, tap, throttle, throttleTime } from 'rxjs/operators';
+import { debounceTime, filter, mergeMap, take, tap, throttle } from 'rxjs/operators';
 import type { DisposableLike } from 'utils-disposables';
 import { createDisposableList } from 'utils-disposables';
 import { LogLevelMasks } from 'utils-logger';
@@ -81,6 +81,10 @@ const defaultDebounceMs = 50;
 // Refresh the dictionary cache every 1000ms.
 const dictionaryRefreshRateMs = 10000;
 
+function containsSpellCheckTrigger(text: string, triggerCharacters: string[] | undefined): boolean {
+    return !!triggerCharacters?.length && triggerCharacters.some((character) => text.includes(character));
+}
+
 async function calcDefaultSettings(): Promise<CSpellUserAndExtensionSettings> {
     return {
         ...CSpell.mergeSettings(
@@ -107,11 +111,13 @@ const knownDiagnosticSeverityLevels: Set<number | undefined> = new Set([
 export function run(): void {
     // debounce buffer
     const disposables = createDisposableList();
-    const validationRequestStream: ReplaySubject<TextDocument> = new ReplaySubject(1);
+    const validationRequestStream: ReplaySubject<{ document: TextDocument; contentChanges?: readonly { text: string }[] }> =
+        new ReplaySubject(1);
     const triggerUpdateConfig: ReplaySubject<void> = new ReplaySubject(1);
     const triggerValidateAll: ReplaySubject<void> = new ReplaySubject(1);
     const validationByDoc: Map<string, Subscription> = new Map();
     const blockValidation: Map<string, number> = new Map();
+    const contentChangesByDoc = new Map<string, readonly { text: string }[]>();
     let isValidationBusy = false;
     const dictionaryWatcher = dd(new DictionaryWatcher());
     dd(disposeValidationByDoc);
@@ -225,40 +231,54 @@ export function run(): void {
 
     // validate documents
     ds(
-        validationRequestStream.pipe(filter((doc) => !validationByDoc.has(doc.uri))).subscribe((doc) => {
-            if (validationByDoc.has(doc.uri)) return;
-            const uri = doc.uri;
+        validationRequestStream.pipe(filter(({ document }) => !validationByDoc.has(document.uri))).subscribe((request) => {
+            if (validationByDoc.has(request.document.uri)) return;
+            const uri = request.document.uri;
 
             log('Register Document Handler:', uri);
 
             if (isUriBlockedBySettings(uri, {})) {
                 validationByDoc.set(
-                    doc.uri,
+                    request.document.uri,
                     validationRequestStream
                         .pipe(
-                            filter((doc) => uri === doc.uri),
+                            filter(({ document }) => uri === document.uri),
                             take(1),
-                            tap((doc) => progressNotifier.emitSpellCheckDocumentStep(doc, 'ignore')),
-                            tap((doc) => log('Ignoring:', doc.uri)),
+                            tap(({ document }) => progressNotifier.emitSpellCheckDocumentStep(document, 'ignore')),
+                            tap(({ document }) => log('Ignoring:', document.uri)),
                         )
                         .subscribe(),
                 );
             } else {
                 validationByDoc.set(
-                    doc.uri,
+                    request.document.uri,
                     validationRequestStream
                         .pipe(
-                            filter((doc) => uri === doc.uri),
-                            tap((doc) => progressNotifier.emitSpellCheckDocumentStep(doc, 'start')),
-                            tap((doc) => log(`Request Validate: v${doc.version}`, doc.uri)),
+                            filter(({ document }) => uri === document.uri),
+                            tap(({ document }) => progressNotifier.emitSpellCheckDocumentStep(document, 'start')),
+                            tap(({ document }) => log(`Request Validate: v${document.version}`, document.uri)),
                         )
                         .pipe(
-                            throttleTime(defaultDebounceMs, undefined, { leading: true, trailing: true }),
-                            mergeMap(async (doc) => ({ doc, settings: await getActiveSettings(doc) }) as DocSettingPair),
+                            mergeMap(async (request) => ({
+                                doc: request.document,
+                                contentChanges: request.contentChanges,
+                                settings: await getActiveSettings(request.document),
+                            })),
                             tap((dsp) => progressNotifier.emitSpellCheckDocumentStep(dsp.doc, 'settings determined')),
+                            filter(({ contentChanges, settings }) =>
+                                !contentChanges ||
+                                !settings.spellCheckTriggerCharacters?.length ||
+                                contentChanges.some(({ text }) =>
+                                    containsSpellCheckTrigger(text, settings.spellCheckTriggerCharacters),
+                                ),
+                            ),
                             throttle(
                                 (dsp) =>
-                                    interval(dsp.settings.spellCheckDelayMs || defaultDebounceMs).pipe(filter(() => !isValidationBusy)),
+                                    interval(
+                                        dsp.contentChanges && dsp.settings.spellCheckTriggerCharacters?.length
+                                            ? 0
+                                            : dsp.settings.spellCheckDelayMs || defaultDebounceMs,
+                                    ).pipe(filter(() => !isValidationBusy)),
                                 { leading: true, trailing: true },
                             ),
                             filter((dsp) => !blockValidation.has(dsp.doc.uri)),
@@ -287,7 +307,7 @@ export function run(): void {
     ds(
         triggerValidateAll.pipe(debounceTime(250)).subscribe(() => {
             log('Validate all documents');
-            documents.all().forEach((doc) => validationRequestStream.next(doc));
+            documents.all().forEach((document) => validationRequestStream.next({ document }));
         }),
     );
 
@@ -295,13 +315,20 @@ export function run(): void {
 
     // Make the text document manager listen on the connection
     // for open, change and close text document events
+    connection.onDidChangeTextDocument((event) => {
+        contentChangesByDoc.set(event.textDocument.uri, event.contentChanges);
+    });
     dd(documents.listen(connection));
 
     disposables.push(
         // The content of a text document has changed. This event is emitted
         // when the text document first opened or when its content has changed.
         documents.onDidChangeContent((event) => {
-            validationRequestStream.next(event.document);
+            validationRequestStream.next({
+                document: event.document,
+                contentChanges: contentChangesByDoc.get(event.document.uri),
+            });
+            contentChangesByDoc.delete(event.document.uri);
         }),
 
         // We want to block validation during saving.
@@ -316,7 +343,7 @@ export function run(): void {
             const { uri, version } = event.document;
             log(`onDidSave: v${version}`, uri);
             blockValidation.delete(uri);
-            validationRequestStream.next(event.document);
+            validationRequestStream.next({ document: event.document });
         }),
 
         // Remove subscriptions when a document closes.

--- a/packages/_server/src/server.mts
+++ b/packages/_server/src/server.mts
@@ -6,7 +6,7 @@ import * as CSpell from 'cspell-lib';
 import { extractImportErrors, getDefaultSettings, refreshDictionaryCache } from 'cspell-lib';
 import type { Subscription } from 'rxjs';
 import { interval, ReplaySubject } from 'rxjs';
-import { debounceTime, filter, mergeMap, take, tap, throttle } from 'rxjs/operators';
+import { debounceTime, filter, mergeMap, take, tap, throttle, throttleTime } from 'rxjs/operators';
 import type { DisposableLike } from 'utils-disposables';
 import { createDisposableList } from 'utils-disposables';
 import { LogLevelMasks } from 'utils-logger';
@@ -81,8 +81,27 @@ const defaultDebounceMs = 50;
 // Refresh the dictionary cache every 1000ms.
 const dictionaryRefreshRateMs = 10000;
 
-function containsSpellCheckTrigger(text: string, triggerCharacters: string[] | undefined): boolean {
+export function containsSpellCheckTrigger(text: string, triggerCharacters: string[] | undefined): boolean {
     return !!triggerCharacters?.length && triggerCharacters.some((character) => text.includes(character));
+}
+
+export function shouldTriggerSpellCheck(
+    contentChanges: readonly { text: string }[] | undefined,
+    triggerCharacters: string[] | undefined,
+): boolean {
+    return (
+        !contentChanges ||
+        !triggerCharacters?.length ||
+        contentChanges.some(({ text }) => containsSpellCheckTrigger(text, triggerCharacters))
+    );
+}
+
+export function getSpellCheckDelayMs(
+    contentChanges: readonly { text: string }[] | undefined,
+    triggerCharacters: string[] | undefined,
+    spellCheckDelayMs: number | undefined,
+): number {
+    return contentChanges && triggerCharacters?.length ? 0 : spellCheckDelayMs || defaultDebounceMs;
 }
 
 async function calcDefaultSettings(): Promise<CSpellUserAndExtensionSettings> {
@@ -133,7 +152,13 @@ export function run(): void {
     const _logger = createPrecisionLogger().setLogLevelMask(LogLevelMasks.none);
 
     // Create a simple text document manager.
-    const documents = new TextDocuments(TextDocument);
+    const documents = new TextDocuments({
+        create: (uri, languageId, version, text) => TextDocument.create(uri, languageId, version, text),
+        update: (document, changes, version) => {
+            contentChangesByDoc.set(document.uri, changes);
+            return TextDocument.update(document, changes, version);
+        },
+    });
 
     const handlers: PartialServerSideHandlers = {
         serverNotifications: {
@@ -266,18 +291,16 @@ export function run(): void {
                             })),
                             tap((dsp) => progressNotifier.emitSpellCheckDocumentStep(dsp.doc, 'settings determined')),
                             filter(({ contentChanges, settings }) =>
-                                !contentChanges ||
-                                !settings.spellCheckTriggerCharacters?.length ||
-                                contentChanges.some(({ text }) =>
-                                    containsSpellCheckTrigger(text, settings.spellCheckTriggerCharacters),
-                                ),
+                                shouldTriggerSpellCheck(contentChanges, settings.spellCheckTriggerCharacters),
                             ),
                             throttle(
                                 (dsp) =>
                                     interval(
-                                        dsp.contentChanges && dsp.settings.spellCheckTriggerCharacters?.length
-                                            ? 0
-                                            : dsp.settings.spellCheckDelayMs || defaultDebounceMs,
+                                        getSpellCheckDelayMs(
+                                            dsp.contentChanges,
+                                            dsp.settings.spellCheckTriggerCharacters,
+                                            dsp.settings.spellCheckDelayMs,
+                                        ),
                                     ).pipe(filter(() => !isValidationBusy)),
                                 { leading: true, trailing: true },
                             ),
@@ -315,9 +338,6 @@ export function run(): void {
 
     // Make the text document manager listen on the connection
     // for open, change and close text document events
-    connection.onDidChangeTextDocument((event) => {
-        contentChangesByDoc.set(event.textDocument.uri, event.contentChanges);
-    });
     dd(documents.listen(connection));
 
     disposables.push(

--- a/packages/_server/src/server.test.mts
+++ b/packages/_server/src/server.test.mts
@@ -1,10 +1,31 @@
 import { describe, expect, test } from 'vitest';
 
-import { run } from './server.mjs';
+import { getSpellCheckDelayMs, run, shouldTriggerSpellCheck } from './server.mjs';
 
 describe('Validate Server', () => {
     test('run', () => {
         // place holder
         expect(run).toBeDefined();
+    });
+
+    test('does not trigger for letter-only edits', () => {
+        expect(shouldTriggerSpellCheck([{ text: 'a' }], [' ', '\n'])).toBe(false);
+    });
+
+    test('triggers for a space edit', () => {
+        expect(shouldTriggerSpellCheck([{ text: 'word ' }], [' ', '\n'])).toBe(true);
+    });
+
+    test('triggers for a newline edit', () => {
+        expect(shouldTriggerSpellCheck([{ text: '\n' }], [' ', '\n'])).toBe(true);
+    });
+
+    test('checks all changes in a multi-change edit', () => {
+        expect(shouldTriggerSpellCheck([{ text: ' ' }, { text: 'word' }], [' ', '\n'])).toBe(true);
+    });
+
+    test('an empty trigger list preserves the configured delay', () => {
+        expect(shouldTriggerSpellCheck([{ text: 'a' }], [])).toBe(true);
+        expect(getSpellCheckDelayMs([{ text: 'a' }], [], 250)).toBe(250);
     });
 });

--- a/website/docs/configuration/auto_performance.md
+++ b/website/docs/configuration/auto_performance.md
@@ -17,6 +17,7 @@ Settings that control the performance of the spell checker.
 | [`cSpell.blockCheckingWhenTextChunkSizeGreaterThan`](#cspellblockcheckingwhentextchunksizegreaterthan) | language-overridable | The maximum length of a chunk of text without word breaks. |
 | [`cSpell.checkLimit`](#cspellchecklimit) | resource | Set the maximum number of blocks of text to check. Each block is 1024 characters. |
 | [`cSpell.spellCheckDelayMs`](#cspellspellcheckdelayms) | application | Delay in ms after a document has changed before checking it for spelling errors. |
+| [`cSpell.spellCheckTriggerCharacters`](#cspellspellchecktriggercharacters) | application | Characters that trigger spell checking after a document change. When set, changes that do not… |
 | [`cSpell.suggestionsTimeout`](#cspellsuggestionstimeout) | resource | The maximum amount of time in milliseconds to generate suggestions for a word. |
 
 
@@ -315,6 +316,68 @@ Default
 <dd>
 
 _`50`_
+
+</dd>
+
+</dl>
+
+---
+
+
+### `cSpell.spellCheckTriggerCharacters`
+
+<dl>
+
+<dt>
+Name
+</dt>
+<dd>
+
+`cSpell.spellCheckTriggerCharacters`
+
+</dd>
+
+<dt>
+Description
+</dt>
+<dd>
+
+Characters that trigger spell checking after a document change.
+When set, changes that do not contain one of these characters are not checked.
+
+ **Example:** check after spaces or new lines
+ ```json
+ "cSpell.spellCheckTriggerCharacters": [" ", "\n"]
+ ```
+
+ Letter-only edits use the configured spell-check delay; matching characters trigger an immediate check.
+
+</dd>
+
+<dt>
+Type
+</dt>
+<dd>
+
+`string[]`
+
+</dd>
+
+<dt>
+Scope
+</dt>
+<dd>
+
+application - Settings that apply to all instances of VS Code and can only be configured in user settings.
+
+</dd>
+
+<dt>
+Default
+</dt>
+<dd>
+
+_`[  ]`_
 
 </dd>
 


### PR DESCRIPTION
**What**

Adds a new setting to control which characters trigger spell checking:

```json
"cSpell.spellCheckTriggerCharacters": [" ", "\n"]
```

**Why**

I did not like seeing spelling warnings while I was still typing a word. I wanted spell checking to happen between words and at the start of new paragraphs.

> Disables checking spelling with delay when enabled

**Demo**

https://github.com/user-attachments/assets/0cfa947a-7989-4f52-8d9c-aa536e53095c


