### PR TITLE
chore: convert build-schema.mjs to TypeScript

### DIFF
--- a/packages/_server/package.json
+++ b/packages/_server/package.json
@@ -58,9 +58,9 @@
   "scripts": {
     "build": "tsdown && npm run build:tsc && npm run build-schema",
     "build-production": "npm run clean-build-production",
-    "build-schema": "node ./scripts/build-schema.mjs",
+    "build-schema": "node ./scripts/build-schema.mts",
     "build:production": "tsdown --production --minify && npm run build-schema",
-    "build:tsc": "tsc -p tsconfig.test.json",
+    "build:tsc": "tsc -p tsconfig.test.json && tsc -p scripts",
     "clean-build-production": "npm run clean && npm run build:production",
     "clean-build": "npm run clean && npm run build",
     "clean": "shx rm -rf dist temp out coverage lib",

--- a/packages/_server/scripts/build-schema.mts
+++ b/packages/_server/scripts/build-schema.mts
@@ -1,4 +1,3 @@
-// @ts-check
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -26,7 +25,7 @@ const rootDir = fileURLToPath(new URL('..', import.meta.url));
  * --validation-keywords since
  * -o spell-checker-config.schema.json
  */
-const config = defConfig({
+const config: tsj.Config = {
     path: p('src/config/cspellConfig/cspellConfig.mts'),
     tsconfig: p('tsconfig.schema.json'),
     type: 'SpellCheckerSettingsVSCode',
@@ -45,7 +44,7 @@ const config = defConfig({
         'since',
         'sinceVersion',
     ],
-});
+};
 
 const outputPath = p('spell-checker-config.schema.json');
 
@@ -53,30 +52,11 @@ const schema = tsj.createGenerator(config).createSchema(config.type);
 const schemaString = stringify(schema, null, 2) + '\n';
 await fs.writeFile(outputPath, cleanJson(schemaString));
 
-/**
- *
- * @param {string} filePath
- * @returns
- */
-function p(filePath) {
+function p(filePath: string): string {
     return path.resolve(rootDir, filePath);
 }
 
-/**
- *
- * @param {tsj.Config} a
- * @returns {tsj.Config}
- */
-function defConfig(a) {
-    return a;
-}
-
-/**
- *
- * @param {string} json
- * @returns
- */
-function cleanJson(json) {
+function cleanJson(json: string): string {
     /** Remove zero width space */
     return json.replaceAll(/\u200B/g, '');
 }

--- a/packages/_server/scripts/tsconfig.json
+++ b/packages/_server/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "target": "esnext",
+        "strict": true,
+        "noEmit": true,
+        "allowImportingTsExtensions": true,
+        "types": ["node"]
+    }
+}


### PR DESCRIPTION
This pull request updates the schema build tooling in the `_server` package to improve TypeScript support and streamline the build process. The main changes include converting the schema build script to TypeScript, updating related build scripts, and introducing a dedicated TypeScript configuration for scripts.

**Build tooling and script improvements:**

* Renamed `build-schema.mjs` to `build-schema.mts`, converting it from JavaScript to TypeScript, and updated type annotations and function signatures for better type safety. Removed unnecessary helper functions and improved code clarity. [[1]](diffhunk://#diff-d3bb32c27761c03ef52b920563c441694955fd31e529eaf3ab8a009dd5260038L1) [[2]](diffhunk://#diff-d3bb32c27761c03ef52b920563c441694955fd31e529eaf3ab8a009dd5260038L29-R28) [[3]](diffhunk://#diff-d3bb32c27761c03ef52b920563c441694955fd31e529eaf3ab8a009dd5260038L48-R59)
* Updated the `build-schema` script in `package.json` to use the new `.mts` TypeScript file.
* Enhanced the `build:tsc` script to compile both the main test config and the `scripts` directory, ensuring all TypeScript scripts are checked.
* Added a new `tsconfig.json` for the `scripts` directory with strict settings and Node compatibility to support TypeScript-based scripts.