### PR TITLE
chore: generate top level ref with definitions for web

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -12,6 +12,7 @@ ignorePaths:
   - '*.log'
   - '*.vsix'
   - '*.tsv'
+  - '*.schema.json'
   - '*.svg'
   - '**/__snapshots__/**'
   - '**/server.js'
@@ -32,7 +33,6 @@ ignorePaths:
   - packages/client/samples/**
   - packages/client/server/**
   - packages/webview-ui/public/assets/**
-  - spell-checker-config.schema.json
   - testFixtures
 ignoreWords: []
 dictionaryDefinitions:

--- a/packages/_server/scripts/build-schema.mts
+++ b/packages/_server/scripts/build-schema.mts
@@ -31,6 +31,7 @@ const config: tsj.Config = {
     type: 'SpellCheckerSettingsVSCode',
     topRef: false,
     expose: 'none',
+    skipTypeCheck: true,
     markdownDescription: true,
     sortProps: true,
     extraTags: [
@@ -46,11 +47,10 @@ const config: tsj.Config = {
     ],
 };
 
-const outputPath = p('spell-checker-config.schema.json');
-
-const schema = tsj.createGenerator(config).createSchema(config.type);
-const schemaString = stringify(schema, null, 2) + '\n';
-await fs.writeFile(outputPath, cleanJson(schemaString));
+const configWeb: tsj.Config = {
+    ...config,
+    topRef: true,
+};
 
 function p(filePath: string): string {
     return path.resolve(rootDir, filePath);
@@ -60,3 +60,16 @@ function cleanJson(json: string): string {
     /** Remove zero width space */
     return json.replaceAll(/\u200B/g, '');
 }
+
+async function genSchema(config: tsj.Config, outputPath: string) {
+    const schema = tsj.createGenerator(config).createSchema(config.type);
+    const schemaString = stringify(schema, null, 2) + '\n';
+    await fs.writeFile(outputPath, cleanJson(schemaString));
+}
+
+async function run() {
+    await genSchema(config, p('spell-checker-config.schema.json'));
+    await genSchema(configWeb, p('spell-checker-config-web.schema.json'));
+}
+
+run();

--- a/packages/_server/scripts/build-schema.mts
+++ b/packages/_server/scripts/build-schema.mts
@@ -50,6 +50,7 @@ const config: tsj.Config = {
 const configWeb: tsj.Config = {
     ...config,
     topRef: true,
+    // expose: 'export',
 };
 
 function p(filePath: string): string {

--- a/packages/_server/scripts/build-schema.mts
+++ b/packages/_server/scripts/build-schema.mts
@@ -50,7 +50,7 @@ const config: tsj.Config = {
 const configWeb: tsj.Config = {
     ...config,
     topRef: true,
-    // expose: 'export',
+    expose: 'export',
 };
 
 function p(filePath: string): string {

--- a/packages/_server/spell-checker-config-web.schema.json
+++ b/packages/_server/spell-checker-config-web.schema.json
@@ -1,0 +1,4471 @@
+{
+  "$ref": "#/definitions/SpellCheckerSettingsVSCode",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SpellCheckerSettingsVSCode": {
+      "items": [
+        {
+          "additionalProperties": false,
+          "description": "Settings that control the behavior of the spell checker.",
+          "order": 0,
+          "properties": {
+            "cSpell.enabled": {
+              "default": true,
+              "description": "Enable / Disable the spell checker.",
+              "markdownDescription": "Enable / Disable the spell checker.",
+              "scope": "resource",
+              "type": "boolean"
+            }
+          },
+          "title": "Code Spell Checker",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Advanced settings that are not commonly used.",
+          "order": 18,
+          "properties": {
+            "cSpell.advanced.feature.useReferenceProviderRemove": {
+              "description": "Used to work around bugs in Reference Providers and Rename Providers. Anything matching the provided Regular Expression will be removed from the text before sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at [Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
+              "markdownDescription": "Used to work around bugs in Reference Providers and Rename Providers.\nAnything matching the provided Regular Expression will be removed from the text\nbefore sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at\n[Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
+              "scope": "language-overridable",
+              "title": "Remove Matching Characters Before Rename",
+              "type": "string"
+            },
+            "cSpell.advanced.feature.useReferenceProviderWithRename": {
+              "default": false,
+              "description": "Use the Reference Provider when fixing spelling issues with the Rename Provider. This feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
+              "markdownDescription": "Use the Reference Provider when fixing spelling issues with the Rename Provider.\nThis feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
+              "scope": "language-overridable",
+              "title": "Use Reference Provider During Rename",
+              "type": "boolean"
+            },
+            "cSpell.fixSpellingWithRenameProvider": {
+              "default": true,
+              "description": "Use Rename Provider when fixing spelling issues.",
+              "markdownDescription": "Use Rename Provider when fixing spelling issues.",
+              "scope": "language-overridable",
+              "type": "boolean"
+            },
+            "cSpell.logFile": {
+              "description": "Have the logs written to a file instead of to VS Code.",
+              "markdownDescription": "Have the logs written to a file instead of to VS Code.",
+              "scope": "window",
+              "title": "Write Logs to a File",
+              "type": "string"
+            },
+            "cSpell.logLevel": {
+              "default": "Error",
+              "description": "Set the Debug Level for logging messages.",
+              "enum": [
+                "None",
+                "Error",
+                "Warning",
+                "Information",
+                "Debug"
+              ],
+              "enumDescriptions": [
+                "Do not log",
+                "Log only errors",
+                "Log errors and warnings",
+                "Log errors, warnings, and info",
+                "Log everything (noisy)"
+              ],
+              "markdownDescription": "Set the Debug Level for logging messages.",
+              "scope": "window",
+              "title": "Set Logging Level",
+              "type": "string"
+            },
+            "cSpell.trustedWorkspace": {
+              "default": true,
+              "description": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace, but a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
+              "markdownDescription": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace,\nbut a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
+              "scope": "window",
+              "sinceVersion": "4.0.0",
+              "type": "boolean"
+            }
+          },
+          "title": "Advanced",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings related to CSpell Command Line Tool.",
+          "order": 5,
+          "properties": {
+            "cSpell.engines": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "description": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
+                    "markdownDescription": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
+                    "type": "string"
+                  },
+                  {
+                    "not": {}
+                  }
+                ],
+                "description": "Other engine version predicates.",
+                "markdownDescription": "Other engine version predicates."
+              },
+              "description": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
+              "markdownDescription": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
+              "properties": {
+                "code-spell-checker": {
+                  "description": "The VSCode Spell Checker version predicate.",
+                  "markdownDescription": "The VSCode Spell Checker version predicate.",
+                  "since": "9.6.3",
+                  "type": "string"
+                },
+                "cspell": {
+                  "description": "CSpell version predicate.",
+                  "markdownDescription": "CSpell version predicate.",
+                  "since": "9.6.3",
+                  "type": "string"
+                }
+              },
+              "since": "9.6.3",
+              "type": "object"
+            },
+            "cSpell.ignoreRandomStrings": {
+              "default": true,
+              "description": "Ignore sequences of characters that look like random strings.",
+              "markdownDescription": "Ignore sequences of characters that look like random strings.",
+              "type": "boolean"
+            },
+            "cSpell.ignoreRegExpList": {
+              "description": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,   it is necessary to escape `\\`.   Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  | | :------------------ | :-------------------- | :------------------------------------------- | | `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         | | `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    | | `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,\n  it is necessary to escape `\\`.\n  Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  |\n| :------------------ | :-------------------- | :------------------------------------------- |\n| `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         |\n| `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    |\n| `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.includeRegExpList": {
+              "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.maxFileSize": {
+              "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+              "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+              "since": "9.4.0",
+              "type": [
+                "number",
+                "string"
+              ]
+            },
+            "cSpell.minRandomLength": {
+              "default": 40,
+              "description": "The minimum length of a random string to be ignored.",
+              "markdownDescription": "The minimum length of a random string to be ignored.",
+              "type": "number"
+            },
+            "cSpell.overrides": {
+              "description": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc \"cSpell.overrides\": [   // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:   {     \"filename\": \"**/{*.hrr,*.crr}\",     \"languageId\": \"cpp\"   },   // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):   {     \"filename\": \"**/dutch/**/*.txt\",     \"language\": \"nl\"   } ] ```",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "allowCompoundWords": {
+                    "default": false,
+                    "description": "True to enable compound word checking.",
+                    "markdownDescription": "True to enable compound word checking.",
+                    "type": "boolean"
+                  },
+                  "caseSensitive": {
+                    "default": false,
+                    "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                    "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "description": "Optional description of configuration.",
+                    "markdownDescription": "Optional description of configuration.",
+                    "type": "string"
+                  },
+                  "diagnosticLevel": {
+                    "default": "Information",
+                    "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                    "enum": [
+                      "Error",
+                      "Warning",
+                      "Information",
+                      "Hint"
+                    ],
+                    "enumDescriptions": [
+                      "Report Spelling Issues as Errors",
+                      "Report Spelling Issues as Warnings",
+                      "Report Spelling Issues as Information",
+                      "Report Spelling Issues as Hints, will not show up in Problems"
+                    ],
+                    "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                    "scope": "resource",
+                    "title": "Set Diagnostic Reporting Level",
+                    "type": "string"
+                  },
+                  "diagnosticLevelFlaggedWords": {
+                    "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                    "enum": [
+                      "Error",
+                      "Warning",
+                      "Information",
+                      "Hint"
+                    ],
+                    "enumDescriptions": [
+                      "Report Spelling Issues as Errors",
+                      "Report Spelling Issues as Warnings",
+                      "Report Spelling Issues as Information",
+                      "Report Spelling Issues as Hints, will not show up in Problems"
+                    ],
+                    "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                    "scope": "resource",
+                    "sinceVersion": "4.0.0",
+                    "title": "Set Diagnostic Reporting Level for Flagged Words",
+                    "type": "string"
+                  },
+                  "dictionaries": {
+                    "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        },
+                        {
+                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                    },
+                    "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                    "type": "array"
+                  },
+                  "dictionaryDefinitions": {
+                    "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "addWords": {
+                              "default": true,
+                              "description": "Indicate if this custom dictionary should be used to store added words.",
+                              "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                              "title": "Add Words to Dictionary",
+                              "type": "boolean"
+                            },
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional: A human readable description.",
+                              "markdownDescription": "Optional: A human readable description.",
+                              "title": "Description of the Dictionary",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                              "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                              "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                              "title": "Name of Dictionary",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                              "type": "string"
+                            },
+                            "scope": {
+                              "anyOf": [
+                                {
+                                  "description": "Specifies the scope of a dictionary.",
+                                  "enum": [
+                                    "user",
+                                    "workspace",
+                                    "folder"
+                                  ],
+                                  "markdownDescription": "Specifies the scope of a dictionary.",
+                                  "type": "string"
+                                },
+                                {
+                                  "items": {
+                                    "description": "Specifies the scope of a dictionary.",
+                                    "enum": [
+                                      "user",
+                                      "workspace",
+                                      "folder"
+                                    ],
+                                    "markdownDescription": "Specifies the scope of a dictionary.",
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              ],
+                              "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                              "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                              "title": "Scope of dictionary"
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional description of the contents / purpose of the dictionary.",
+                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Path or url to the dictionary file.",
+                              "markdownDescription": "Path or url to the dictionary file.",
+                              "type": "string"
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "addWords": {
+                              "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                              "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                              "type": "boolean"
+                            },
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional description of the contents / purpose of the dictionary.",
+                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "A file path or url to a custom dictionary file.",
+                              "markdownDescription": "A file path or url to a custom dictionary file.",
+                              "type": "string"
+                            },
+                            "scope": {
+                              "anyOf": [
+                                {
+                                  "description": "Specifies the scope of a dictionary.",
+                                  "enum": [
+                                    "user",
+                                    "workspace",
+                                    "folder"
+                                  ],
+                                  "markdownDescription": "Specifies the scope of a dictionary.",
+                                  "type": "string"
+                                },
+                                {
+                                  "items": {
+                                    "description": "Specifies the scope of a dictionary.",
+                                    "enum": [
+                                      "user",
+                                      "workspace",
+                                      "folder"
+                                    ],
+                                    "markdownDescription": "Specifies the scope of a dictionary.",
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              ],
+                              "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
+                              "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "addWords",
+                            "name"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                    "scope": "resource",
+                    "title": "Dictionary Definitions",
+                    "type": "array"
+                  },
+                  "enableFiletypes": {
+                    "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+                    "items": {
+                      "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                      "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                      "type": "string"
+                    },
+                    "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+                    "scope": "resource",
+                    "title": "Enable File Types",
+                    "type": "array",
+                    "uniqueItems": true
+                  },
+                  "enabled": {
+                    "default": true,
+                    "description": "Is the spell checker enabled.",
+                    "markdownDescription": "Is the spell checker enabled.",
+                    "type": "boolean"
+                  },
+                  "enabledFileTypes": {
+                    "additionalProperties": {
+                      "type": "boolean"
+                    },
+                    "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
+                    "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
+                    "since": "8.8.1",
+                    "title": "Enabled File Types to Check",
+                    "type": "object"
+                  },
+                  "enabledLanguageIds": {
+                    "description": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
+                    "items": {
+                      "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                      "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                      "type": "string"
+                    },
+                    "markdownDescription": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
+                    "title": "Enabled Language Ids",
+                    "type": "array",
+                    "uniqueItems": true
+                  },
+                  "filename": {
+                    "anyOf": [
+                      {
+                        "description": "These are glob expressions.",
+                        "markdownDescription": "These are glob expressions.",
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "description": "These are glob expressions.",
+                          "markdownDescription": "These are glob expressions.",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "Glob pattern or patterns to match against.",
+                    "markdownDescription": "Glob pattern or patterns to match against."
+                  },
+                  "flagWords": {
+                    "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "Optional identifier.",
+                    "markdownDescription": "Optional identifier.",
+                    "type": "string"
+                  },
+                  "ignoreRandomStrings": {
+                    "default": true,
+                    "description": "Ignore sequences of characters that look like random strings.",
+                    "markdownDescription": "Ignore sequences of characters that look like random strings.",
+                    "type": "boolean"
+                  },
+                  "ignoreRegExpList": {
+                    "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "description": "This matches the name in a pattern definition.",
+                          "markdownDescription": "This matches the name in a pattern definition.",
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "Base64",
+                            "Base64MultiLine",
+                            "Base64SingleLine",
+                            "CStyleComment",
+                            "CStyleHexValue",
+                            "CSSHexValue",
+                            "CommitHash",
+                            "CommitHashLink",
+                            "Email",
+                            "EscapeCharacters",
+                            "HexValues",
+                            "href",
+                            "PhpHereDoc",
+                            "PublicKey",
+                            "RsaCert",
+                            "SshRsa",
+                            "SHA",
+                            "HashStrings",
+                            "SpellCheckerDisable",
+                            "SpellCheckerDisableBlock",
+                            "SpellCheckerDisableLine",
+                            "SpellCheckerDisableNext",
+                            "SpellCheckerIgnoreInDocSetting",
+                            "string",
+                            "UnicodeRef",
+                            "Urls",
+                            "UUID",
+                            "Everything"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A PatternRef is a Pattern or PatternId.",
+                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                    },
+                    "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "type": "array"
+                  },
+                  "ignoreWords": {
+                    "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                    "type": "array"
+                  },
+                  "includeRegExpList": {
+                    "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "description": "This matches the name in a pattern definition.",
+                          "markdownDescription": "This matches the name in a pattern definition.",
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "Base64",
+                            "Base64MultiLine",
+                            "Base64SingleLine",
+                            "CStyleComment",
+                            "CStyleHexValue",
+                            "CSSHexValue",
+                            "CommitHash",
+                            "CommitHashLink",
+                            "Email",
+                            "EscapeCharacters",
+                            "HexValues",
+                            "href",
+                            "PhpHereDoc",
+                            "PublicKey",
+                            "RsaCert",
+                            "SshRsa",
+                            "SHA",
+                            "HashStrings",
+                            "SpellCheckerDisable",
+                            "SpellCheckerDisableBlock",
+                            "SpellCheckerDisableLine",
+                            "SpellCheckerDisableNext",
+                            "SpellCheckerIgnoreInDocSetting",
+                            "string",
+                            "UnicodeRef",
+                            "Urls",
+                            "UUID",
+                            "Everything"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A PatternRef is a Pattern or PatternId.",
+                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                    },
+                    "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "type": "array"
+                  },
+                  "language": {
+                    "description": "Sets the locale.",
+                    "markdownDescription": "Sets the locale.",
+                    "type": "string"
+                  },
+                  "languageId": {
+                    "anyOf": [
+                      {
+                        "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                        "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                        "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                        "type": "string"
+                      },
+                      {
+                        "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                        "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                        "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                        "type": "string"
+                      },
+                      {
+                        "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                        "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                        "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "Sets the programming language id to match file type.",
+                    "markdownDescription": "Sets the programming language id to match file type."
+                  },
+                  "languageSettings": {
+                    "description": "Additional settings for individual programming languages and locales.",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "allowCompoundWords": {
+                          "default": false,
+                          "description": "True to enable compound word checking.",
+                          "markdownDescription": "True to enable compound word checking.",
+                          "type": "boolean"
+                        },
+                        "caseSensitive": {
+                          "default": false,
+                          "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                          "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                          "type": "boolean"
+                        },
+                        "description": {
+                          "description": "Optional description of configuration.",
+                          "markdownDescription": "Optional description of configuration.",
+                          "type": "string"
+                        },
+                        "dictionaries": {
+                          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                                "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                                "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                                "type": "string"
+                              },
+                              {
+                                "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                                "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                                "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                            "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                          },
+                          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                          "type": "array"
+                        },
+                        "dictionaryDefinitions": {
+                          "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "addWords": {
+                                    "default": true,
+                                    "description": "Indicate if this custom dictionary should be used to store added words.",
+                                    "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                                    "title": "Add Words to Dictionary",
+                                    "type": "boolean"
+                                  },
+                                  "btrie": {
+                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                                    "since": "9.6.0",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "description": "Optional: A human readable description.",
+                                    "markdownDescription": "Optional: A human readable description.",
+                                    "title": "Description of the Dictionary",
+                                    "type": "string"
+                                  },
+                                  "ignoreForbiddenWords": {
+                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                                    "title": "Name of Dictionary",
+                                    "type": "string"
+                                  },
+                                  "noSuggest": {
+                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                                    "type": "boolean"
+                                  },
+                                  "path": {
+                                    "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                                    "type": "string"
+                                  },
+                                  "scope": {
+                                    "anyOf": [
+                                      {
+                                        "description": "Specifies the scope of a dictionary.",
+                                        "enum": [
+                                          "user",
+                                          "workspace",
+                                          "folder"
+                                        ],
+                                        "markdownDescription": "Specifies the scope of a dictionary.",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "items": {
+                                          "description": "Specifies the scope of a dictionary.",
+                                          "enum": [
+                                            "user",
+                                            "workspace",
+                                            "folder"
+                                          ],
+                                          "markdownDescription": "Specifies the scope of a dictionary.",
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    ],
+                                    "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                                    "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                                    "title": "Scope of dictionary"
+                                  },
+                                  "supportNonStrictSearches": {
+                                    "default": true,
+                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "name",
+                                  "path"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "btrie": {
+                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                                    "since": "9.6.0",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "description": "Optional description of the contents / purpose of the dictionary.",
+                                    "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                                    "type": "string"
+                                  },
+                                  "ignoreForbiddenWords": {
+                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                                    "type": "string"
+                                  },
+                                  "noSuggest": {
+                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                                    "type": "boolean"
+                                  },
+                                  "path": {
+                                    "description": "Path or url to the dictionary file.",
+                                    "markdownDescription": "Path or url to the dictionary file.",
+                                    "type": "string"
+                                  },
+                                  "supportNonStrictSearches": {
+                                    "default": true,
+                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "name"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "additionalProperties": false,
+                                "properties": {
+                                  "addWords": {
+                                    "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                                    "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                                    "type": "boolean"
+                                  },
+                                  "btrie": {
+                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                                    "since": "9.6.0",
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "description": "Optional description of the contents / purpose of the dictionary.",
+                                    "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                                    "type": "string"
+                                  },
+                                  "ignoreForbiddenWords": {
+                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                                    "type": "boolean"
+                                  },
+                                  "name": {
+                                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                                    "type": "string"
+                                  },
+                                  "noSuggest": {
+                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                                    "type": "boolean"
+                                  },
+                                  "path": {
+                                    "description": "A file path or url to a custom dictionary file.",
+                                    "markdownDescription": "A file path or url to a custom dictionary file.",
+                                    "type": "string"
+                                  },
+                                  "scope": {
+                                    "anyOf": [
+                                      {
+                                        "description": "Specifies the scope of a dictionary.",
+                                        "enum": [
+                                          "user",
+                                          "workspace",
+                                          "folder"
+                                        ],
+                                        "markdownDescription": "Specifies the scope of a dictionary.",
+                                        "type": "string"
+                                      },
+                                      {
+                                        "items": {
+                                          "description": "Specifies the scope of a dictionary.",
+                                          "enum": [
+                                            "user",
+                                            "workspace",
+                                            "folder"
+                                          ],
+                                          "markdownDescription": "Specifies the scope of a dictionary.",
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    ],
+                                    "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
+                                    "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
+                                  },
+                                  "supportNonStrictSearches": {
+                                    "default": true,
+                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "path",
+                                  "addWords",
+                                  "name"
+                                ],
+                                "type": "object"
+                              }
+                            ]
+                          },
+                          "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                          "scope": "resource",
+                          "title": "Dictionary Definitions",
+                          "type": "array"
+                        },
+                        "enabled": {
+                          "default": true,
+                          "description": "Is the spell checker enabled.",
+                          "markdownDescription": "Is the spell checker enabled.",
+                          "type": "boolean"
+                        },
+                        "flagWords": {
+                          "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                          "type": "array"
+                        },
+                        "id": {
+                          "description": "Optional identifier.",
+                          "markdownDescription": "Optional identifier.",
+                          "type": "string"
+                        },
+                        "ignoreRegExpList": {
+                          "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "description": "This matches the name in a pattern definition.",
+                                "markdownDescription": "This matches the name in a pattern definition.",
+                                "type": "string"
+                              },
+                              {
+                                "enum": [
+                                  "Base64",
+                                  "Base64MultiLine",
+                                  "Base64SingleLine",
+                                  "CStyleComment",
+                                  "CStyleHexValue",
+                                  "CSSHexValue",
+                                  "CommitHash",
+                                  "CommitHashLink",
+                                  "Email",
+                                  "EscapeCharacters",
+                                  "HexValues",
+                                  "href",
+                                  "PhpHereDoc",
+                                  "PublicKey",
+                                  "RsaCert",
+                                  "SshRsa",
+                                  "SHA",
+                                  "HashStrings",
+                                  "SpellCheckerDisable",
+                                  "SpellCheckerDisableBlock",
+                                  "SpellCheckerDisableLine",
+                                  "SpellCheckerDisableNext",
+                                  "SpellCheckerIgnoreInDocSetting",
+                                  "string",
+                                  "UnicodeRef",
+                                  "Urls",
+                                  "UUID",
+                                  "Everything"
+                                ],
+                                "type": "string"
+                              }
+                            ],
+                            "description": "A PatternRef is a Pattern or PatternId.",
+                            "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                          },
+                          "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                          "type": "array"
+                        },
+                        "ignoreWords": {
+                          "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                          "type": "array"
+                        },
+                        "includeRegExpList": {
+                          "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "description": "This matches the name in a pattern definition.",
+                                "markdownDescription": "This matches the name in a pattern definition.",
+                                "type": "string"
+                              },
+                              {
+                                "enum": [
+                                  "Base64",
+                                  "Base64MultiLine",
+                                  "Base64SingleLine",
+                                  "CStyleComment",
+                                  "CStyleHexValue",
+                                  "CSSHexValue",
+                                  "CommitHash",
+                                  "CommitHashLink",
+                                  "Email",
+                                  "EscapeCharacters",
+                                  "HexValues",
+                                  "href",
+                                  "PhpHereDoc",
+                                  "PublicKey",
+                                  "RsaCert",
+                                  "SshRsa",
+                                  "SHA",
+                                  "HashStrings",
+                                  "SpellCheckerDisable",
+                                  "SpellCheckerDisableBlock",
+                                  "SpellCheckerDisableLine",
+                                  "SpellCheckerDisableNext",
+                                  "SpellCheckerIgnoreInDocSetting",
+                                  "string",
+                                  "UnicodeRef",
+                                  "Urls",
+                                  "UUID",
+                                  "Everything"
+                                ],
+                                "type": "string"
+                              }
+                            ],
+                            "description": "A PatternRef is a Pattern or PatternId.",
+                            "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                          },
+                          "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                          "type": "array"
+                        },
+                        "languageId": {
+                          "anyOf": [
+                            {
+                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                              "type": "string"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                                    "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                                    "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                                    "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                                    "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                                    "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                                    "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                                    "type": "string"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
+                          "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
+                        },
+                        "locale": {
+                          "anyOf": [
+                            {
+                              "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                              "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                              "type": "string"
+                            },
+                            {
+                              "items": {
+                                "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                                "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
+                          "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
+                        },
+                        "name": {
+                          "description": "Optional name of configuration.",
+                          "markdownDescription": "Optional name of configuration.",
+                          "type": "string"
+                        },
+                        "noSuggestDictionaries": {
+                          "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                                "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                                "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                                "type": "string"
+                              },
+                              {
+                                "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                                "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                                "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                                "type": "string"
+                              }
+                            ],
+                            "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                            "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                          },
+                          "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                          "type": "array"
+                        },
+                        "patterns": {
+                          "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                          "items": {
+                            "additionalProperties": false,
+                            "properties": {
+                              "description": {
+                                "description": "Description of the pattern.",
+                                "markdownDescription": "Description of the pattern.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                                "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                                "type": "string"
+                              },
+                              "pattern": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                ],
+                                "description": "RegExp pattern or array of RegExp patterns.",
+                                "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "pattern"
+                            ],
+                            "type": "object"
+                          },
+                          "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                          "type": "array"
+                        },
+                        "substitutionDefinitions": {
+                          "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                          "items": {
+                            "additionalProperties": false,
+                            "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                            "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                            "properties": {
+                              "description": {
+                                "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                                "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                                "type": "string"
+                              },
+                              "entries": {
+                                "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                                "items": {
+                                  "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                                  "items": [
+                                    {
+                                      "title": "find",
+                                      "type": "string"
+                                    },
+                                    {
+                                      "title": "replacement",
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                                  "maxItems": 2,
+                                  "minItems": 2,
+                                  "since": "9.7.0",
+                                  "type": "array"
+                                },
+                                "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                                "type": "array"
+                              },
+                              "name": {
+                                "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                                "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                                "since": "9.7.0",
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "entries"
+                            ],
+                            "since": "9.7.0",
+                            "type": "object"
+                          },
+                          "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                          "since": "9.7.0",
+                          "type": "array"
+                        },
+                        "substitutions": {
+                          "description": "The set of substitutions to apply to a document before spell checking.",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                                "items": [
+                                  {
+                                    "title": "find",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "title": "replacement",
+                                    "type": "string"
+                                  }
+                                ],
+                                "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "since": "9.7.0",
+                                "type": "array"
+                              },
+                              {
+                                "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                                "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                                "since": "9.7.0",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+                          "since": "9.7.0",
+                          "type": "array"
+                        },
+                        "suggestWords": {
+                          "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                          "items": {
+                            "type": "string"
+                          },
+                          "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                          "type": "array"
+                        },
+                        "unknownWords": {
+                          "default": "report-all",
+                          "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                          "enum": [
+                            "report-all",
+                            "report-simple",
+                            "report-common-typos",
+                            "report-flagged"
+                          ],
+                          "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                          "since": "9.1.0",
+                          "type": "string"
+                        },
+                        "useIntlWordSegmentation": {
+                          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                          "since": "10.2.0",
+                          "type": "boolean"
+                        },
+                        "words": {
+                          "description": "List of words to be considered correct.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "markdownDescription": "List of words to be considered correct.",
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "languageId"
+                      ],
+                      "type": "object"
+                    },
+                    "markdownDescription": "Additional settings for individual programming languages and locales.",
+                    "scope": "resource",
+                    "type": "array"
+                  },
+                  "loadDefaultConfiguration": {
+                    "default": true,
+                    "description": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false` will prevent ALL default configuration from being loaded.",
+                    "markdownDescription": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false`\nwill prevent ALL default configuration from being loaded.",
+                    "type": "boolean"
+                  },
+                  "maxDuplicateProblems": {
+                    "default": 5,
+                    "description": "The maximum number of times the same word can be flagged as an error in a file.",
+                    "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
+                    "type": "number"
+                  },
+                  "maxFileSize": {
+                    "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+                    "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+                    "since": "9.4.0",
+                    "type": [
+                      "number",
+                      "string"
+                    ]
+                  },
+                  "maxNumberOfProblems": {
+                    "default": 10000,
+                    "description": "The maximum number of problems to report in a file.",
+                    "markdownDescription": "The maximum number of problems to report in a file.",
+                    "type": "number"
+                  },
+                  "minRandomLength": {
+                    "default": 40,
+                    "description": "The minimum length of a random string to be ignored.",
+                    "markdownDescription": "The minimum length of a random string to be ignored.",
+                    "type": "number"
+                  },
+                  "minWordLength": {
+                    "default": 4,
+                    "description": "The minimum length of a word before checking it against a dictionary.",
+                    "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
+                    "type": "number"
+                  },
+                  "name": {
+                    "description": "Optional name of configuration.",
+                    "markdownDescription": "Optional name of configuration.",
+                    "type": "string"
+                  },
+                  "noSuggestDictionaries": {
+                    "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        },
+                        {
+                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                    },
+                    "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                    "type": "array"
+                  },
+                  "numSuggestions": {
+                    "default": 10,
+                    "description": "Number of suggestions to make.",
+                    "markdownDescription": "Number of suggestions to make.",
+                    "type": "number"
+                  },
+                  "patterns": {
+                    "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "description": "Description of the pattern.",
+                          "markdownDescription": "Description of the pattern.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                          "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "RegExp pattern or array of RegExp patterns.",
+                          "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "pattern"
+                      ],
+                      "type": "object"
+                    },
+                    "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                    "type": "array"
+                  },
+                  "pnpFiles": {
+                    "default": [
+                      ".pnp.js",
+                      ".pnp.cjs"
+                    ],
+                    "description": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
+                    "type": "array"
+                  },
+                  "substitutionDefinitions": {
+                    "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                      "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                      "properties": {
+                        "description": {
+                          "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                          "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                          "type": "string"
+                        },
+                        "entries": {
+                          "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                          "items": {
+                            "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                            "items": [
+                              {
+                                "title": "find",
+                                "type": "string"
+                              },
+                              {
+                                "title": "replacement",
+                                "type": "string"
+                              }
+                            ],
+                            "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "since": "9.7.0",
+                            "type": "array"
+                          },
+                          "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "since": "9.7.0",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "entries"
+                      ],
+                      "since": "9.7.0",
+                      "type": "object"
+                    },
+                    "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                    "since": "9.7.0",
+                    "type": "array"
+                  },
+                  "substitutions": {
+                    "description": "The set of substitutions to apply to a document before spell checking.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                          "items": [
+                            {
+                              "title": "find",
+                              "type": "string"
+                            },
+                            {
+                              "title": "replacement",
+                              "type": "string"
+                            }
+                          ],
+                          "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                          "maxItems": 2,
+                          "minItems": 2,
+                          "since": "9.7.0",
+                          "type": "array"
+                        },
+                        {
+                          "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "since": "9.7.0",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+                    "since": "9.7.0",
+                    "type": "array"
+                  },
+                  "suggestWords": {
+                    "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                    "type": "array"
+                  },
+                  "suggestionNumChanges": {
+                    "default": 3,
+                    "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+                    "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+                    "type": "number"
+                  },
+                  "suggestionsTimeout": {
+                    "default": 500,
+                    "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+                    "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+                    "type": "number"
+                  },
+                  "unknownWords": {
+                    "default": "report-all",
+                    "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                    "enum": [
+                      "report-all",
+                      "report-simple",
+                      "report-common-typos",
+                      "report-flagged"
+                    ],
+                    "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                    "since": "9.1.0",
+                    "type": "string"
+                  },
+                  "useIntlWordSegmentation": {
+                    "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                    "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                    "since": "10.2.0",
+                    "type": "boolean"
+                  },
+                  "usePnP": {
+                    "default": false,
+                    "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
+                    "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
+                    "type": "boolean"
+                  },
+                  "words": {
+                    "description": "List of words to be considered correct.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to be considered correct.",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "filename"
+                ],
+                "type": "object"
+              },
+              "markdownDescription": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc\n\"cSpell.overrides\": [\n  // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:\n  {\n    \"filename\": \"**/{*.hrr,*.crr}\",\n    \"languageId\": \"cpp\"\n  },\n  // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):\n  {\n    \"filename\": \"**/dutch/**/*.txt\",\n    \"language\": \"nl\"\n  }\n]\n```",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.patterns": {
+              "description": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and `#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc \"cSpell.patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   } ] ```",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "description": {
+                    "description": "Description of the pattern.",
+                    "markdownDescription": "Description of the pattern.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                    "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                    "type": "string"
+                  },
+                  "pattern": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "RegExp pattern or array of RegExp patterns.",
+                    "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                  }
+                },
+                "required": [
+                  "name",
+                  "pattern"
+                ],
+                "type": "object"
+              },
+              "markdownDescription": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and\n`#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc\n\"cSpell.patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  }\n]\n```",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.substitutionDefinitions": {
+              "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+              "items": {
+                "additionalProperties": false,
+                "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                "properties": {
+                  "description": {
+                    "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                    "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                    "type": "string"
+                  },
+                  "entries": {
+                    "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                    "items": {
+                      "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                      "items": [
+                        {
+                          "title": "find",
+                          "type": "string"
+                        },
+                        {
+                          "title": "replacement",
+                          "type": "string"
+                        }
+                      ],
+                      "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "since": "9.7.0",
+                      "type": "array"
+                    },
+                    "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                    "type": "array"
+                  },
+                  "name": {
+                    "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                    "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                    "since": "9.7.0",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "entries"
+                ],
+                "since": "9.7.0",
+                "type": "object"
+              },
+              "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+              "since": "9.7.0",
+              "type": "array"
+            },
+            "cSpell.substitutions": {
+              "description": "The set of substitutions to apply to a document before spell checking.",
+              "items": {
+                "anyOf": [
+                  {
+                    "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                    "items": [
+                      {
+                        "title": "find",
+                        "type": "string"
+                      },
+                      {
+                        "title": "replacement",
+                        "type": "string"
+                      }
+                    ],
+                    "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "since": "9.7.0",
+                    "type": "array"
+                  },
+                  {
+                    "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                    "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                    "since": "9.7.0",
+                    "type": "string"
+                  }
+                ]
+              },
+              "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+              "since": "9.7.0",
+              "type": "array"
+            },
+            "cSpell.unknownWords": {
+              "default": "report-all",
+              "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+              "enum": [
+                "report-all",
+                "report-simple",
+                "report-common-typos",
+                "report-flagged"
+              ],
+              "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+              "since": "9.1.0",
+              "type": "string"
+            },
+            "cSpell.useIntlWordSegmentation": {
+              "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+              "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+              "since": "10.2.0",
+              "type": "boolean"
+            },
+            "cSpell.vfs": {
+              "additionalProperties": {
+                "additionalProperties": false,
+                "description": "An entry in the CSpell Virtual File System. It may or may not have a URL.",
+                "markdownDescription": "An entry in the CSpell Virtual File System.\nIt may or may not have a URL.",
+                "properties": {
+                  "data": {
+                    "description": "The content data of the file.",
+                    "markdownDescription": "The content data of the file.",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "description": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
+                    "enum": [
+                      "base64",
+                      "plaintext",
+                      "utf8"
+                    ],
+                    "markdownDescription": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
+                    "type": "string"
+                  },
+                  "url": {
+                    "description": "The optional file vfs url. It is already part of the CSpellVFS key.",
+                    "markdownDescription": "The optional file vfs url. It is already part of the CSpellVFS key.",
+                    "since": "9.7.0",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "data"
+                ],
+                "since": "9.7.0",
+                "type": "object"
+              },
+              "description": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
+              "markdownDescription": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
+              "since": "9.7.0",
+              "type": "object"
+            }
+          },
+          "title": "CSpell",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Experimental settings that may change or be removed in the future.",
+          "order": 19,
+          "properties": {
+            "cSpell.experimental.enableRegexpView": {
+              "default": false,
+              "description": "Show Regular Expression Explorer",
+              "markdownDescription": "Show Regular Expression Explorer",
+              "scope": "application",
+              "type": "boolean"
+            },
+            "cSpell.experimental.symbols": {
+              "default": false,
+              "description": "Experiment with executeDocumentSymbolProvider. This feature is experimental and will be removed in the future.",
+              "markdownDescription": "Experiment with executeDocumentSymbolProvider.\nThis feature is experimental and will be removed in the future.",
+              "scope": "application",
+              "title": "Experiment with `executeDocumentSymbolProvider`",
+              "type": "boolean"
+            },
+            "cSpell.reportUnknownWords": {
+              "deprecated": true,
+              "deprecationMessage": "Use Unknown Words settings instead.",
+              "description": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only reporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
+              "enum": [
+                "all",
+                "simple",
+                "typos",
+                "flagged"
+              ],
+              "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
+              "scope": "language-overridable",
+              "title": "Strict Spell Checking",
+              "type": "string"
+            }
+          },
+          "title": "Experimental",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings that control which files and folders are spell checked.",
+          "order": 3,
+          "properties": {
+            "cSpell.allowedSchemas": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.enabledSchemes#` instead.",
+              "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
+              "scope": "window",
+              "title": "Define Allowed Schemes",
+              "type": "array"
+            },
+            "cSpell.checkOnlyEnabledFileTypes": {
+              "default": true,
+              "description": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#` to turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`. See `#cSpell.enabledFileTypes#` on how to disable a file type.",
+              "markdownDescription": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`.\nSee `#cSpell.enabledFileTypes#` on how to disable a file type.",
+              "scope": "resource",
+              "title": "Check Only Enabled File Types",
+              "type": "boolean"
+            },
+            "cSpell.checkVSCodeSystemFiles": {
+              "default": false,
+              "description": "Spell check VS Code system files. These include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+              "markdownDescription": "Spell check VS Code system files.\nThese include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+              "scope": "application",
+              "type": "boolean"
+            },
+            "cSpell.enableFiletypes": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
+              "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`. To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+              "items": {
+                "description": "Enable / Disable checking file types (languageIds). To disable a language, prefix with `!` as in `!json`,\n\n\nExample: ``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```",
+                "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+                "pattern": "(^!*(?!\\s)[\\s\\w_.\\-]+$)|(^!*[*]$)",
+                "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
+                "type": "string"
+              },
+              "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`.\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+              "scope": "resource",
+              "title": "Enable File Types",
+              "type": "array",
+              "uniqueItems": true
+            },
+            "cSpell.enabledFileTypes": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "default": {
+                "*": true,
+                "markdown": true
+              },
+              "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
+              "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
+              "scope": "resource",
+              "title": "Enabled File Types to Check",
+              "type": "object"
+            },
+            "cSpell.enabledSchemes": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "default": {
+                "chatSessionInput": true,
+                "comment": true,
+                "file": true,
+                "gist": true,
+                "repo": true,
+                "sftp": true,
+                "untitled": true,
+                "vscode-notebook-cell": true,
+                "vscode-scm": true,
+                "vscode-userdata": true,
+                "vscode-vfs": true,
+                "vsls": true
+              },
+              "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry. This is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment | | ------ | ------- | ------- | | `*`    | `true`  | Enable all schemes. | | `git`  | `false` | Do not check documents provided by the `git` file system. |",
+              "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry.\nThis is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment |\n| ------ | ------- | ------- |\n| `*`    | `true`  | Enable all schemes. |\n| `git`  | `false` | Do not check documents provided by the `git` file system. |",
+              "scope": "window",
+              "title": "Specify Allowed Schemes",
+              "type": "object"
+            },
+            "cSpell.files": {
+              "description": "Glob patterns of files to be checked. Glob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+              "items": {
+                "description": "These are glob expressions.",
+                "markdownDescription": "These are glob expressions.",
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns of files to be checked.\nGlob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+              "scope": "resource",
+              "title": "Glob patterns of files to be checked",
+              "type": "array"
+            },
+            "cSpell.globRoot": {
+              "description": "The root to use for glob patterns found in this configuration. Default: The current workspace folder. Use `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
+              "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: The current workspace folder.\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file.\nDefining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
+              "scope": "resource",
+              "type": "string"
+            },
+            "cSpell.ignorePaths": {
+              "default": [
+                "package-lock.json",
+                "node_modules",
+                "vscode-extension",
+                ".git/{info,lfs,logs,refs,objects}/**",
+                ".git/{index,*refs,*HEAD}",
+                ".vscode",
+                ".vscode-insiders"
+              ],
+              "description": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+              "items": {
+                "description": "Simple Glob string, the root will be globRoot.",
+                "markdownDescription": "Simple Glob string, the root will be globRoot.",
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+              "scope": "resource",
+              "title": "Glob patterns of files to be ignored",
+              "type": "array"
+            },
+            "cSpell.import": {
+              "description": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
+              "items": {
+                "description": "A File System Path. Relative paths are relative to the configuration file.",
+                "markdownDescription": "A File System Path. Relative paths are relative to the configuration file.",
+                "type": "string"
+              },
+              "markdownDescription": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.mergeCSpellSettings": {
+              "default": true,
+              "description": "Specify if fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
+              "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
+              "scope": "resource",
+              "sinceVersion": "4.0.0",
+              "type": "boolean"
+            },
+            "cSpell.mergeCSpellSettingsFields": {
+              "additionalProperties": false,
+              "default": {
+                "allowCompoundWords": true,
+                "caseSensitive": true,
+                "dictionaries": true,
+                "dictionaryDefinitions": true,
+                "enableGlobDot": true,
+                "features": true,
+                "files": true,
+                "flagWords": true,
+                "gitignoreRoot": true,
+                "globRoot": true,
+                "ignorePaths": true,
+                "ignoreRegExpList": true,
+                "ignoreWords": true,
+                "import": true,
+                "includeRegExpList": true,
+                "language": true,
+                "languageId": true,
+                "languageSettings": true,
+                "loadDefaultConfiguration": true,
+                "minWordLength": true,
+                "noConfigSearch": true,
+                "noSuggestDictionaries": true,
+                "numSuggestions": true,
+                "overrides": true,
+                "patterns": true,
+                "pnpFiles": true,
+                "reporters": true,
+                "suggestWords": true,
+                "useGitignore": true,
+                "usePnP": true,
+                "userWords": true,
+                "validateDirectives": true,
+                "words": true
+              },
+              "description": "Specify which fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace and `#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample: ```jsonc \"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false } ```",
+              "markdownDescription": "Specify which fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace and\n`#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample:\n```jsonc\n\"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false }\n```",
+              "properties": {
+                "allowCompoundWords": {
+                  "type": "boolean"
+                },
+                "caseSensitive": {
+                  "type": "boolean"
+                },
+                "dictionaries": {
+                  "type": "boolean"
+                },
+                "dictionaryDefinitions": {
+                  "type": "boolean"
+                },
+                "enableGlobDot": {
+                  "type": "boolean"
+                },
+                "features": {
+                  "type": "boolean"
+                },
+                "files": {
+                  "type": "boolean"
+                },
+                "flagWords": {
+                  "type": "boolean"
+                },
+                "gitignoreRoot": {
+                  "type": "boolean"
+                },
+                "globRoot": {
+                  "type": "boolean"
+                },
+                "ignorePaths": {
+                  "type": "boolean"
+                },
+                "ignoreRegExpList": {
+                  "type": "boolean"
+                },
+                "ignoreWords": {
+                  "type": "boolean"
+                },
+                "import": {
+                  "type": "boolean"
+                },
+                "includeRegExpList": {
+                  "type": "boolean"
+                },
+                "language": {
+                  "type": "boolean"
+                },
+                "languageId": {
+                  "type": "boolean"
+                },
+                "languageSettings": {
+                  "type": "boolean"
+                },
+                "loadDefaultConfiguration": {
+                  "type": "boolean"
+                },
+                "minWordLength": {
+                  "type": "boolean"
+                },
+                "noConfigSearch": {
+                  "type": "boolean"
+                },
+                "noSuggestDictionaries": {
+                  "type": "boolean"
+                },
+                "numSuggestions": {
+                  "type": "boolean"
+                },
+                "overrides": {
+                  "type": "boolean"
+                },
+                "patterns": {
+                  "type": "boolean"
+                },
+                "pnpFiles": {
+                  "type": "boolean"
+                },
+                "reporters": {
+                  "type": "boolean"
+                },
+                "suggestWords": {
+                  "type": "boolean"
+                },
+                "useGitignore": {
+                  "type": "boolean"
+                },
+                "usePnP": {
+                  "type": "boolean"
+                },
+                "userWords": {
+                  "type": "boolean"
+                },
+                "validateDirectives": {
+                  "type": "boolean"
+                },
+                "words": {
+                  "type": "boolean"
+                }
+              },
+              "scope": "resource",
+              "sinceVersion": "4.0.0",
+              "type": "object"
+            },
+            "cSpell.noConfigSearch": {
+              "description": "Prevents searching for local configuration when checking individual documents.",
+              "markdownDescription": "Prevents searching for local configuration when checking individual documents.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.spellCheckOnlyWorkspaceFiles": {
+              "default": false,
+              "description": "Only spell check files that are in the currently open workspace. This same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js \"cSpell.files\": [\"/**\"] ```",
+              "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js\n\"cSpell.files\": [\"/**\"]\n```",
+              "scope": "window",
+              "title": "Spell Check Only Workspace Files",
+              "type": "boolean"
+            },
+            "cSpell.useGitignore": {
+              "default": true,
+              "description": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
+              "markdownDescription": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.usePnP": {
+              "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
+              "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.workspaceRootPath": {
+              "description": "Define the path to the workspace root folder in a multi-root workspace. By default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder** ``` ${workspaceFolder:client} ```",
+              "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder**\n```\n${workspaceFolder:client}\n```",
+              "scope": "resource",
+              "title": "Workspace Root Folder Path",
+              "type": "string"
+            }
+          },
+          "title": "Files, Folders, and Workspaces",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings that control dictionaries and language preferences.",
+          "order": 1,
+          "properties": {
+            "cSpell.caseSensitive": {
+              "description": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.   **Note:** Some languages like Portuguese have case sensitivity turned on by default.   You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
+              "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.customDictionaries": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "title": "Named dictionary to be enabled / disabled\n- `true` - turn on the named dictionary\n- `false` - turn off the named dictionary",
+                    "type": "boolean"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "description": "Define a custom dictionary to be included.",
+                    "markdownDescription": "Define a custom dictionary to be included.",
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "anyOf": [
+                          {
+                            "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                            "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                            "title": "Path to Dictionary Text File",
+                            "type": "string"
+                          },
+                          {
+                            "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                            "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "title": "Path to Dictionary Text File"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "title": "Custom Dictionary Entry",
+                    "type": "object"
+                  }
+                ]
+              },
+              "description": "Define custom dictionaries to be included by default. If `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js \"cSpell.customDictionaries\": {   \"project-words\": {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   },   \"custom\": true, // Enable the `custom` dictionary   \"internal-terms\": false // Disable the `internal-terms` dictionary } ```",
+              "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
+              "scope": "resource",
+              "title": "Custom Dictionaries",
+              "type": "object"
+            },
+            "cSpell.dictionaries": {
+              "description": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name. i.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc // Enable `lorem-ipsum` and disable `typescript` \"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"] ```",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name.\ni.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc\n// Enable `lorem-ipsum` and disable `typescript`\n\"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"]\n```",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.dictionaryDefinitions": {
+              "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional description of the contents / purpose of the dictionary.",
+                        "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                        "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Path or url to the dictionary file.",
+                        "markdownDescription": "Path or url to the dictionary file.",
+                        "type": "string"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                        "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional description of the contents / purpose of the dictionary.",
+                        "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                        "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "A file path or url to a custom dictionary file.",
+                        "markdownDescription": "A file path or url to a custom dictionary file.",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
+                        "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "path",
+                      "addWords",
+                      "name"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              },
+              "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+              "scope": "resource",
+              "title": "Dictionary Definitions",
+              "type": "array"
+            },
+            "cSpell.flagWords": {
+              "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.ignoreWords": {
+              "description": "A list of words to be ignored by the spell checker.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "A list of words to be ignored by the spell checker.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.language": {
+              "default": "en",
+              "description": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
+              "markdownDescription": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
+              "scope": "resource",
+              "type": "string"
+            },
+            "cSpell.languageSettings": {
+              "description": "Additional settings for individual programming languages and locales.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "allowCompoundWords": {
+                    "default": false,
+                    "description": "True to enable compound word checking.",
+                    "markdownDescription": "True to enable compound word checking.",
+                    "type": "boolean"
+                  },
+                  "caseSensitive": {
+                    "default": false,
+                    "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                    "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                    "type": "boolean"
+                  },
+                  "description": {
+                    "description": "Optional description of configuration.",
+                    "markdownDescription": "Optional description of configuration.",
+                    "type": "string"
+                  },
+                  "dictionaries": {
+                    "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        },
+                        {
+                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                    },
+                    "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                    "type": "array"
+                  },
+                  "dictionaryDefinitions": {
+                    "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "addWords": {
+                              "default": true,
+                              "description": "Indicate if this custom dictionary should be used to store added words.",
+                              "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                              "title": "Add Words to Dictionary",
+                              "type": "boolean"
+                            },
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional: A human readable description.",
+                              "markdownDescription": "Optional: A human readable description.",
+                              "title": "Description of the Dictionary",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                              "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                              "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                              "title": "Name of Dictionary",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                              "type": "string"
+                            },
+                            "scope": {
+                              "anyOf": [
+                                {
+                                  "description": "Specifies the scope of a dictionary.",
+                                  "enum": [
+                                    "user",
+                                    "workspace",
+                                    "folder"
+                                  ],
+                                  "markdownDescription": "Specifies the scope of a dictionary.",
+                                  "type": "string"
+                                },
+                                {
+                                  "items": {
+                                    "description": "Specifies the scope of a dictionary.",
+                                    "enum": [
+                                      "user",
+                                      "workspace",
+                                      "folder"
+                                    ],
+                                    "markdownDescription": "Specifies the scope of a dictionary.",
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              ],
+                              "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                              "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                              "title": "Scope of dictionary"
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "path"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional description of the contents / purpose of the dictionary.",
+                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "Path or url to the dictionary file.",
+                              "markdownDescription": "Path or url to the dictionary file.",
+                              "type": "string"
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "name"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "addWords": {
+                              "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                              "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+                              "type": "boolean"
+                            },
+                            "btrie": {
+                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                              "since": "9.6.0",
+                              "type": "string"
+                            },
+                            "description": {
+                              "description": "Optional description of the contents / purpose of the dictionary.",
+                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+                              "type": "string"
+                            },
+                            "ignoreForbiddenWords": {
+                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                              "type": "string"
+                            },
+                            "noSuggest": {
+                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                              "type": "boolean"
+                            },
+                            "path": {
+                              "description": "A file path or url to a custom dictionary file.",
+                              "markdownDescription": "A file path or url to a custom dictionary file.",
+                              "type": "string"
+                            },
+                            "scope": {
+                              "anyOf": [
+                                {
+                                  "description": "Specifies the scope of a dictionary.",
+                                  "enum": [
+                                    "user",
+                                    "workspace",
+                                    "folder"
+                                  ],
+                                  "markdownDescription": "Specifies the scope of a dictionary.",
+                                  "type": "string"
+                                },
+                                {
+                                  "items": {
+                                    "description": "Specifies the scope of a dictionary.",
+                                    "enum": [
+                                      "user",
+                                      "workspace",
+                                      "folder"
+                                    ],
+                                    "markdownDescription": "Specifies the scope of a dictionary.",
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              ],
+                              "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
+                              "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
+                            },
+                            "supportNonStrictSearches": {
+                              "default": true,
+                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "path",
+                            "addWords",
+                            "name"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                    "scope": "resource",
+                    "title": "Dictionary Definitions",
+                    "type": "array"
+                  },
+                  "enabled": {
+                    "default": true,
+                    "description": "Is the spell checker enabled.",
+                    "markdownDescription": "Is the spell checker enabled.",
+                    "type": "boolean"
+                  },
+                  "flagWords": {
+                    "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                    "type": "array"
+                  },
+                  "id": {
+                    "description": "Optional identifier.",
+                    "markdownDescription": "Optional identifier.",
+                    "type": "string"
+                  },
+                  "ignoreRegExpList": {
+                    "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "description": "This matches the name in a pattern definition.",
+                          "markdownDescription": "This matches the name in a pattern definition.",
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "Base64",
+                            "Base64MultiLine",
+                            "Base64SingleLine",
+                            "CStyleComment",
+                            "CStyleHexValue",
+                            "CSSHexValue",
+                            "CommitHash",
+                            "CommitHashLink",
+                            "Email",
+                            "EscapeCharacters",
+                            "HexValues",
+                            "href",
+                            "PhpHereDoc",
+                            "PublicKey",
+                            "RsaCert",
+                            "SshRsa",
+                            "SHA",
+                            "HashStrings",
+                            "SpellCheckerDisable",
+                            "SpellCheckerDisableBlock",
+                            "SpellCheckerDisableLine",
+                            "SpellCheckerDisableNext",
+                            "SpellCheckerIgnoreInDocSetting",
+                            "string",
+                            "UnicodeRef",
+                            "Urls",
+                            "UUID",
+                            "Everything"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A PatternRef is a Pattern or PatternId.",
+                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                    },
+                    "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "type": "array"
+                  },
+                  "ignoreWords": {
+                    "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                    "type": "array"
+                  },
+                  "includeRegExpList": {
+                    "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "description": "This matches the name in a pattern definition.",
+                          "markdownDescription": "This matches the name in a pattern definition.",
+                          "type": "string"
+                        },
+                        {
+                          "enum": [
+                            "Base64",
+                            "Base64MultiLine",
+                            "Base64SingleLine",
+                            "CStyleComment",
+                            "CStyleHexValue",
+                            "CSSHexValue",
+                            "CommitHash",
+                            "CommitHashLink",
+                            "Email",
+                            "EscapeCharacters",
+                            "HexValues",
+                            "href",
+                            "PhpHereDoc",
+                            "PublicKey",
+                            "RsaCert",
+                            "SshRsa",
+                            "SHA",
+                            "HashStrings",
+                            "SpellCheckerDisable",
+                            "SpellCheckerDisableBlock",
+                            "SpellCheckerDisableLine",
+                            "SpellCheckerDisableNext",
+                            "SpellCheckerIgnoreInDocSetting",
+                            "string",
+                            "UnicodeRef",
+                            "Urls",
+                            "UUID",
+                            "Everything"
+                          ],
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A PatternRef is a Pattern or PatternId.",
+                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                    },
+                    "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                    "type": "array"
+                  },
+                  "languageId": {
+                    "anyOf": [
+                      {
+                        "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                        "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                        "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                        "type": "string"
+                      },
+                      {
+                        "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                        "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                        "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                        "type": "string"
+                      },
+                      {
+                        "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                        "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                        "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                              "type": "string"
+                            },
+                            {
+                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
+                    "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
+                  },
+                  "locale": {
+                    "anyOf": [
+                      {
+                        "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                        "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                          "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                          "type": "string"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
+                    "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
+                  },
+                  "name": {
+                    "description": "Optional name of configuration.",
+                    "markdownDescription": "Optional name of configuration.",
+                    "type": "string"
+                  },
+                  "noSuggestDictionaries": {
+                    "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        },
+                        {
+                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "type": "string"
+                        }
+                      ],
+                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                    },
+                    "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                    "type": "array"
+                  },
+                  "patterns": {
+                    "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "description": {
+                          "description": "Description of the pattern.",
+                          "markdownDescription": "Description of the pattern.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                          "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                          "type": "string"
+                        },
+                        "pattern": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "RegExp pattern or array of RegExp patterns.",
+                          "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "pattern"
+                      ],
+                      "type": "object"
+                    },
+                    "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                    "type": "array"
+                  },
+                  "substitutionDefinitions": {
+                    "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                    "items": {
+                      "additionalProperties": false,
+                      "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                      "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                      "properties": {
+                        "description": {
+                          "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                          "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                          "type": "string"
+                        },
+                        "entries": {
+                          "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                          "items": {
+                            "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                            "items": [
+                              {
+                                "title": "find",
+                                "type": "string"
+                              },
+                              {
+                                "title": "replacement",
+                                "type": "string"
+                              }
+                            ],
+                            "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "since": "9.7.0",
+                            "type": "array"
+                          },
+                          "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                          "type": "array"
+                        },
+                        "name": {
+                          "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "since": "9.7.0",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "entries"
+                      ],
+                      "since": "9.7.0",
+                      "type": "object"
+                    },
+                    "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                    "since": "9.7.0",
+                    "type": "array"
+                  },
+                  "substitutions": {
+                    "description": "The set of substitutions to apply to a document before spell checking.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                          "items": [
+                            {
+                              "title": "find",
+                              "type": "string"
+                            },
+                            {
+                              "title": "replacement",
+                              "type": "string"
+                            }
+                          ],
+                          "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                          "maxItems": 2,
+                          "minItems": 2,
+                          "since": "9.7.0",
+                          "type": "array"
+                        },
+                        {
+                          "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                          "since": "9.7.0",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+                    "since": "9.7.0",
+                    "type": "array"
+                  },
+                  "suggestWords": {
+                    "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                    "type": "array"
+                  },
+                  "unknownWords": {
+                    "default": "report-all",
+                    "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                    "enum": [
+                      "report-all",
+                      "report-simple",
+                      "report-common-typos",
+                      "report-flagged"
+                    ],
+                    "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                    "since": "9.1.0",
+                    "type": "string"
+                  },
+                  "useIntlWordSegmentation": {
+                    "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                    "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                    "since": "10.2.0",
+                    "type": "boolean"
+                  },
+                  "words": {
+                    "description": "List of words to be considered correct.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "markdownDescription": "List of words to be considered correct.",
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "languageId"
+                ],
+                "type": "object"
+              },
+              "markdownDescription": "Additional settings for individual programming languages and locales.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.noSuggestDictionaries": {
+              "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.suggestWords": {
+              "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+              "type": "array"
+            },
+            "cSpell.useLocallyInstalledCSpellDictionaries": {
+              "default": true,
+              "description": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
+              "markdownDescription": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
+              "scope": "resource",
+              "sinceVersion": "4.0.0",
+              "type": "boolean"
+            },
+            "cSpell.userWords": {
+              "description": "Words to add to global dictionary -- should only be in the user config file.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Words to add to global dictionary -- should only be in the user config file.",
+              "scope": "resource",
+              "type": "array"
+            },
+            "cSpell.words": {
+              "description": "List of words to be considered correct.",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "List of words to be considered correct.",
+              "scope": "resource",
+              "type": "array"
+            }
+          },
+          "title": "Languages and Dictionaries",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings that control the appearance of the spell checker.",
+          "order": 6,
+          "properties": {
+            "cSpell.dark": {
+              "additionalProperties": false,
+              "description": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+              "markdownDescription": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+              "properties": {
+                "overviewRulerColor": {
+                  "default": "#348feb80",
+                  "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                  "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecoration": {
+                  "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+                  "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColor": {
+                  "default": "#348feb",
+                  "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColorFlagged": {
+                  "default": "#f44",
+                  "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColorSuggestion": {
+                  "default": "#cf88",
+                  "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.2",
+                  "type": "string"
+                },
+                "textDecorationLine": {
+                  "default": "underline",
+                  "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+                  "enum": [
+                    "underline",
+                    "overline",
+                    "line-through"
+                  ],
+                  "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationStyle": {
+                  "default": "dashed",
+                  "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+                  "enum": [
+                    "solid",
+                    "wavy",
+                    "dotted",
+                    "dashed",
+                    "double"
+                  ],
+                  "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationThickness": {
+                  "default": "auto",
+                  "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+                  "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                }
+              },
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "object"
+            },
+            "cSpell.doNotUseCustomDecorationForScheme": {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "default": {
+                "chatSessionInput": true,
+                "comment": true,
+                "vscode-scm": true
+              },
+              "description": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up. This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
+              "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "title": "Use VS Code to Render Spelling Issues",
+              "type": "object"
+            },
+            "cSpell.light": {
+              "additionalProperties": false,
+              "description": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+              "markdownDescription": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+              "properties": {
+                "overviewRulerColor": {
+                  "default": "#348feb80",
+                  "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                  "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecoration": {
+                  "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+                  "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColor": {
+                  "default": "#348feb",
+                  "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColorFlagged": {
+                  "default": "#f44",
+                  "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationColorSuggestion": {
+                  "default": "#cf88",
+                  "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.2",
+                  "type": "string"
+                },
+                "textDecorationLine": {
+                  "default": "underline",
+                  "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+                  "enum": [
+                    "underline",
+                    "overline",
+                    "line-through"
+                  ],
+                  "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationStyle": {
+                  "default": "dashed",
+                  "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+                  "enum": [
+                    "solid",
+                    "wavy",
+                    "dotted",
+                    "dashed",
+                    "double"
+                  ],
+                  "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                },
+                "textDecorationThickness": {
+                  "default": "auto",
+                  "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+                  "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+                  "scope": "application",
+                  "sinceVersion": "4.0.0",
+                  "type": "string"
+                }
+              },
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "object"
+            },
+            "cSpell.overviewRulerColor": {
+              "default": "#348feb80",
+              "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.showInRuler": {
+              "default": true,
+              "description": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
+              "markdownDescription": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
+              "scope": "application",
+              "sinceVersion": "4.0.35",
+              "type": "boolean"
+            },
+            "cSpell.textDecoration": {
+              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.textDecorationColor": {
+              "default": "#348feb",
+              "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.textDecorationColorFlagged": {
+              "default": "#f44",
+              "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.textDecorationColorSuggestion": {
+              "default": "#cf88",
+              "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.2",
+              "type": "string"
+            },
+            "cSpell.textDecorationLine": {
+              "default": "underline",
+              "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+              "enum": [
+                "underline",
+                "overline",
+                "line-through"
+              ],
+              "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.textDecorationStyle": {
+              "default": "dashed",
+              "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+              "enum": [
+                "solid",
+                "wavy",
+                "dotted",
+                "dashed",
+                "double"
+              ],
+              "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.textDecorationThickness": {
+              "default": "auto",
+              "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+              "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "cSpell.useCustomDecorations": {
+              "default": false,
+              "description": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
+              "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "boolean"
+            }
+          },
+          "title": "Appearance",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Legacy settings that have been deprecated or are not commonly used.",
+          "order": 20,
+          "properties": {
+            "cSpell.allowCompoundWords": {
+              "default": false,
+              "description": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
+              "markdownDescription": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.customFolderDictionaries": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+              "description": "Define custom dictionaries to be included by default for the folder. If `addWords` is `true` words will be added to this dictionary.",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "title": "Path to Dictionary Text File",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                    "type": "string"
+                  }
+                ]
+              },
+              "markdownDescription": "Define custom dictionaries to be included by default for the folder.\nIf `addWords` is `true` words will be added to this dictionary.",
+              "scope": "resource",
+              "title": "Custom Folder Dictionaries",
+              "type": "array"
+            },
+            "cSpell.customUserDictionaries": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+              "description": "Define custom dictionaries to be included by default for the user. If `addWords` is `true` words will be added to this dictionary.",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "title": "Path to Dictionary Text File",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                    "type": "string"
+                  }
+                ]
+              },
+              "markdownDescription": "Define custom dictionaries to be included by default for the user.\nIf `addWords` is `true` words will be added to this dictionary.",
+              "scope": "application",
+              "title": "Custom User Dictionaries",
+              "type": "array"
+            },
+            "cSpell.customWorkspaceDictionaries": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+              "description": "Define custom dictionaries to be included by default for the workspace. If `addWords` is `true` words will be added to this dictionary.",
+              "items": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "title": "Path to Dictionary Text File",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      }
+                    },
+                    "required": [
+                      "name"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "addWords": {
+                        "default": true,
+                        "description": "Indicate if this custom dictionary should be used to store added words.",
+                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+                        "title": "Add Words to Dictionary",
+                        "type": "boolean"
+                      },
+                      "btrie": {
+                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+                        "since": "9.6.0",
+                        "type": "string"
+                      },
+                      "description": {
+                        "description": "Optional: A human readable description.",
+                        "markdownDescription": "Optional: A human readable description.",
+                        "title": "Description of the Dictionary",
+                        "type": "string"
+                      },
+                      "ignoreForbiddenWords": {
+                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                        "title": "Name of Dictionary",
+                        "type": "string"
+                      },
+                      "noSuggest": {
+                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+                        "type": "boolean"
+                      },
+                      "path": {
+                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+                        "type": "string"
+                      },
+                      "scope": {
+                        "anyOf": [
+                          {
+                            "description": "Specifies the scope of a dictionary.",
+                            "enum": [
+                              "user",
+                              "workspace",
+                              "folder"
+                            ],
+                            "markdownDescription": "Specifies the scope of a dictionary.",
+                            "type": "string"
+                          },
+                          {
+                            "items": {
+                              "description": "Specifies the scope of a dictionary.",
+                              "enum": [
+                                "user",
+                                "workspace",
+                                "folder"
+                              ],
+                              "markdownDescription": "Specifies the scope of a dictionary.",
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+                        "title": "Scope of dictionary"
+                      },
+                      "supportNonStrictSearches": {
+                        "default": true,
+                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "path"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                    "type": "string"
+                  }
+                ]
+              },
+              "markdownDescription": "Define custom dictionaries to be included by default for the workspace.\nIf `addWords` is `true` words will be added to this dictionary.",
+              "scope": "resource",
+              "title": "Custom Workspace Dictionaries",
+              "type": "array"
+            },
+            "cSpell.enabledLanguageIds": {
+              "deprecated": true,
+              "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
+              "description": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
+              "items": {
+                "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                "type": "string"
+              },
+              "markdownDescription": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
+              "scope": "resource",
+              "title": "Enabled Language Ids",
+              "type": "array",
+              "uniqueItems": true
+            },
+            "cSpell.showStatus": {
+              "default": true,
+              "deprecationMessage": "No longer used.",
+              "description": "Display the spell checker status on the status bar.",
+              "markdownDescription": "Display the spell checker status on the status bar.",
+              "scope": "application",
+              "type": "boolean"
+            },
+            "cSpell.showStatusAlignment": {
+              "default": "Right",
+              "deprecated": true,
+              "deprecationMessage": "No longer supported.",
+              "description": "The side of the status bar to display the spell checker status.",
+              "enum": [
+                "Left",
+                "Right"
+              ],
+              "enumDescriptions": [
+                "Left Side of Statusbar",
+                "Right Side of Statusbar"
+              ],
+              "markdownDescription": "The side of the status bar to display the spell checker status.",
+              "scope": "application",
+              "type": "string"
+            }
+          },
+          "title": "Legacy",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings that control the performance of the spell checker.",
+          "order": 4,
+          "properties": {
+            "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
+              "default": 200,
+              "description": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "scope": "language-overridable",
+              "type": "number"
+            },
+            "cSpell.blockCheckingWhenLineLengthGreaterThan": {
+              "default": 20000,
+              "description": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given. This is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "markdownDescription": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "scope": "language-overridable",
+              "type": "number"
+            },
+            "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
+              "default": 1000,
+              "description": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+              "scope": "language-overridable",
+              "type": "number"
+            },
+            "cSpell.checkLimit": {
+              "default": 500,
+              "description": "Set the maximum number of blocks of text to check. Each block is 1024 characters.",
+              "markdownDescription": "Set the maximum number of blocks of text to check.\nEach block is 1024 characters.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.spellCheckDelayMs": {
+              "default": 50,
+              "description": "Delay in ms after a document has changed before checking it for spelling errors.",
+              "markdownDescription": "Delay in ms after a document has changed before checking it for spelling errors.",
+              "scope": "application",
+              "type": "number"
+            },
+            "cSpell.suggestionsTimeout": {
+              "default": 400,
+              "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+              "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+              "scope": "resource",
+              "type": "number"
+            }
+          },
+          "title": "Performance",
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Settings that control how the spell checker reports and displays errors.",
+          "order": 2,
+          "properties": {
+            "cSpell.autoFormatConfigFile": {
+              "default": false,
+              "description": "If a `cspell` configuration file is updated, format the configuration file using the VS Code Format Document Provider. This will cause the configuration file to be saved prior to being updated.",
+              "markdownDescription": "If a `cspell` configuration file is updated, format the configuration file\nusing the VS Code Format Document Provider. This will cause the configuration\nfile to be saved prior to being updated.",
+              "scope": "window",
+              "title": "Auto Format Configuration File",
+              "type": "boolean"
+            },
+            "cSpell.autocorrect": {
+              "default": false,
+              "description": "Enable / Disable autocorrect while typing.",
+              "markdownDescription": "Enable / Disable autocorrect while typing.",
+              "scope": "resource",
+              "title": "Autocorrect",
+              "type": "boolean"
+            },
+            "cSpell.diagnosticLevel": {
+              "default": "Information",
+              "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+              "enum": [
+                "Error",
+                "Warning",
+                "Information",
+                "Hint"
+              ],
+              "enumDescriptions": [
+                "Report Spelling Issues as Errors",
+                "Report Spelling Issues as Warnings",
+                "Report Spelling Issues as Information",
+                "Report Spelling Issues as Hints, will not show up in Problems"
+              ],
+              "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+              "scope": "resource",
+              "title": "Set Diagnostic Reporting Level",
+              "type": "string"
+            },
+            "cSpell.diagnosticLevelFlaggedWords": {
+              "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+              "enum": [
+                "Error",
+                "Warning",
+                "Information",
+                "Hint"
+              ],
+              "enumDescriptions": [
+                "Report Spelling Issues as Errors",
+                "Report Spelling Issues as Warnings",
+                "Report Spelling Issues as Information",
+                "Report Spelling Issues as Hints, will not show up in Problems"
+              ],
+              "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+              "scope": "resource",
+              "sinceVersion": "4.0.0",
+              "title": "Set Diagnostic Reporting Level for Flagged Words",
+              "type": "string"
+            },
+            "cSpell.enabledNotifications": {
+              "additionalProperties": false,
+              "default": {
+                "Average Word Length too Long": true,
+                "Lines too Long": true,
+                "Maximum Word Length Exceeded": true
+              },
+              "description": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
+              "markdownDescription": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
+              "properties": {
+                "Average Word Length too Long": {
+                  "description": "Enable notifications if the average word size is too high.",
+                  "markdownDescription": "Enable notifications if the average word size is too high.",
+                  "type": "boolean"
+                },
+                "Lines too Long": {
+                  "description": "Enable notifications if the line is too long.",
+                  "markdownDescription": "Enable notifications if the line is too long.",
+                  "type": "boolean"
+                },
+                "Maximum Word Length Exceeded": {
+                  "description": "Enable notifications if the maximum word length is exceeded.",
+                  "markdownDescription": "Enable notifications if the maximum word length is exceeded.",
+                  "type": "boolean"
+                }
+              },
+              "scope": "resource",
+              "sinceVersion": "4.0.41",
+              "title": "Enabled Notifications",
+              "type": "object"
+            },
+            "cSpell.hideAddToDictionaryCodeActions": {
+              "default": false,
+              "description": "Hide the options to add words to dictionaries or settings.",
+              "markdownDescription": "Hide the options to add words to dictionaries or settings.",
+              "scope": "resource",
+              "type": "boolean"
+            },
+            "cSpell.hideIssuesWhileTyping": {
+              "default": "Word",
+              "description": "Control how spelling issues are displayed while typing. See: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
+              "enum": [
+                "Off",
+                "Word",
+                "Line",
+                "Document"
+              ],
+              "enumDescriptions": [
+                "Show issues while typing",
+                "Hide issues while typing in the current word",
+                "Hide issues while typing on the line",
+                "Hide all issues while typing in the document"
+              ],
+              "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "title": "Hide Issues While Typing",
+              "type": "string"
+            },
+            "cSpell.maxDuplicateProblems": {
+              "default": 20,
+              "description": "The maximum number of times the same word can be flagged as an error in a file.",
+              "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.maxNumberOfProblems": {
+              "default": 100,
+              "description": "Controls the maximum number of spelling errors per document.",
+              "markdownDescription": "Controls the maximum number of spelling errors per document.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.minWordLength": {
+              "default": 4,
+              "description": "The minimum length of a word before checking it against a dictionary.",
+              "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.numSuggestions": {
+              "default": 8,
+              "description": "Controls the number of suggestions shown.",
+              "markdownDescription": "Controls the number of suggestions shown.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.revealIssuesAfterDelayMS": {
+              "default": 1500,
+              "description": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+              "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "title": "Reveal Issues After a Delay in Milliseconds",
+              "type": "number"
+            },
+            "cSpell.showAutocompleteDirectiveSuggestions": {
+              "default": true,
+              "description": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
+              "markdownDescription": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
+              "scope": "language-overridable",
+              "type": "boolean"
+            },
+            "cSpell.showCommandsInEditorContextMenu": {
+              "default": true,
+              "description": "Show Spell Checker actions in Editor Context Menu",
+              "markdownDescription": "Show Spell Checker actions in Editor Context Menu",
+              "scope": "application",
+              "type": "boolean"
+            },
+            "cSpell.showSuggestionsLinkInEditorContextMenu": {
+              "default": true,
+              "description": "Show Spelling Suggestions link in the top level context menu.",
+              "markdownDescription": "Show Spelling Suggestions link in the top level context menu.",
+              "scope": "application",
+              "type": "boolean"
+            },
+            "cSpell.suggestionMenuType": {
+              "default": "quickPick",
+              "description": "The type of menu used to display spelling suggestions.",
+              "enum": [
+                "quickPick",
+                "quickFix"
+              ],
+              "enumDescriptions": [
+                "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
+                "Suggestions will appear inline near the word, inside the text editor."
+              ],
+              "markdownDescription": "The type of menu used to display spelling suggestions.",
+              "scope": "resource",
+              "type": "string"
+            },
+            "cSpell.suggestionNumChanges": {
+              "default": 3,
+              "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+              "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+              "scope": "resource",
+              "type": "number"
+            },
+            "cSpell.validateDirectives": {
+              "description": "Verify that the in-document directives are correct.",
+              "markdownDescription": "Verify that the in-document directives are correct.",
+              "scope": "window",
+              "type": "boolean"
+            }
+          },
+          "title": "Reporting and Display",
+          "type": "object"
+        }
+      ],
+      "maxItems": 10,
+      "minItems": 10,
+      "type": "array"
+    }
+  }
+}

--- a/packages/_server/spell-checker-config-web.schema.json
+++ b/packages/_server/spell-checker-config-web.schema.json
@@ -2,1731 +2,1047 @@
   "$ref": "#/definitions/SpellCheckerSettingsVSCode",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "SpellCheckerSettingsVSCode": {
-      "items": [
-        {
-          "additionalProperties": false,
-          "description": "Settings that control the behavior of the spell checker.",
-          "order": 0,
-          "properties": {
-            "cSpell.enabled": {
-              "default": true,
-              "description": "Enable / Disable the spell checker.",
-              "markdownDescription": "Enable / Disable the spell checker.",
-              "scope": "resource",
-              "type": "boolean"
-            }
-          },
-          "title": "Code Spell Checker",
-          "type": "object"
+    "CSpellMergeFields": {
+      "additionalProperties": false,
+      "properties": {
+        "allowCompoundWords": {
+          "type": "boolean"
         },
-        {
-          "additionalProperties": false,
-          "description": "Advanced settings that are not commonly used.",
-          "order": 18,
-          "properties": {
-            "cSpell.advanced.feature.useReferenceProviderRemove": {
-              "description": "Used to work around bugs in Reference Providers and Rename Providers. Anything matching the provided Regular Expression will be removed from the text before sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at [Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
-              "markdownDescription": "Used to work around bugs in Reference Providers and Rename Providers.\nAnything matching the provided Regular Expression will be removed from the text\nbefore sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at\n[Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
-              "scope": "language-overridable",
-              "title": "Remove Matching Characters Before Rename",
+        "caseSensitive": {
+          "type": "boolean"
+        },
+        "dictionaries": {
+          "type": "boolean"
+        },
+        "dictionaryDefinitions": {
+          "type": "boolean"
+        },
+        "enableGlobDot": {
+          "type": "boolean"
+        },
+        "features": {
+          "type": "boolean"
+        },
+        "files": {
+          "type": "boolean"
+        },
+        "flagWords": {
+          "type": "boolean"
+        },
+        "gitignoreRoot": {
+          "type": "boolean"
+        },
+        "globRoot": {
+          "type": "boolean"
+        },
+        "ignorePaths": {
+          "type": "boolean"
+        },
+        "ignoreRegExpList": {
+          "type": "boolean"
+        },
+        "ignoreWords": {
+          "type": "boolean"
+        },
+        "import": {
+          "type": "boolean"
+        },
+        "includeRegExpList": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "boolean"
+        },
+        "languageId": {
+          "type": "boolean"
+        },
+        "languageSettings": {
+          "type": "boolean"
+        },
+        "loadDefaultConfiguration": {
+          "type": "boolean"
+        },
+        "minWordLength": {
+          "type": "boolean"
+        },
+        "noConfigSearch": {
+          "type": "boolean"
+        },
+        "noSuggestDictionaries": {
+          "type": "boolean"
+        },
+        "numSuggestions": {
+          "type": "boolean"
+        },
+        "overrides": {
+          "type": "boolean"
+        },
+        "patterns": {
+          "type": "boolean"
+        },
+        "pnpFiles": {
+          "type": "boolean"
+        },
+        "reporters": {
+          "type": "boolean"
+        },
+        "suggestWords": {
+          "type": "boolean"
+        },
+        "useGitignore": {
+          "type": "boolean"
+        },
+        "usePnP": {
+          "type": "boolean"
+        },
+        "userWords": {
+          "type": "boolean"
+        },
+        "validateDirectives": {
+          "type": "boolean"
+        },
+        "words": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "CustomDictionaries": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/EnableCustomDictionary"
+          },
+          {
+            "$ref": "#/definitions/CustomDictionariesDictionary"
+          }
+        ]
+      },
+      "propertyNames": {
+        "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+        "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$"
+      },
+      "type": "object"
+    },
+    "CustomDictionariesDictionary": {
+      "additionalProperties": false,
+      "description": "Define a custom dictionary to be included.",
+      "markdownDescription": "Define a custom dictionary to be included.",
+      "properties": {
+        "addWords": {
+          "default": true,
+          "description": "Indicate if this custom dictionary should be used to store added words.",
+          "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+          "title": "Add Words to Dictionary",
+          "type": "boolean"
+        },
+        "btrie": {
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional: A human readable description.",
+          "markdownDescription": "Optional: A human readable description.",
+          "title": "Description of the Dictionary",
+          "type": "string"
+        },
+        "ignoreForbiddenWords": {
+          "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+          "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "title": "Name of Dictionary",
+          "type": "string"
+        },
+        "noSuggest": {
+          "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+          "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+          "type": "boolean"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+              "title": "Path to Dictionary Text File",
               "type": "string"
             },
-            "cSpell.advanced.feature.useReferenceProviderWithRename": {
-              "default": false,
-              "description": "Use the Reference Provider when fixing spelling issues with the Rename Provider. This feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
-              "markdownDescription": "Use the Reference Provider when fixing spelling issues with the Rename Provider.\nThis feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
-              "scope": "language-overridable",
-              "title": "Use Reference Provider During Rename",
-              "type": "boolean"
-            },
-            "cSpell.fixSpellingWithRenameProvider": {
-              "default": true,
-              "description": "Use Rename Provider when fixing spelling issues.",
-              "markdownDescription": "Use Rename Provider when fixing spelling issues.",
-              "scope": "language-overridable",
-              "type": "boolean"
-            },
-            "cSpell.logFile": {
-              "description": "Have the logs written to a file instead of to VS Code.",
-              "markdownDescription": "Have the logs written to a file instead of to VS Code.",
-              "scope": "window",
-              "title": "Write Logs to a File",
+            {
+              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
               "type": "string"
-            },
-            "cSpell.logLevel": {
-              "default": "Error",
-              "description": "Set the Debug Level for logging messages.",
+            }
+          ],
+          "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+          "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+          "title": "Path to Dictionary Text File"
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "description": "Specifies the scope of a dictionary.",
               "enum": [
-                "None",
-                "Error",
-                "Warning",
-                "Information",
-                "Debug"
+                "user",
+                "workspace",
+                "folder"
               ],
-              "enumDescriptions": [
-                "Do not log",
-                "Log only errors",
-                "Log errors and warnings",
-                "Log errors, warnings, and info",
-                "Log everything (noisy)"
-              ],
-              "markdownDescription": "Set the Debug Level for logging messages.",
-              "scope": "window",
-              "title": "Set Logging Level",
+              "markdownDescription": "Specifies the scope of a dictionary.",
               "type": "string"
             },
-            "cSpell.trustedWorkspace": {
+            {
+              "items": {
+                "description": "Specifies the scope of a dictionary.",
+                "enum": [
+                  "user",
+                  "workspace",
+                  "folder"
+                ],
+                "markdownDescription": "Specifies the scope of a dictionary.",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "title": "Scope of dictionary"
+        },
+        "supportNonStrictSearches": {
+          "default": true,
+          "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+          "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+          "type": "boolean"
+        }
+      },
+      "title": "Custom Dictionary Entry",
+      "type": "object"
+    },
+    "CustomDictionary": {
+      "additionalProperties": false,
+      "properties": {
+        "addWords": {
+          "default": true,
+          "description": "Indicate if this custom dictionary should be used to store added words.",
+          "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+          "title": "Add Words to Dictionary",
+          "type": "boolean"
+        },
+        "btrie": {
+          "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+          "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+          "since": "9.6.0",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional: A human readable description.",
+          "markdownDescription": "Optional: A human readable description.",
+          "title": "Description of the Dictionary",
+          "type": "string"
+        },
+        "ignoreForbiddenWords": {
+          "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+          "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+          "title": "Name of Dictionary",
+          "type": "string"
+        },
+        "noSuggest": {
+          "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+          "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+          "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+          "type": "string"
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "description": "Specifies the scope of a dictionary.",
+              "enum": [
+                "user",
+                "workspace",
+                "folder"
+              ],
+              "markdownDescription": "Specifies the scope of a dictionary.",
+              "type": "string"
+            },
+            {
+              "items": {
+                "description": "Specifies the scope of a dictionary.",
+                "enum": [
+                  "user",
+                  "workspace",
+                  "folder"
+                ],
+                "markdownDescription": "Specifies the scope of a dictionary.",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "title": "Scope of dictionary"
+        },
+        "supportNonStrictSearches": {
+          "default": true,
+          "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+          "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "path"
+      ],
+      "type": "object"
+    },
+    "CustomDictionaryAugmentExistingDictionary": {
+      "additionalProperties": false,
+      "properties": {
+        "addWords": {
+          "default": true,
+          "description": "Indicate if this custom dictionary should be used to store added words.",
+          "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
+          "title": "Add Words to Dictionary",
+          "type": "boolean"
+        },
+        "description": {
+          "description": "Optional: A human readable description.",
+          "markdownDescription": "Optional: A human readable description.",
+          "title": "Description of the Dictionary",
+          "type": "string"
+        },
+        "name": {
+          "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
+          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+          "title": "Name of Dictionary",
+          "type": "string"
+        },
+        "noSuggest": {
+          "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+          "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
+          "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
+          "title": "Path to Dictionary Text File",
+          "type": "string"
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "description": "Specifies the scope of a dictionary.",
+              "enum": [
+                "user",
+                "workspace",
+                "folder"
+              ],
+              "markdownDescription": "Specifies the scope of a dictionary.",
+              "type": "string"
+            },
+            {
+              "items": {
+                "description": "Specifies the scope of a dictionary.",
+                "enum": [
+                  "user",
+                  "workspace",
+                  "folder"
+                ],
+                "markdownDescription": "Specifies the scope of a dictionary.",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
+          "title": "Scope of dictionary"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "CustomDictionaryEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CustomDictionaryAugmentExistingDictionary"
+        },
+        {
+          "$ref": "#/definitions/CustomDictionary"
+        },
+        {
+          "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+          "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+          "type": "string"
+        }
+      ]
+    },
+    "DiagnosticLevel": {
+      "enum": [
+        "Error",
+        "Warning",
+        "Information",
+        "Hint"
+      ],
+      "type": "string"
+    },
+    "DictionaryDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CustomDictionary"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "btrie": {
+              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+              "since": "9.6.0",
+              "type": "string"
+            },
+            "description": {
+              "description": "Optional description of the contents / purpose of the dictionary.",
+              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+              "type": "string"
+            },
+            "ignoreForbiddenWords": {
+              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+              "type": "string"
+            },
+            "noSuggest": {
+              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+              "type": "boolean"
+            },
+            "path": {
+              "description": "Path or url to the dictionary file.",
+              "markdownDescription": "Path or url to the dictionary file.",
+              "type": "string"
+            },
+            "supportNonStrictSearches": {
               "default": true,
-              "description": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace, but a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
-              "markdownDescription": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace,\nbut a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
-              "scope": "window",
-              "sinceVersion": "4.0.0",
+              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
               "type": "boolean"
             }
           },
-          "title": "Advanced",
+          "required": [
+            "path",
+            "name"
+          ],
           "type": "object"
         },
         {
           "additionalProperties": false,
-          "description": "Settings related to CSpell Command Line Tool.",
-          "order": 5,
           "properties": {
-            "cSpell.engines": {
-              "additionalProperties": {
+            "addWords": {
+              "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+              "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
+              "type": "boolean"
+            },
+            "btrie": {
+              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
+              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
+              "since": "9.6.0",
+              "type": "string"
+            },
+            "description": {
+              "description": "Optional description of the contents / purpose of the dictionary.",
+              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
+              "type": "string"
+            },
+            "ignoreForbiddenWords": {
+              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
+              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
+              "type": "string"
+            },
+            "noSuggest": {
+              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
+              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
+              "type": "boolean"
+            },
+            "path": {
+              "description": "A file path or url to a custom dictionary file.",
+              "markdownDescription": "A file path or url to a custom dictionary file.",
+              "type": "string"
+            },
+            "scope": {
+              "anyOf": [
+                {
+                  "description": "Specifies the scope of a dictionary.",
+                  "enum": [
+                    "user",
+                    "workspace",
+                    "folder"
+                  ],
+                  "markdownDescription": "Specifies the scope of a dictionary.",
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "description": "Specifies the scope of a dictionary.",
+                    "enum": [
+                      "user",
+                      "workspace",
+                      "folder"
+                    ],
+                    "markdownDescription": "Specifies the scope of a dictionary.",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
+              "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
+            },
+            "supportNonStrictSearches": {
+              "default": true,
+              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
+              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "path",
+            "addWords",
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "EnableCustomDictionary": {
+      "title": "Named dictionary to be enabled / disabled\n- `true` - turn on the named dictionary\n- `false` - turn off the named dictionary",
+      "type": "boolean"
+    },
+    "EnableFileTypeId": {
+      "description": "Enable / Disable checking file types (languageIds). To disable a language, prefix with `!` as in `!json`,\n\n\nExample: ``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```",
+      "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
+      "pattern": "(^!*(?!\\s)[\\s\\w_.\\-]+$)|(^!*[*]$)",
+      "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
+      "type": "string"
+    },
+    "EnabledFileTypes": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "EnabledNotifications": {
+      "additionalProperties": false,
+      "description": "Control which notifications are displayed.",
+      "markdownDescription": "Control which notifications are displayed.",
+      "properties": {
+        "Average Word Length too Long": {
+          "description": "Enable notifications if the average word size is too high.",
+          "markdownDescription": "Enable notifications if the average word size is too high.",
+          "type": "boolean"
+        },
+        "Lines too Long": {
+          "description": "Enable notifications if the line is too long.",
+          "markdownDescription": "Enable notifications if the line is too long.",
+          "type": "boolean"
+        },
+        "Maximum Word Length Exceeded": {
+          "description": "Enable notifications if the maximum word length is exceeded.",
+          "markdownDescription": "Enable notifications if the maximum word length is exceeded.",
+          "type": "boolean"
+        }
+      },
+      "scope": "resource",
+      "sinceVersion": "4.0.41",
+      "title": "Enabled Notifications",
+      "type": "object"
+    },
+    "EnabledSchemes": {
+      "additionalProperties": {
+        "type": "boolean"
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-4207-4277-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.enabled": {
+          "default": true,
+          "description": "Enable / Disable the spell checker.",
+          "markdownDescription": "Enable / Disable the spell checker.",
+          "scope": "resource",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-4503-4919-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.caseSensitive": {
+          "description": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.   **Note:** Some languages like Portuguese have case sensitivity turned on by default.   You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
+          "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.customDictionaries": {
+          "$ref": "#/definitions/CustomDictionaries",
+          "description": "Define custom dictionaries to be included by default. If `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js \"cSpell.customDictionaries\": {   \"project-words\": {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   },   \"custom\": true, // Enable the `custom` dictionary   \"internal-terms\": false // Disable the `internal-terms` dictionary } ```",
+          "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
+          "scope": "resource",
+          "title": "Custom Dictionaries"
+        },
+        "cSpell.dictionaries": {
+          "description": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name. i.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc // Enable `lorem-ipsum` and disable `typescript` \"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"] ```",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name.\ni.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc\n// Enable `lorem-ipsum` and disable `typescript`\n\"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"]\n```",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.dictionaryDefinitions": {
+          "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+          "items": {
+            "$ref": "#/definitions/DictionaryDef"
+          },
+          "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+          "scope": "resource",
+          "title": "Dictionary Definitions",
+          "type": "array"
+        },
+        "cSpell.flagWords": {
+          "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.ignoreWords": {
+          "description": "A list of words to be ignored by the spell checker.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "A list of words to be ignored by the spell checker.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.language": {
+          "default": "en",
+          "description": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
+          "markdownDescription": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
+          "scope": "resource",
+          "type": "string"
+        },
+        "cSpell.languageSettings": {
+          "description": "Additional settings for individual programming languages and locales.",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "allowCompoundWords": {
+                "default": false,
+                "description": "True to enable compound word checking.",
+                "markdownDescription": "True to enable compound word checking.",
+                "type": "boolean"
+              },
+              "caseSensitive": {
+                "default": false,
+                "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                "type": "boolean"
+              },
+              "description": {
+                "description": "Optional description of configuration.",
+                "markdownDescription": "Optional description of configuration.",
+                "type": "string"
+              },
+              "dictionaries": {
+                "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                      "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                      "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    },
+                    {
+                      "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                      "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                      "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                  "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                },
+                "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                "type": "array"
+              },
+              "dictionaryDefinitions": {
+                "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                "items": {
+                  "$ref": "#/definitions/DictionaryDef"
+                },
+                "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                "scope": "resource",
+                "title": "Dictionary Definitions",
+                "type": "array"
+              },
+              "enabled": {
+                "default": true,
+                "description": "Is the spell checker enabled.",
+                "markdownDescription": "Is the spell checker enabled.",
+                "type": "boolean"
+              },
+              "flagWords": {
+                "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                "type": "array"
+              },
+              "id": {
+                "description": "Optional identifier.",
+                "markdownDescription": "Optional identifier.",
+                "type": "string"
+              },
+              "ignoreRegExpList": {
+                "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "description": "This matches the name in a pattern definition.",
+                      "markdownDescription": "This matches the name in a pattern definition.",
+                      "type": "string"
+                    },
+                    {
+                      "enum": [
+                        "Base64",
+                        "Base64MultiLine",
+                        "Base64SingleLine",
+                        "CStyleComment",
+                        "CStyleHexValue",
+                        "CSSHexValue",
+                        "CommitHash",
+                        "CommitHashLink",
+                        "Email",
+                        "EscapeCharacters",
+                        "HexValues",
+                        "href",
+                        "PhpHereDoc",
+                        "PublicKey",
+                        "RsaCert",
+                        "SshRsa",
+                        "SHA",
+                        "HashStrings",
+                        "SpellCheckerDisable",
+                        "SpellCheckerDisableBlock",
+                        "SpellCheckerDisableLine",
+                        "SpellCheckerDisableNext",
+                        "SpellCheckerIgnoreInDocSetting",
+                        "string",
+                        "UnicodeRef",
+                        "Urls",
+                        "UUID",
+                        "Everything"
+                      ],
+                      "type": "string"
+                    }
+                  ],
+                  "description": "A PatternRef is a Pattern or PatternId.",
+                  "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                },
+                "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "type": "array"
+              },
+              "ignoreWords": {
+                "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                "type": "array"
+              },
+              "includeRegExpList": {
+                "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "description": "This matches the name in a pattern definition.",
+                      "markdownDescription": "This matches the name in a pattern definition.",
+                      "type": "string"
+                    },
+                    {
+                      "enum": [
+                        "Base64",
+                        "Base64MultiLine",
+                        "Base64SingleLine",
+                        "CStyleComment",
+                        "CStyleHexValue",
+                        "CSSHexValue",
+                        "CommitHash",
+                        "CommitHashLink",
+                        "Email",
+                        "EscapeCharacters",
+                        "HexValues",
+                        "href",
+                        "PhpHereDoc",
+                        "PublicKey",
+                        "RsaCert",
+                        "SshRsa",
+                        "SHA",
+                        "HashStrings",
+                        "SpellCheckerDisable",
+                        "SpellCheckerDisableBlock",
+                        "SpellCheckerDisableLine",
+                        "SpellCheckerDisableNext",
+                        "SpellCheckerIgnoreInDocSetting",
+                        "string",
+                        "UnicodeRef",
+                        "Urls",
+                        "UUID",
+                        "Everything"
+                      ],
+                      "type": "string"
+                    }
+                  ],
+                  "description": "A PatternRef is a Pattern or PatternId.",
+                  "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                },
+                "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "type": "array"
+              },
+              "languageId": {
                 "anyOf": [
                   {
-                    "description": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
-                    "markdownDescription": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
+                    "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                    "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                    "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
                     "type": "string"
                   },
                   {
-                    "not": {}
-                  }
-                ],
-                "description": "Other engine version predicates.",
-                "markdownDescription": "Other engine version predicates."
-              },
-              "description": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
-              "markdownDescription": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
-              "properties": {
-                "code-spell-checker": {
-                  "description": "The VSCode Spell Checker version predicate.",
-                  "markdownDescription": "The VSCode Spell Checker version predicate.",
-                  "since": "9.6.3",
-                  "type": "string"
-                },
-                "cspell": {
-                  "description": "CSpell version predicate.",
-                  "markdownDescription": "CSpell version predicate.",
-                  "since": "9.6.3",
-                  "type": "string"
-                }
-              },
-              "since": "9.6.3",
-              "type": "object"
-            },
-            "cSpell.ignoreRandomStrings": {
-              "default": true,
-              "description": "Ignore sequences of characters that look like random strings.",
-              "markdownDescription": "Ignore sequences of characters that look like random strings.",
-              "type": "boolean"
-            },
-            "cSpell.ignoreRegExpList": {
-              "description": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,   it is necessary to escape `\\`.   Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  | | :------------------ | :-------------------- | :------------------------------------------- | | `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         | | `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    | | `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,\n  it is necessary to escape `\\`.\n  Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  |\n| :------------------ | :-------------------- | :------------------------------------------- |\n| `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         |\n| `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    |\n| `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.includeRegExpList": {
-              "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.maxFileSize": {
-              "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
-              "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
-              "since": "9.4.0",
-              "type": [
-                "number",
-                "string"
-              ]
-            },
-            "cSpell.minRandomLength": {
-              "default": 40,
-              "description": "The minimum length of a random string to be ignored.",
-              "markdownDescription": "The minimum length of a random string to be ignored.",
-              "type": "number"
-            },
-            "cSpell.overrides": {
-              "description": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc \"cSpell.overrides\": [   // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:   {     \"filename\": \"**/{*.hrr,*.crr}\",     \"languageId\": \"cpp\"   },   // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):   {     \"filename\": \"**/dutch/**/*.txt\",     \"language\": \"nl\"   } ] ```",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "allowCompoundWords": {
-                    "default": false,
-                    "description": "True to enable compound word checking.",
-                    "markdownDescription": "True to enable compound word checking.",
-                    "type": "boolean"
-                  },
-                  "caseSensitive": {
-                    "default": false,
-                    "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                    "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                    "type": "boolean"
-                  },
-                  "description": {
-                    "description": "Optional description of configuration.",
-                    "markdownDescription": "Optional description of configuration.",
+                    "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                    "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                    "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
                     "type": "string"
                   },
-                  "diagnosticLevel": {
-                    "default": "Information",
-                    "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-                    "enum": [
-                      "Error",
-                      "Warning",
-                      "Information",
-                      "Hint"
-                    ],
-                    "enumDescriptions": [
-                      "Report Spelling Issues as Errors",
-                      "Report Spelling Issues as Warnings",
-                      "Report Spelling Issues as Information",
-                      "Report Spelling Issues as Hints, will not show up in Problems"
-                    ],
-                    "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-                    "scope": "resource",
-                    "title": "Set Diagnostic Reporting Level",
+                  {
+                    "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                    "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                    "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
                     "type": "string"
                   },
-                  "diagnosticLevelFlaggedWords": {
-                    "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-                    "enum": [
-                      "Error",
-                      "Warning",
-                      "Information",
-                      "Hint"
-                    ],
-                    "enumDescriptions": [
-                      "Report Spelling Issues as Errors",
-                      "Report Spelling Issues as Warnings",
-                      "Report Spelling Issues as Information",
-                      "Report Spelling Issues as Hints, will not show up in Problems"
-                    ],
-                    "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-                    "scope": "resource",
-                    "sinceVersion": "4.0.0",
-                    "title": "Set Diagnostic Reporting Level for Flagged Words",
-                    "type": "string"
-                  },
-                  "dictionaries": {
-                    "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                  {
                     "items": {
                       "anyOf": [
                         {
-                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
                           "type": "string"
                         },
                         {
-                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                          "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
                           "type": "string"
-                        }
-                      ],
-                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
-                    },
-                    "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
-                    "type": "array"
-                  },
-                  "dictionaryDefinitions": {
-                    "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "addWords": {
-                              "default": true,
-                              "description": "Indicate if this custom dictionary should be used to store added words.",
-                              "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                              "title": "Add Words to Dictionary",
-                              "type": "boolean"
-                            },
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional: A human readable description.",
-                              "markdownDescription": "Optional: A human readable description.",
-                              "title": "Description of the Dictionary",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                              "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                              "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                              "title": "Name of Dictionary",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                              "type": "string"
-                            },
-                            "scope": {
-                              "anyOf": [
-                                {
-                                  "description": "Specifies the scope of a dictionary.",
-                                  "enum": [
-                                    "user",
-                                    "workspace",
-                                    "folder"
-                                  ],
-                                  "markdownDescription": "Specifies the scope of a dictionary.",
-                                  "type": "string"
-                                },
-                                {
-                                  "items": {
-                                    "description": "Specifies the scope of a dictionary.",
-                                    "enum": [
-                                      "user",
-                                      "workspace",
-                                      "folder"
-                                    ],
-                                    "markdownDescription": "Specifies the scope of a dictionary.",
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              ],
-                              "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                              "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                              "title": "Scope of dictionary"
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "path"
-                          ],
-                          "type": "object"
                         },
                         {
-                          "additionalProperties": false,
-                          "properties": {
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional description of the contents / purpose of the dictionary.",
-                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "Path or url to the dictionary file.",
-                              "markdownDescription": "Path or url to the dictionary file.",
-                              "type": "string"
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "name"
-                          ],
-                          "type": "object"
-                        },
-                        {
-                          "additionalProperties": false,
-                          "properties": {
-                            "addWords": {
-                              "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                              "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                              "type": "boolean"
-                            },
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional description of the contents / purpose of the dictionary.",
-                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "A file path or url to a custom dictionary file.",
-                              "markdownDescription": "A file path or url to a custom dictionary file.",
-                              "type": "string"
-                            },
-                            "scope": {
-                              "anyOf": [
-                                {
-                                  "description": "Specifies the scope of a dictionary.",
-                                  "enum": [
-                                    "user",
-                                    "workspace",
-                                    "folder"
-                                  ],
-                                  "markdownDescription": "Specifies the scope of a dictionary.",
-                                  "type": "string"
-                                },
-                                {
-                                  "items": {
-                                    "description": "Specifies the scope of a dictionary.",
-                                    "enum": [
-                                      "user",
-                                      "workspace",
-                                      "folder"
-                                    ],
-                                    "markdownDescription": "Specifies the scope of a dictionary.",
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              ],
-                              "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
-                              "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "addWords",
-                            "name"
-                          ],
-                          "type": "object"
+                          "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                          "type": "string"
                         }
                       ]
                     },
-                    "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
-                    "scope": "resource",
-                    "title": "Dictionary Definitions",
                     "type": "array"
+                  }
+                ],
+                "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
+                "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
+              },
+              "locale": {
+                "anyOf": [
+                  {
+                    "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                    "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                    "type": "string"
                   },
-                  "enableFiletypes": {
-                    "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+                  {
                     "items": {
-                      "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                      "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                      "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                      "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
                       "type": "string"
                     },
-                    "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
-                    "scope": "resource",
-                    "title": "Enable File Types",
-                    "type": "array",
-                    "uniqueItems": true
-                  },
-                  "enabled": {
-                    "default": true,
-                    "description": "Is the spell checker enabled.",
-                    "markdownDescription": "Is the spell checker enabled.",
-                    "type": "boolean"
-                  },
-                  "enabledFileTypes": {
-                    "additionalProperties": {
-                      "type": "boolean"
-                    },
-                    "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
-                    "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
-                    "since": "8.8.1",
-                    "title": "Enabled File Types to Check",
-                    "type": "object"
-                  },
-                  "enabledLanguageIds": {
-                    "description": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
-                    "items": {
-                      "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                      "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                      "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                    "type": "array"
+                  }
+                ],
+                "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
+                "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
+              },
+              "name": {
+                "description": "Optional name of configuration.",
+                "markdownDescription": "Optional name of configuration.",
+                "type": "string"
+              },
+              "noSuggestDictionaries": {
+                "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                      "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                      "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
                       "type": "string"
                     },
-                    "markdownDescription": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
-                    "title": "Enabled Language Ids",
-                    "type": "array",
-                    "uniqueItems": true
-                  },
-                  "filename": {
-                    "anyOf": [
-                      {
-                        "description": "These are glob expressions.",
-                        "markdownDescription": "These are glob expressions.",
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "description": "These are glob expressions.",
-                          "markdownDescription": "These are glob expressions.",
+                    {
+                      "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                      "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                      "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                  "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                },
+                "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                "type": "array"
+              },
+              "patterns": {
+                "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "Description of the pattern.",
+                      "markdownDescription": "Description of the pattern.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                      "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "anyOf": [
+                        {
                           "type": "string"
                         },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      ],
+                      "description": "RegExp pattern or array of RegExp patterns.",
+                      "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "pattern"
+                  ],
+                  "type": "object"
+                },
+                "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                "type": "array"
+              },
+              "substitutionDefinitions": {
+                "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                  "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                  "properties": {
+                    "description": {
+                      "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                      "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                      "type": "string"
+                    },
+                    "entries": {
+                      "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                      "items": {
+                        "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                        "items": [
+                          {
+                            "title": "find",
+                            "type": "string"
+                          },
+                          {
+                            "title": "replacement",
+                            "type": "string"
+                          }
+                        ],
+                        "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "since": "9.7.0",
                         "type": "array"
-                      }
-                    ],
-                    "description": "Glob pattern or patterns to match against.",
-                    "markdownDescription": "Glob pattern or patterns to match against."
-                  },
-                  "flagWords": {
-                    "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
-                    "type": "array"
-                  },
-                  "id": {
-                    "description": "Optional identifier.",
-                    "markdownDescription": "Optional identifier.",
-                    "type": "string"
-                  },
-                  "ignoreRandomStrings": {
-                    "default": true,
-                    "description": "Ignore sequences of characters that look like random strings.",
-                    "markdownDescription": "Ignore sequences of characters that look like random strings.",
-                    "type": "boolean"
-                  },
-                  "ignoreRegExpList": {
-                    "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "description": "This matches the name in a pattern definition.",
-                          "markdownDescription": "This matches the name in a pattern definition.",
-                          "type": "string"
-                        },
-                        {
-                          "enum": [
-                            "Base64",
-                            "Base64MultiLine",
-                            "Base64SingleLine",
-                            "CStyleComment",
-                            "CStyleHexValue",
-                            "CSSHexValue",
-                            "CommitHash",
-                            "CommitHashLink",
-                            "Email",
-                            "EscapeCharacters",
-                            "HexValues",
-                            "href",
-                            "PhpHereDoc",
-                            "PublicKey",
-                            "RsaCert",
-                            "SshRsa",
-                            "SHA",
-                            "HashStrings",
-                            "SpellCheckerDisable",
-                            "SpellCheckerDisableBlock",
-                            "SpellCheckerDisableLine",
-                            "SpellCheckerDisableNext",
-                            "SpellCheckerIgnoreInDocSetting",
-                            "string",
-                            "UnicodeRef",
-                            "Urls",
-                            "UUID",
-                            "Everything"
-                          ],
-                          "type": "string"
-                        }
-                      ],
-                      "description": "A PatternRef is a Pattern or PatternId.",
-                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
-                    },
-                    "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "type": "array"
-                  },
-                  "ignoreWords": {
-                    "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
-                    "type": "array"
-                  },
-                  "includeRegExpList": {
-                    "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "description": "This matches the name in a pattern definition.",
-                          "markdownDescription": "This matches the name in a pattern definition.",
-                          "type": "string"
-                        },
-                        {
-                          "enum": [
-                            "Base64",
-                            "Base64MultiLine",
-                            "Base64SingleLine",
-                            "CStyleComment",
-                            "CStyleHexValue",
-                            "CSSHexValue",
-                            "CommitHash",
-                            "CommitHashLink",
-                            "Email",
-                            "EscapeCharacters",
-                            "HexValues",
-                            "href",
-                            "PhpHereDoc",
-                            "PublicKey",
-                            "RsaCert",
-                            "SshRsa",
-                            "SHA",
-                            "HashStrings",
-                            "SpellCheckerDisable",
-                            "SpellCheckerDisableBlock",
-                            "SpellCheckerDisableLine",
-                            "SpellCheckerDisableNext",
-                            "SpellCheckerIgnoreInDocSetting",
-                            "string",
-                            "UnicodeRef",
-                            "Urls",
-                            "UUID",
-                            "Everything"
-                          ],
-                          "type": "string"
-                        }
-                      ],
-                      "description": "A PatternRef is a Pattern or PatternId.",
-                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
-                    },
-                    "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "type": "array"
-                  },
-                  "language": {
-                    "description": "Sets the locale.",
-                    "markdownDescription": "Sets the locale.",
-                    "type": "string"
-                  },
-                  "languageId": {
-                    "anyOf": [
-                      {
-                        "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                        "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                        "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                        "type": "string"
                       },
-                      {
-                        "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                        "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                        "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                        "type": "string"
-                      },
-                      {
-                        "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                        "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                        "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "anyOf": [
-                            {
-                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "type": "array"
-                      }
-                    ],
-                    "description": "Sets the programming language id to match file type.",
-                    "markdownDescription": "Sets the programming language id to match file type."
-                  },
-                  "languageSettings": {
-                    "description": "Additional settings for individual programming languages and locales.",
-                    "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "allowCompoundWords": {
-                          "default": false,
-                          "description": "True to enable compound word checking.",
-                          "markdownDescription": "True to enable compound word checking.",
-                          "type": "boolean"
-                        },
-                        "caseSensitive": {
-                          "default": false,
-                          "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                          "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                          "type": "boolean"
-                        },
-                        "description": {
-                          "description": "Optional description of configuration.",
-                          "markdownDescription": "Optional description of configuration.",
-                          "type": "string"
-                        },
-                        "dictionaries": {
-                          "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                                "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                                "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                                "type": "string"
-                              },
-                              {
-                                "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                                "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                                "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                                "type": "string"
-                              }
-                            ],
-                            "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                            "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
-                          },
-                          "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
-                          "type": "array"
-                        },
-                        "dictionaryDefinitions": {
-                          "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "addWords": {
-                                    "default": true,
-                                    "description": "Indicate if this custom dictionary should be used to store added words.",
-                                    "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                                    "title": "Add Words to Dictionary",
-                                    "type": "boolean"
-                                  },
-                                  "btrie": {
-                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                                    "since": "9.6.0",
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "description": "Optional: A human readable description.",
-                                    "markdownDescription": "Optional: A human readable description.",
-                                    "title": "Description of the Dictionary",
-                                    "type": "string"
-                                  },
-                                  "ignoreForbiddenWords": {
-                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                                    "type": "boolean"
-                                  },
-                                  "name": {
-                                    "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                                    "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                                    "title": "Name of Dictionary",
-                                    "type": "string"
-                                  },
-                                  "noSuggest": {
-                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                                    "type": "boolean"
-                                  },
-                                  "path": {
-                                    "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                                    "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                                    "type": "string"
-                                  },
-                                  "scope": {
-                                    "anyOf": [
-                                      {
-                                        "description": "Specifies the scope of a dictionary.",
-                                        "enum": [
-                                          "user",
-                                          "workspace",
-                                          "folder"
-                                        ],
-                                        "markdownDescription": "Specifies the scope of a dictionary.",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "items": {
-                                          "description": "Specifies the scope of a dictionary.",
-                                          "enum": [
-                                            "user",
-                                            "workspace",
-                                            "folder"
-                                          ],
-                                          "markdownDescription": "Specifies the scope of a dictionary.",
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    ],
-                                    "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                                    "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                                    "title": "Scope of dictionary"
-                                  },
-                                  "supportNonStrictSearches": {
-                                    "default": true,
-                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "name",
-                                  "path"
-                                ],
-                                "type": "object"
-                              },
-                              {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "btrie": {
-                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                                    "since": "9.6.0",
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "description": "Optional description of the contents / purpose of the dictionary.",
-                                    "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                                    "type": "string"
-                                  },
-                                  "ignoreForbiddenWords": {
-                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                                    "type": "boolean"
-                                  },
-                                  "name": {
-                                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                                    "type": "string"
-                                  },
-                                  "noSuggest": {
-                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                                    "type": "boolean"
-                                  },
-                                  "path": {
-                                    "description": "Path or url to the dictionary file.",
-                                    "markdownDescription": "Path or url to the dictionary file.",
-                                    "type": "string"
-                                  },
-                                  "supportNonStrictSearches": {
-                                    "default": true,
-                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "path",
-                                  "name"
-                                ],
-                                "type": "object"
-                              },
-                              {
-                                "additionalProperties": false,
-                                "properties": {
-                                  "addWords": {
-                                    "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                                    "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                                    "type": "boolean"
-                                  },
-                                  "btrie": {
-                                    "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                                    "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                                    "since": "9.6.0",
-                                    "type": "string"
-                                  },
-                                  "description": {
-                                    "description": "Optional description of the contents / purpose of the dictionary.",
-                                    "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                                    "type": "string"
-                                  },
-                                  "ignoreForbiddenWords": {
-                                    "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                                    "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                                    "type": "boolean"
-                                  },
-                                  "name": {
-                                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                                    "type": "string"
-                                  },
-                                  "noSuggest": {
-                                    "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                                    "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                                    "type": "boolean"
-                                  },
-                                  "path": {
-                                    "description": "A file path or url to a custom dictionary file.",
-                                    "markdownDescription": "A file path or url to a custom dictionary file.",
-                                    "type": "string"
-                                  },
-                                  "scope": {
-                                    "anyOf": [
-                                      {
-                                        "description": "Specifies the scope of a dictionary.",
-                                        "enum": [
-                                          "user",
-                                          "workspace",
-                                          "folder"
-                                        ],
-                                        "markdownDescription": "Specifies the scope of a dictionary.",
-                                        "type": "string"
-                                      },
-                                      {
-                                        "items": {
-                                          "description": "Specifies the scope of a dictionary.",
-                                          "enum": [
-                                            "user",
-                                            "workspace",
-                                            "folder"
-                                          ],
-                                          "markdownDescription": "Specifies the scope of a dictionary.",
-                                          "type": "string"
-                                        },
-                                        "type": "array"
-                                      }
-                                    ],
-                                    "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
-                                    "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
-                                  },
-                                  "supportNonStrictSearches": {
-                                    "default": true,
-                                    "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                                    "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                                    "type": "boolean"
-                                  }
-                                },
-                                "required": [
-                                  "path",
-                                  "addWords",
-                                  "name"
-                                ],
-                                "type": "object"
-                              }
-                            ]
-                          },
-                          "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
-                          "scope": "resource",
-                          "title": "Dictionary Definitions",
-                          "type": "array"
-                        },
-                        "enabled": {
-                          "default": true,
-                          "description": "Is the spell checker enabled.",
-                          "markdownDescription": "Is the spell checker enabled.",
-                          "type": "boolean"
-                        },
-                        "flagWords": {
-                          "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
-                          "type": "array"
-                        },
-                        "id": {
-                          "description": "Optional identifier.",
-                          "markdownDescription": "Optional identifier.",
-                          "type": "string"
-                        },
-                        "ignoreRegExpList": {
-                          "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "description": "This matches the name in a pattern definition.",
-                                "markdownDescription": "This matches the name in a pattern definition.",
-                                "type": "string"
-                              },
-                              {
-                                "enum": [
-                                  "Base64",
-                                  "Base64MultiLine",
-                                  "Base64SingleLine",
-                                  "CStyleComment",
-                                  "CStyleHexValue",
-                                  "CSSHexValue",
-                                  "CommitHash",
-                                  "CommitHashLink",
-                                  "Email",
-                                  "EscapeCharacters",
-                                  "HexValues",
-                                  "href",
-                                  "PhpHereDoc",
-                                  "PublicKey",
-                                  "RsaCert",
-                                  "SshRsa",
-                                  "SHA",
-                                  "HashStrings",
-                                  "SpellCheckerDisable",
-                                  "SpellCheckerDisableBlock",
-                                  "SpellCheckerDisableLine",
-                                  "SpellCheckerDisableNext",
-                                  "SpellCheckerIgnoreInDocSetting",
-                                  "string",
-                                  "UnicodeRef",
-                                  "Urls",
-                                  "UUID",
-                                  "Everything"
-                                ],
-                                "type": "string"
-                              }
-                            ],
-                            "description": "A PatternRef is a Pattern or PatternId.",
-                            "markdownDescription": "A PatternRef is a Pattern or PatternId."
-                          },
-                          "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                          "type": "array"
-                        },
-                        "ignoreWords": {
-                          "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
-                          "type": "array"
-                        },
-                        "includeRegExpList": {
-                          "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "description": "This matches the name in a pattern definition.",
-                                "markdownDescription": "This matches the name in a pattern definition.",
-                                "type": "string"
-                              },
-                              {
-                                "enum": [
-                                  "Base64",
-                                  "Base64MultiLine",
-                                  "Base64SingleLine",
-                                  "CStyleComment",
-                                  "CStyleHexValue",
-                                  "CSSHexValue",
-                                  "CommitHash",
-                                  "CommitHashLink",
-                                  "Email",
-                                  "EscapeCharacters",
-                                  "HexValues",
-                                  "href",
-                                  "PhpHereDoc",
-                                  "PublicKey",
-                                  "RsaCert",
-                                  "SshRsa",
-                                  "SHA",
-                                  "HashStrings",
-                                  "SpellCheckerDisable",
-                                  "SpellCheckerDisableBlock",
-                                  "SpellCheckerDisableLine",
-                                  "SpellCheckerDisableNext",
-                                  "SpellCheckerIgnoreInDocSetting",
-                                  "string",
-                                  "UnicodeRef",
-                                  "Urls",
-                                  "UUID",
-                                  "Everything"
-                                ],
-                                "type": "string"
-                              }
-                            ],
-                            "description": "A PatternRef is a Pattern or PatternId.",
-                            "markdownDescription": "A PatternRef is a Pattern or PatternId."
-                          },
-                          "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                          "type": "array"
-                        },
-                        "languageId": {
-                          "anyOf": [
-                            {
-                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                              "type": "string"
-                            },
-                            {
-                              "items": {
-                                "anyOf": [
-                                  {
-                                    "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                                    "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                                    "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                                    "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                                    "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                                    "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                                    "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                                    "type": "string"
-                                  }
-                                ]
-                              },
-                              "type": "array"
-                            }
-                          ],
-                          "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
-                          "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
-                        },
-                        "locale": {
-                          "anyOf": [
-                            {
-                              "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                              "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                              "type": "string"
-                            },
-                            {
-                              "items": {
-                                "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                                "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                                "type": "string"
-                              },
-                              "type": "array"
-                            }
-                          ],
-                          "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
-                          "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
-                        },
-                        "name": {
-                          "description": "Optional name of configuration.",
-                          "markdownDescription": "Optional name of configuration.",
-                          "type": "string"
-                        },
-                        "noSuggestDictionaries": {
-                          "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                                "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                                "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                                "type": "string"
-                              },
-                              {
-                                "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                                "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                                "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                                "type": "string"
-                              }
-                            ],
-                            "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                            "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
-                          },
-                          "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
-                          "type": "array"
-                        },
-                        "patterns": {
-                          "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
-                          "items": {
-                            "additionalProperties": false,
-                            "properties": {
-                              "description": {
-                                "description": "Description of the pattern.",
-                                "markdownDescription": "Description of the pattern.",
-                                "type": "string"
-                              },
-                              "name": {
-                                "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
-                                "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
-                                "type": "string"
-                              },
-                              "pattern": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "type": "array"
-                                  }
-                                ],
-                                "description": "RegExp pattern or array of RegExp patterns.",
-                                "markdownDescription": "RegExp pattern or array of RegExp patterns."
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "pattern"
-                            ],
-                            "type": "object"
-                          },
-                          "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
-                          "type": "array"
-                        },
-                        "substitutionDefinitions": {
-                          "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                          "items": {
-                            "additionalProperties": false,
-                            "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
-                            "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
-                            "properties": {
-                              "description": {
-                                "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
-                                "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
-                                "type": "string"
-                              },
-                              "entries": {
-                                "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
-                                "items": {
-                                  "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                                  "items": [
-                                    {
-                                      "title": "find",
-                                      "type": "string"
-                                    },
-                                    {
-                                      "title": "replacement",
-                                      "type": "string"
-                                    }
-                                  ],
-                                  "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                                  "maxItems": 2,
-                                  "minItems": 2,
-                                  "since": "9.7.0",
-                                  "type": "array"
-                                },
-                                "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
-                                "type": "array"
-                              },
-                              "name": {
-                                "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                                "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                                "since": "9.7.0",
-                                "type": "string"
-                              }
-                            },
-                            "required": [
-                              "name",
-                              "entries"
-                            ],
-                            "since": "9.7.0",
-                            "type": "object"
-                          },
-                          "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                          "since": "9.7.0",
-                          "type": "array"
-                        },
-                        "substitutions": {
-                          "description": "The set of substitutions to apply to a document before spell checking.",
-                          "items": {
-                            "anyOf": [
-                              {
-                                "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                                "items": [
-                                  {
-                                    "title": "find",
-                                    "type": "string"
-                                  },
-                                  {
-                                    "title": "replacement",
-                                    "type": "string"
-                                  }
-                                ],
-                                "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                                "maxItems": 2,
-                                "minItems": 2,
-                                "since": "9.7.0",
-                                "type": "array"
-                              },
-                              {
-                                "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                                "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                                "since": "9.7.0",
-                                "type": "string"
-                              }
-                            ]
-                          },
-                          "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
-                          "since": "9.7.0",
-                          "type": "array"
-                        },
-                        "suggestWords": {
-                          "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
-                          "items": {
-                            "type": "string"
-                          },
-                          "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-                          "type": "array"
-                        },
-                        "unknownWords": {
-                          "default": "report-all",
-                          "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                          "enum": [
-                            "report-all",
-                            "report-simple",
-                            "report-common-typos",
-                            "report-flagged"
-                          ],
-                          "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                          "since": "9.1.0",
-                          "type": "string"
-                        },
-                        "useIntlWordSegmentation": {
-                          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-                          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
-                          "since": "10.2.0",
-                          "type": "boolean"
-                        },
-                        "words": {
-                          "description": "List of words to be considered correct.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "markdownDescription": "List of words to be considered correct.",
-                          "type": "array"
-                        }
-                      },
-                      "required": [
-                        "languageId"
-                      ],
-                      "type": "object"
+                      "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                      "type": "array"
                     },
-                    "markdownDescription": "Additional settings for individual programming languages and locales.",
-                    "scope": "resource",
-                    "type": "array"
-                  },
-                  "loadDefaultConfiguration": {
-                    "default": true,
-                    "description": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false` will prevent ALL default configuration from being loaded.",
-                    "markdownDescription": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false`\nwill prevent ALL default configuration from being loaded.",
-                    "type": "boolean"
-                  },
-                  "maxDuplicateProblems": {
-                    "default": 5,
-                    "description": "The maximum number of times the same word can be flagged as an error in a file.",
-                    "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
-                    "type": "number"
-                  },
-                  "maxFileSize": {
-                    "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
-                    "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
-                    "since": "9.4.0",
-                    "type": [
-                      "number",
-                      "string"
-                    ]
-                  },
-                  "maxNumberOfProblems": {
-                    "default": 10000,
-                    "description": "The maximum number of problems to report in a file.",
-                    "markdownDescription": "The maximum number of problems to report in a file.",
-                    "type": "number"
-                  },
-                  "minRandomLength": {
-                    "default": 40,
-                    "description": "The minimum length of a random string to be ignored.",
-                    "markdownDescription": "The minimum length of a random string to be ignored.",
-                    "type": "number"
-                  },
-                  "minWordLength": {
-                    "default": 4,
-                    "description": "The minimum length of a word before checking it against a dictionary.",
-                    "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
-                    "type": "number"
-                  },
-                  "name": {
-                    "description": "Optional name of configuration.",
-                    "markdownDescription": "Optional name of configuration.",
-                    "type": "string"
-                  },
-                  "noSuggestDictionaries": {
-                    "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
-                        },
-                        {
-                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
-                        }
-                      ],
-                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
-                    },
-                    "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
-                    "type": "array"
-                  },
-                  "numSuggestions": {
-                    "default": 10,
-                    "description": "Number of suggestions to make.",
-                    "markdownDescription": "Number of suggestions to make.",
-                    "type": "number"
-                  },
-                  "patterns": {
-                    "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
-                    "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "description": "Description of the pattern.",
-                          "markdownDescription": "Description of the pattern.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
-                          "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
-                          "type": "string"
-                        },
-                        "pattern": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "items": {
-                                "type": "string"
-                              },
-                              "type": "array"
-                            }
-                          ],
-                          "description": "RegExp pattern or array of RegExp patterns.",
-                          "markdownDescription": "RegExp pattern or array of RegExp patterns."
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "pattern"
-                      ],
-                      "type": "object"
-                    },
-                    "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
-                    "type": "array"
-                  },
-                  "pnpFiles": {
-                    "default": [
-                      ".pnp.js",
-                      ".pnp.cjs"
-                    ],
-                    "description": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
-                    "type": "array"
-                  },
-                  "substitutionDefinitions": {
-                    "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                    "items": {
-                      "additionalProperties": false,
-                      "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
-                      "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
-                      "properties": {
-                        "description": {
-                          "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
-                          "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
-                          "type": "string"
-                        },
-                        "entries": {
-                          "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
-                          "items": {
-                            "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                            "items": [
-                              {
-                                "title": "find",
-                                "type": "string"
-                              },
-                              {
-                                "title": "replacement",
-                                "type": "string"
-                              }
-                            ],
-                            "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                            "maxItems": 2,
-                            "minItems": 2,
-                            "since": "9.7.0",
-                            "type": "array"
-                          },
-                          "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "since": "9.7.0",
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "entries"
-                      ],
+                    "name": {
+                      "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
                       "since": "9.7.0",
-                      "type": "object"
-                    },
-                    "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                    "since": "9.7.0",
-                    "type": "array"
-                  },
-                  "substitutions": {
-                    "description": "The set of substitutions to apply to a document before spell checking.",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                          "items": [
-                            {
-                              "title": "find",
-                              "type": "string"
-                            },
-                            {
-                              "title": "replacement",
-                              "type": "string"
-                            }
-                          ],
-                          "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                          "maxItems": 2,
-                          "minItems": 2,
-                          "since": "9.7.0",
-                          "type": "array"
-                        },
-                        {
-                          "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "since": "9.7.0",
-                          "type": "string"
-                        }
-                      ]
-                    },
-                    "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
-                    "since": "9.7.0",
-                    "type": "array"
-                  },
-                  "suggestWords": {
-                    "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
-                    "items": {
                       "type": "string"
-                    },
-                    "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-                    "type": "array"
+                    }
                   },
-                  "suggestionNumChanges": {
-                    "default": 3,
-                    "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
-                    "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
-                    "type": "number"
-                  },
-                  "suggestionsTimeout": {
-                    "default": 500,
-                    "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
-                    "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
-                    "type": "number"
-                  },
-                  "unknownWords": {
-                    "default": "report-all",
-                    "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                    "enum": [
-                      "report-all",
-                      "report-simple",
-                      "report-common-typos",
-                      "report-flagged"
-                    ],
-                    "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                    "since": "9.1.0",
-                    "type": "string"
-                  },
-                  "useIntlWordSegmentation": {
-                    "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-                    "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
-                    "since": "10.2.0",
-                    "type": "boolean"
-                  },
-                  "usePnP": {
-                    "default": false,
-                    "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
-                    "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
-                    "type": "boolean"
-                  },
-                  "words": {
-                    "description": "List of words to be considered correct.",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "List of words to be considered correct.",
-                    "type": "array"
-                  }
+                  "required": [
+                    "name",
+                    "entries"
+                  ],
+                  "since": "9.7.0",
+                  "type": "object"
                 },
-                "required": [
-                  "filename"
-                ],
-                "type": "object"
+                "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                "since": "9.7.0",
+                "type": "array"
               },
-              "markdownDescription": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc\n\"cSpell.overrides\": [\n  // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:\n  {\n    \"filename\": \"**/{*.hrr,*.crr}\",\n    \"languageId\": \"cpp\"\n  },\n  // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):\n  {\n    \"filename\": \"**/dutch/**/*.txt\",\n    \"language\": \"nl\"\n  }\n]\n```",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.patterns": {
-              "description": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and `#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc \"cSpell.patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   } ] ```",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "description": {
-                    "description": "Description of the pattern.",
-                    "markdownDescription": "Description of the pattern.",
-                    "type": "string"
-                  },
-                  "name": {
-                    "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
-                    "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
-                    "type": "string"
-                  },
-                  "pattern": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "type": "string"
-                        },
-                        "type": "array"
-                      }
-                    ],
-                    "description": "RegExp pattern or array of RegExp patterns.",
-                    "markdownDescription": "RegExp pattern or array of RegExp patterns."
-                  }
-                },
-                "required": [
-                  "name",
-                  "pattern"
-                ],
-                "type": "object"
-              },
-              "markdownDescription": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and\n`#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc\n\"cSpell.patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  }\n]\n```",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.substitutionDefinitions": {
-              "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-              "items": {
-                "additionalProperties": false,
-                "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
-                "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
-                "properties": {
-                  "description": {
-                    "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
-                    "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
-                    "type": "string"
-                  },
-                  "entries": {
-                    "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
-                    "items": {
+              "substitutions": {
+                "description": "The set of substitutions to apply to a document before spell checking.",
+                "items": {
+                  "anyOf": [
+                    {
                       "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
                       "items": [
                         {
@@ -1744,1428 +1060,1120 @@
                       "since": "9.7.0",
                       "type": "array"
                     },
-                    "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
-                    "type": "array"
-                  },
-                  "name": {
-                    "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                    "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                    "since": "9.7.0",
-                    "type": "string"
-                  }
+                    {
+                      "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "since": "9.7.0",
+                      "type": "string"
+                    }
+                  ]
                 },
-                "required": [
-                  "name",
-                  "entries"
-                ],
+                "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
                 "since": "9.7.0",
-                "type": "object"
+                "type": "array"
               },
-              "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-              "since": "9.7.0",
-              "type": "array"
-            },
-            "cSpell.substitutions": {
-              "description": "The set of substitutions to apply to a document before spell checking.",
-              "items": {
-                "anyOf": [
-                  {
-                    "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                    "items": [
-                      {
-                        "title": "find",
-                        "type": "string"
-                      },
-                      {
-                        "title": "replacement",
-                        "type": "string"
-                      }
-                    ],
-                    "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                    "maxItems": 2,
-                    "minItems": 2,
-                    "since": "9.7.0",
-                    "type": "array"
-                  },
-                  {
-                    "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                    "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                    "since": "9.7.0",
-                    "type": "string"
-                  }
-                ]
-              },
-              "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
-              "since": "9.7.0",
-              "type": "array"
-            },
-            "cSpell.unknownWords": {
-              "default": "report-all",
-              "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-              "enum": [
-                "report-all",
-                "report-simple",
-                "report-common-typos",
-                "report-flagged"
-              ],
-              "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-              "since": "9.1.0",
-              "type": "string"
-            },
-            "cSpell.useIntlWordSegmentation": {
-              "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-              "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
-              "since": "10.2.0",
-              "type": "boolean"
-            },
-            "cSpell.vfs": {
-              "additionalProperties": {
-                "additionalProperties": false,
-                "description": "An entry in the CSpell Virtual File System. It may or may not have a URL.",
-                "markdownDescription": "An entry in the CSpell Virtual File System.\nIt may or may not have a URL.",
-                "properties": {
-                  "data": {
-                    "description": "The content data of the file.",
-                    "markdownDescription": "The content data of the file.",
-                    "type": "string"
-                  },
-                  "encoding": {
-                    "description": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
-                    "enum": [
-                      "base64",
-                      "plaintext",
-                      "utf8"
-                    ],
-                    "markdownDescription": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
-                    "type": "string"
-                  },
-                  "url": {
-                    "description": "The optional file vfs url. It is already part of the CSpellVFS key.",
-                    "markdownDescription": "The optional file vfs url. It is already part of the CSpellVFS key.",
-                    "since": "9.7.0",
-                    "type": "string"
-                  }
+              "suggestWords": {
+                "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                "items": {
+                  "type": "string"
                 },
-                "required": [
-                  "data"
-                ],
-                "since": "9.7.0",
-                "type": "object"
+                "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                "type": "array"
               },
-              "description": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
-              "markdownDescription": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
-              "since": "9.7.0",
-              "type": "object"
-            }
-          },
-          "title": "CSpell",
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Experimental settings that may change or be removed in the future.",
-          "order": 19,
-          "properties": {
-            "cSpell.experimental.enableRegexpView": {
-              "default": false,
-              "description": "Show Regular Expression Explorer",
-              "markdownDescription": "Show Regular Expression Explorer",
-              "scope": "application",
-              "type": "boolean"
-            },
-            "cSpell.experimental.symbols": {
-              "default": false,
-              "description": "Experiment with executeDocumentSymbolProvider. This feature is experimental and will be removed in the future.",
-              "markdownDescription": "Experiment with executeDocumentSymbolProvider.\nThis feature is experimental and will be removed in the future.",
-              "scope": "application",
-              "title": "Experiment with `executeDocumentSymbolProvider`",
-              "type": "boolean"
-            },
-            "cSpell.reportUnknownWords": {
-              "deprecated": true,
-              "deprecationMessage": "Use Unknown Words settings instead.",
-              "description": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only reporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
-              "enum": [
-                "all",
-                "simple",
-                "typos",
-                "flagged"
-              ],
-              "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
-              "scope": "language-overridable",
-              "title": "Strict Spell Checking",
-              "type": "string"
-            }
-          },
-          "title": "Experimental",
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Settings that control which files and folders are spell checked.",
-          "order": 3,
-          "properties": {
-            "cSpell.allowedSchemas": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.enabledSchemes#` instead.",
-              "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
-              "items": {
+              "unknownWords": {
+                "default": "report-all",
+                "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                "enum": [
+                  "report-all",
+                  "report-simple",
+                  "report-common-typos",
+                  "report-flagged"
+                ],
+                "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                "since": "9.1.0",
                 "type": "string"
               },
-              "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
-              "scope": "window",
-              "title": "Define Allowed Schemes",
-              "type": "array"
-            },
-            "cSpell.checkOnlyEnabledFileTypes": {
-              "default": true,
-              "description": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#` to turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`. See `#cSpell.enabledFileTypes#` on how to disable a file type.",
-              "markdownDescription": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`.\nSee `#cSpell.enabledFileTypes#` on how to disable a file type.",
-              "scope": "resource",
-              "title": "Check Only Enabled File Types",
-              "type": "boolean"
-            },
-            "cSpell.checkVSCodeSystemFiles": {
-              "default": false,
-              "description": "Spell check VS Code system files. These include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
-              "markdownDescription": "Spell check VS Code system files.\nThese include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
-              "scope": "application",
-              "type": "boolean"
-            },
-            "cSpell.enableFiletypes": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
-              "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`. To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
-              "items": {
-                "description": "Enable / Disable checking file types (languageIds). To disable a language, prefix with `!` as in `!json`,\n\n\nExample: ``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```",
-                "markdownDescription": "Enable / Disable checking file types (languageIds).\nTo disable a language, prefix with `!` as in `!json`,\n\n\nExample:\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```",
-                "pattern": "(^!*(?!\\s)[\\s\\w_.\\-]+$)|(^!*[*]$)",
-                "patternErrorMessage": "Allowed characters are `a-zA-Z`, `.`, `-`, `_` and space.",
-                "type": "string"
-              },
-              "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`.\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
-              "scope": "resource",
-              "title": "Enable File Types",
-              "type": "array",
-              "uniqueItems": true
-            },
-            "cSpell.enabledFileTypes": {
-              "additionalProperties": {
+              "useIntlWordSegmentation": {
+                "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                "since": "10.2.0",
                 "type": "boolean"
               },
-              "default": {
-                "*": true,
-                "markdown": true
-              },
-              "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
-              "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
-              "scope": "resource",
-              "title": "Enabled File Types to Check",
-              "type": "object"
+              "words": {
+                "description": "List of words to be considered correct.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to be considered correct.",
+                "type": "array"
+              }
             },
-            "cSpell.enabledSchemes": {
-              "additionalProperties": {
-                "type": "boolean"
-              },
-              "default": {
-                "chatSessionInput": true,
-                "comment": true,
-                "file": true,
-                "gist": true,
-                "repo": true,
-                "sftp": true,
-                "untitled": true,
-                "vscode-notebook-cell": true,
-                "vscode-scm": true,
-                "vscode-userdata": true,
-                "vscode-vfs": true,
-                "vsls": true
-              },
-              "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry. This is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment | | ------ | ------- | ------- | | `*`    | `true`  | Enable all schemes. | | `git`  | `false` | Do not check documents provided by the `git` file system. |",
-              "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry.\nThis is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment |\n| ------ | ------- | ------- |\n| `*`    | `true`  | Enable all schemes. |\n| `git`  | `false` | Do not check documents provided by the `git` file system. |",
-              "scope": "window",
-              "title": "Specify Allowed Schemes",
-              "type": "object"
-            },
-            "cSpell.files": {
-              "description": "Glob patterns of files to be checked. Glob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
-              "items": {
-                "description": "These are glob expressions.",
-                "markdownDescription": "These are glob expressions.",
+            "required": [
+              "languageId"
+            ],
+            "type": "object"
+          },
+          "markdownDescription": "Additional settings for individual programming languages and locales.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.noSuggestDictionaries": {
+          "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.suggestWords": {
+          "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+          "type": "array"
+        },
+        "cSpell.useLocallyInstalledCSpellDictionaries": {
+          "default": true,
+          "description": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
+          "markdownDescription": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
+          "scope": "resource",
+          "sinceVersion": "4.0.0",
+          "type": "boolean"
+        },
+        "cSpell.userWords": {
+          "description": "Words to add to global dictionary -- should only be in the user config file.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Words to add to global dictionary -- should only be in the user config file.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.words": {
+          "description": "List of words to be considered correct.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of words to be considered correct.",
+          "scope": "resource",
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-5124-5774-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.autoFormatConfigFile": {
+          "default": false,
+          "description": "If a `cspell` configuration file is updated, format the configuration file using the VS Code Format Document Provider. This will cause the configuration file to be saved prior to being updated.",
+          "markdownDescription": "If a `cspell` configuration file is updated, format the configuration file\nusing the VS Code Format Document Provider. This will cause the configuration\nfile to be saved prior to being updated.",
+          "scope": "window",
+          "title": "Auto Format Configuration File",
+          "type": "boolean"
+        },
+        "cSpell.autocorrect": {
+          "default": false,
+          "description": "Enable / Disable autocorrect while typing.",
+          "markdownDescription": "Enable / Disable autocorrect while typing.",
+          "scope": "resource",
+          "title": "Autocorrect",
+          "type": "boolean"
+        },
+        "cSpell.diagnosticLevel": {
+          "$ref": "#/definitions/DiagnosticLevel",
+          "default": "Information",
+          "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems"
+          ],
+          "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "scope": "resource",
+          "title": "Set Diagnostic Reporting Level"
+        },
+        "cSpell.diagnosticLevelFlaggedWords": {
+          "$ref": "#/definitions/DiagnosticLevel",
+          "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "enumDescriptions": [
+            "Report Spelling Issues as Errors",
+            "Report Spelling Issues as Warnings",
+            "Report Spelling Issues as Information",
+            "Report Spelling Issues as Hints, will not show up in Problems"
+          ],
+          "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+          "scope": "resource",
+          "sinceVersion": "4.0.0",
+          "title": "Set Diagnostic Reporting Level for Flagged Words"
+        },
+        "cSpell.enabledNotifications": {
+          "$ref": "#/definitions/EnabledNotifications",
+          "default": {
+            "Average Word Length too Long": true,
+            "Lines too Long": true,
+            "Maximum Word Length Exceeded": true
+          },
+          "description": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
+          "markdownDescription": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
+          "scope": "resource",
+          "sinceVersion": "4.0.41",
+          "title": "Enabled Notifications"
+        },
+        "cSpell.hideAddToDictionaryCodeActions": {
+          "default": false,
+          "description": "Hide the options to add words to dictionaries or settings.",
+          "markdownDescription": "Hide the options to add words to dictionaries or settings.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.hideIssuesWhileTyping": {
+          "default": "Word",
+          "description": "Control how spelling issues are displayed while typing. See: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
+          "enum": [
+            "Off",
+            "Word",
+            "Line",
+            "Document"
+          ],
+          "enumDescriptions": [
+            "Show issues while typing",
+            "Hide issues while typing in the current word",
+            "Hide issues while typing on the line",
+            "Hide all issues while typing in the document"
+          ],
+          "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "title": "Hide Issues While Typing",
+          "type": "string"
+        },
+        "cSpell.maxDuplicateProblems": {
+          "default": 20,
+          "description": "The maximum number of times the same word can be flagged as an error in a file.",
+          "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.maxNumberOfProblems": {
+          "default": 100,
+          "description": "Controls the maximum number of spelling errors per document.",
+          "markdownDescription": "Controls the maximum number of spelling errors per document.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.minWordLength": {
+          "default": 4,
+          "description": "The minimum length of a word before checking it against a dictionary.",
+          "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.numSuggestions": {
+          "default": 8,
+          "description": "Controls the number of suggestions shown.",
+          "markdownDescription": "Controls the number of suggestions shown.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.revealIssuesAfterDelayMS": {
+          "default": 1500,
+          "description": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+          "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "title": "Reveal Issues After a Delay in Milliseconds",
+          "type": "number"
+        },
+        "cSpell.showAutocompleteDirectiveSuggestions": {
+          "default": true,
+          "description": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
+          "markdownDescription": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
+          "scope": "language-overridable",
+          "type": "boolean"
+        },
+        "cSpell.showCommandsInEditorContextMenu": {
+          "default": true,
+          "description": "Show Spell Checker actions in Editor Context Menu",
+          "markdownDescription": "Show Spell Checker actions in Editor Context Menu",
+          "scope": "application",
+          "type": "boolean"
+        },
+        "cSpell.showSuggestionsLinkInEditorContextMenu": {
+          "default": true,
+          "description": "Show Spelling Suggestions link in the top level context menu.",
+          "markdownDescription": "Show Spelling Suggestions link in the top level context menu.",
+          "scope": "application",
+          "type": "boolean"
+        },
+        "cSpell.suggestionMenuType": {
+          "default": "quickPick",
+          "description": "The type of menu used to display spelling suggestions.",
+          "enum": [
+            "quickPick",
+            "quickFix"
+          ],
+          "enumDescriptions": [
+            "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
+            "Suggestions will appear inline near the word, inside the text editor."
+          ],
+          "markdownDescription": "The type of menu used to display spelling suggestions.",
+          "scope": "resource",
+          "type": "string"
+        },
+        "cSpell.suggestionNumChanges": {
+          "default": 3,
+          "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+          "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.validateDirectives": {
+          "description": "Verify that the in-document directives are correct.",
+          "markdownDescription": "Verify that the in-document directives are correct.",
+          "scope": "window",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-5946-6234-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
+          "default": 200,
+          "description": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "scope": "language-overridable",
+          "type": "number"
+        },
+        "cSpell.blockCheckingWhenLineLengthGreaterThan": {
+          "default": 20000,
+          "description": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given. This is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "markdownDescription": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "scope": "language-overridable",
+          "type": "number"
+        },
+        "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
+          "default": 1000,
+          "description": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
+          "scope": "language-overridable",
+          "type": "number"
+        },
+        "cSpell.checkLimit": {
+          "default": 500,
+          "description": "Set the maximum number of blocks of text to check. Each block is 1024 characters.",
+          "markdownDescription": "Set the maximum number of blocks of text to check.\nEach block is 1024 characters.",
+          "scope": "resource",
+          "type": "number"
+        },
+        "cSpell.spellCheckDelayMs": {
+          "default": 50,
+          "description": "Delay in ms after a document has changed before checking it for spelling errors.",
+          "markdownDescription": "Delay in ms after a document has changed before checking it for spelling errors.",
+          "scope": "application",
+          "type": "number"
+        },
+        "cSpell.suggestionsTimeout": {
+          "default": 400,
+          "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+          "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+          "scope": "resource",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-6391-6748-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.engines": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "description": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
+                "markdownDescription": "Semantic Version Predicate\n\nExamples:\n- `>=8`",
                 "type": "string"
               },
-              "markdownDescription": "Glob patterns of files to be checked.\nGlob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
-              "scope": "resource",
-              "title": "Glob patterns of files to be checked",
-              "type": "array"
-            },
-            "cSpell.globRoot": {
-              "description": "The root to use for glob patterns found in this configuration. Default: The current workspace folder. Use `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
-              "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: The current workspace folder.\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file.\nDefining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
-              "scope": "resource",
+              {
+                "not": {}
+              }
+            ],
+            "description": "Other engine version predicates.",
+            "markdownDescription": "Other engine version predicates."
+          },
+          "description": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
+          "markdownDescription": "Specify compatible engine versions.\n\nThis allows dictionaries and other components to specify the versions of engines (like cspell) they are compatible with.\n\nIt does not enforce compatibility, it is up to the client to use this information as needed.",
+          "properties": {
+            "code-spell-checker": {
+              "description": "The VSCode Spell Checker version predicate.",
+              "markdownDescription": "The VSCode Spell Checker version predicate.",
+              "since": "9.6.3",
               "type": "string"
             },
-            "cSpell.ignorePaths": {
-              "default": [
-                "package-lock.json",
-                "node_modules",
-                "vscode-extension",
-                ".git/{info,lfs,logs,refs,objects}/**",
-                ".git/{index,*refs,*HEAD}",
-                ".vscode",
-                ".vscode-insiders"
-              ],
-              "description": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
-              "items": {
-                "description": "Simple Glob string, the root will be globRoot.",
-                "markdownDescription": "Simple Glob string, the root will be globRoot.",
-                "type": "string"
-              },
-              "markdownDescription": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
-              "scope": "resource",
-              "title": "Glob patterns of files to be ignored",
-              "type": "array"
-            },
-            "cSpell.import": {
-              "description": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
-              "items": {
-                "description": "A File System Path. Relative paths are relative to the configuration file.",
-                "markdownDescription": "A File System Path. Relative paths are relative to the configuration file.",
-                "type": "string"
-              },
-              "markdownDescription": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.mergeCSpellSettings": {
-              "default": true,
-              "description": "Specify if fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
-              "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
-              "scope": "resource",
-              "sinceVersion": "4.0.0",
-              "type": "boolean"
-            },
-            "cSpell.mergeCSpellSettingsFields": {
-              "additionalProperties": false,
-              "default": {
-                "allowCompoundWords": true,
-                "caseSensitive": true,
-                "dictionaries": true,
-                "dictionaryDefinitions": true,
-                "enableGlobDot": true,
-                "features": true,
-                "files": true,
-                "flagWords": true,
-                "gitignoreRoot": true,
-                "globRoot": true,
-                "ignorePaths": true,
-                "ignoreRegExpList": true,
-                "ignoreWords": true,
-                "import": true,
-                "includeRegExpList": true,
-                "language": true,
-                "languageId": true,
-                "languageSettings": true,
-                "loadDefaultConfiguration": true,
-                "minWordLength": true,
-                "noConfigSearch": true,
-                "noSuggestDictionaries": true,
-                "numSuggestions": true,
-                "overrides": true,
-                "patterns": true,
-                "pnpFiles": true,
-                "reporters": true,
-                "suggestWords": true,
-                "useGitignore": true,
-                "usePnP": true,
-                "userWords": true,
-                "validateDirectives": true,
-                "words": true
-              },
-              "description": "Specify which fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace and `#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample: ```jsonc \"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false } ```",
-              "markdownDescription": "Specify which fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace and\n`#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample:\n```jsonc\n\"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false }\n```",
-              "properties": {
-                "allowCompoundWords": {
-                  "type": "boolean"
-                },
-                "caseSensitive": {
-                  "type": "boolean"
-                },
-                "dictionaries": {
-                  "type": "boolean"
-                },
-                "dictionaryDefinitions": {
-                  "type": "boolean"
-                },
-                "enableGlobDot": {
-                  "type": "boolean"
-                },
-                "features": {
-                  "type": "boolean"
-                },
-                "files": {
-                  "type": "boolean"
-                },
-                "flagWords": {
-                  "type": "boolean"
-                },
-                "gitignoreRoot": {
-                  "type": "boolean"
-                },
-                "globRoot": {
-                  "type": "boolean"
-                },
-                "ignorePaths": {
-                  "type": "boolean"
-                },
-                "ignoreRegExpList": {
-                  "type": "boolean"
-                },
-                "ignoreWords": {
-                  "type": "boolean"
-                },
-                "import": {
-                  "type": "boolean"
-                },
-                "includeRegExpList": {
-                  "type": "boolean"
-                },
-                "language": {
-                  "type": "boolean"
-                },
-                "languageId": {
-                  "type": "boolean"
-                },
-                "languageSettings": {
-                  "type": "boolean"
-                },
-                "loadDefaultConfiguration": {
-                  "type": "boolean"
-                },
-                "minWordLength": {
-                  "type": "boolean"
-                },
-                "noConfigSearch": {
-                  "type": "boolean"
-                },
-                "noSuggestDictionaries": {
-                  "type": "boolean"
-                },
-                "numSuggestions": {
-                  "type": "boolean"
-                },
-                "overrides": {
-                  "type": "boolean"
-                },
-                "patterns": {
-                  "type": "boolean"
-                },
-                "pnpFiles": {
-                  "type": "boolean"
-                },
-                "reporters": {
-                  "type": "boolean"
-                },
-                "suggestWords": {
-                  "type": "boolean"
-                },
-                "useGitignore": {
-                  "type": "boolean"
-                },
-                "usePnP": {
-                  "type": "boolean"
-                },
-                "userWords": {
-                  "type": "boolean"
-                },
-                "validateDirectives": {
-                  "type": "boolean"
-                },
-                "words": {
-                  "type": "boolean"
-                }
-              },
-              "scope": "resource",
-              "sinceVersion": "4.0.0",
-              "type": "object"
-            },
-            "cSpell.noConfigSearch": {
-              "description": "Prevents searching for local configuration when checking individual documents.",
-              "markdownDescription": "Prevents searching for local configuration when checking individual documents.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.spellCheckOnlyWorkspaceFiles": {
-              "default": false,
-              "description": "Only spell check files that are in the currently open workspace. This same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js \"cSpell.files\": [\"/**\"] ```",
-              "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js\n\"cSpell.files\": [\"/**\"]\n```",
-              "scope": "window",
-              "title": "Spell Check Only Workspace Files",
-              "type": "boolean"
-            },
-            "cSpell.useGitignore": {
-              "default": true,
-              "description": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
-              "markdownDescription": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.usePnP": {
-              "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
-              "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.workspaceRootPath": {
-              "description": "Define the path to the workspace root folder in a multi-root workspace. By default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder** ``` ${workspaceFolder:client} ```",
-              "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder**\n```\n${workspaceFolder:client}\n```",
-              "scope": "resource",
-              "title": "Workspace Root Folder Path",
+            "cspell": {
+              "description": "CSpell version predicate.",
+              "markdownDescription": "CSpell version predicate.",
+              "since": "9.6.3",
               "type": "string"
             }
           },
-          "title": "Files, Folders, and Workspaces",
+          "since": "9.6.3",
           "type": "object"
         },
-        {
-          "additionalProperties": false,
-          "description": "Settings that control dictionaries and language preferences.",
-          "order": 1,
-          "properties": {
-            "cSpell.caseSensitive": {
-              "description": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.   **Note:** Some languages like Portuguese have case sensitivity turned on by default.   You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
-              "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.customDictionaries": {
-              "additionalProperties": {
+        "cSpell.ignoreRandomStrings": {
+          "default": true,
+          "description": "Ignore sequences of characters that look like random strings.",
+          "markdownDescription": "Ignore sequences of characters that look like random strings.",
+          "type": "boolean"
+        },
+        "cSpell.ignoreRegExpList": {
+          "description": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,   it is necessary to escape `\\`.   Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  | | :------------------ | :-------------------- | :------------------------------------------- | | `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         | | `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    | | `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of regular expressions or Pattern names (defined in `#cSpell.patterns#`) to exclude from spell checking.\n\n- When using the VS Code Preferences UI, it is not necessary to escape the `\\`, VS Code takes care of that.\n- When editing the VS Code `settings.json` file,\n  it is necessary to escape `\\`.\n  Each `\\` becomes `\\\\`.\n\nThe default regular expression flags are `gi`. Add `u` (`gui`), to enable Unicode.\n\n| VS Code UI          | settings.json         | Description                                  |\n| :------------------ | :-------------------- | :------------------------------------------- |\n| `/\\\\[a-z]+/gi`      | `/\\\\\\\\[a-z]+/gi`      | Exclude LaTeX command like `\\mapsto`         |\n| `/\\b[A-Z]{3,5}\\b/g` | `/\\\\b[A-Z]{3,5}\\\\b/g` | Exclude full-caps acronyms of 3-5 length.    |\n| `CStyleComment`     | `CStyleComment`       | A built in pattern                           |",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.includeRegExpList": {
+          "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.maxFileSize": {
+          "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+          "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+          "since": "9.4.0",
+          "type": [
+            "number",
+            "string"
+          ]
+        },
+        "cSpell.minRandomLength": {
+          "default": 40,
+          "description": "The minimum length of a random string to be ignored.",
+          "markdownDescription": "The minimum length of a random string to be ignored.",
+          "type": "number"
+        },
+        "cSpell.overrides": {
+          "description": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc \"cSpell.overrides\": [   // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:   {     \"filename\": \"**/{*.hrr,*.crr}\",     \"languageId\": \"cpp\"   },   // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):   {     \"filename\": \"**/dutch/**/*.txt\",     \"language\": \"nl\"   } ] ```",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "allowCompoundWords": {
+                "default": false,
+                "description": "True to enable compound word checking.",
+                "markdownDescription": "True to enable compound word checking.",
+                "type": "boolean"
+              },
+              "caseSensitive": {
+                "default": false,
+                "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                "type": "boolean"
+              },
+              "description": {
+                "description": "Optional description of configuration.",
+                "markdownDescription": "Optional description of configuration.",
+                "type": "string"
+              },
+              "diagnosticLevel": {
+                "$ref": "#/definitions/DiagnosticLevel",
+                "default": "Information",
+                "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "enumDescriptions": [
+                  "Report Spelling Issues as Errors",
+                  "Report Spelling Issues as Warnings",
+                  "Report Spelling Issues as Information",
+                  "Report Spelling Issues as Hints, will not show up in Problems"
+                ],
+                "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "scope": "resource",
+                "title": "Set Diagnostic Reporting Level"
+              },
+              "diagnosticLevelFlaggedWords": {
+                "$ref": "#/definitions/DiagnosticLevel",
+                "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "enumDescriptions": [
+                  "Report Spelling Issues as Errors",
+                  "Report Spelling Issues as Warnings",
+                  "Report Spelling Issues as Information",
+                  "Report Spelling Issues as Hints, will not show up in Problems"
+                ],
+                "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
+                "scope": "resource",
+                "sinceVersion": "4.0.0",
+                "title": "Set Diagnostic Reporting Level for Flagged Words"
+              },
+              "dictionaries": {
+                "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                      "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                      "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    },
+                    {
+                      "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                      "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                      "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                  "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                },
+                "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                "type": "array"
+              },
+              "dictionaryDefinitions": {
+                "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                "items": {
+                  "$ref": "#/definitions/DictionaryDef"
+                },
+                "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                "scope": "resource",
+                "title": "Dictionary Definitions",
+                "type": "array"
+              },
+              "enableFiletypes": {
+                "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } . To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+                "items": {
+                  "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                  "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                  "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                  "type": "string"
+                },
+                "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by  {@link  Settings.enabledLanguageIds } .\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+                "scope": "resource",
+                "title": "Enable File Types",
+                "type": "array",
+                "uniqueItems": true
+              },
+              "enabled": {
+                "default": true,
+                "description": "Is the spell checker enabled.",
+                "markdownDescription": "Is the spell checker enabled.",
+                "type": "boolean"
+              },
+              "enabledFileTypes": {
+                "additionalProperties": {
+                  "type": "boolean"
+                },
+                "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
+                "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces:  {@link  Settings.enabledLanguageIds }  and  {@link  Settings.enableFiletypes } .\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
+                "since": "8.8.1",
+                "title": "Enabled File Types to Check",
+                "type": "object"
+              },
+              "enabledLanguageIds": {
+                "description": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
+                "items": {
+                  "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                  "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                  "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                  "type": "string"
+                },
+                "markdownDescription": "Specify a list of file types to spell check. It is better to use  {@link  Settings.enabledFileTypes }  to Enable / Disable checking files types.",
+                "title": "Enabled Language Ids",
+                "type": "array",
+                "uniqueItems": true
+              },
+              "filename": {
                 "anyOf": [
                   {
-                    "title": "Named dictionary to be enabled / disabled\n- `true` - turn on the named dictionary\n- `false` - turn off the named dictionary",
-                    "type": "boolean"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "description": "Define a custom dictionary to be included.",
-                    "markdownDescription": "Define a custom dictionary to be included.",
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "anyOf": [
-                          {
-                            "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                            "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                            "title": "Path to Dictionary Text File",
-                            "type": "string"
-                          },
-                          {
-                            "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                            "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                            "type": "string"
-                          }
-                        ],
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "title": "Path to Dictionary Text File"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "title": "Custom Dictionary Entry",
-                    "type": "object"
-                  }
-                ]
-              },
-              "description": "Define custom dictionaries to be included by default. If `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js \"cSpell.customDictionaries\": {   \"project-words\": {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   },   \"custom\": true, // Enable the `custom` dictionary   \"internal-terms\": false // Disable the `internal-terms` dictionary } ```",
-              "markdownDescription": "Define custom dictionaries to be included by default.\nIf `addWords` is `true` words will be added to this dictionary.\n\n\n**Example:**\n\n```js\n\"cSpell.customDictionaries\": {\n  \"project-words\": {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  },\n  \"custom\": true, // Enable the `custom` dictionary\n  \"internal-terms\": false // Disable the `internal-terms` dictionary\n}\n```",
-              "scope": "resource",
-              "title": "Custom Dictionaries",
-              "type": "object"
-            },
-            "cSpell.dictionaries": {
-              "description": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name. i.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc // Enable `lorem-ipsum` and disable `typescript` \"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"] ```",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "Optional list of dictionaries to use.\n\nEach entry should match the name of the dictionary.\n\nTo remove a dictionary from the list add `!` before the name.\ni.e. `!typescript` will turn off the dictionary with the name `typescript`.\n\n\nExample:\n\n```jsonc\n// Enable `lorem-ipsum` and disable `typescript`\n\"cSpell.dictionaries\": [\"lorem-ipsum\", \"!typescript\"]\n```",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.dictionaryDefinitions": {
-              "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "path"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional description of the contents / purpose of the dictionary.",
-                        "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                        "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Path or url to the dictionary file.",
-                        "markdownDescription": "Path or url to the dictionary file.",
-                        "type": "string"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "path",
-                      "name"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                        "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional description of the contents / purpose of the dictionary.",
-                        "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                        "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "A file path or url to a custom dictionary file.",
-                        "markdownDescription": "A file path or url to a custom dictionary file.",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
-                        "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "path",
-                      "addWords",
-                      "name"
-                    ],
-                    "type": "object"
-                  }
-                ]
-              },
-              "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
-              "scope": "resource",
-              "title": "Dictionary Definitions",
-              "type": "array"
-            },
-            "cSpell.flagWords": {
-              "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.ignoreWords": {
-              "description": "A list of words to be ignored by the spell checker.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "A list of words to be ignored by the spell checker.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.language": {
-              "default": "en",
-              "description": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
-              "markdownDescription": "Current active spelling language.\n\nExample: `en-GB` for British English\n\nExample: `en,nl` to enable both English and Dutch",
-              "scope": "resource",
-              "type": "string"
-            },
-            "cSpell.languageSettings": {
-              "description": "Additional settings for individual programming languages and locales.",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "allowCompoundWords": {
-                    "default": false,
-                    "description": "True to enable compound word checking.",
-                    "markdownDescription": "True to enable compound word checking.",
-                    "type": "boolean"
-                  },
-                  "caseSensitive": {
-                    "default": false,
-                    "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                    "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
-                    "type": "boolean"
-                  },
-                  "description": {
-                    "description": "Optional description of configuration.",
-                    "markdownDescription": "Optional description of configuration.",
+                    "description": "These are glob expressions.",
+                    "markdownDescription": "These are glob expressions.",
                     "type": "string"
                   },
-                  "dictionaries": {
-                    "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                  {
                     "items": {
-                      "anyOf": [
-                        {
-                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
-                        },
-                        {
-                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
-                        }
+                      "description": "These are glob expressions.",
+                      "markdownDescription": "These are glob expressions.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                ],
+                "description": "Glob pattern or patterns to match against.",
+                "markdownDescription": "Glob pattern or patterns to match against."
+              },
+              "flagWords": {
+                "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                "type": "array"
+              },
+              "id": {
+                "description": "Optional identifier.",
+                "markdownDescription": "Optional identifier.",
+                "type": "string"
+              },
+              "ignoreRandomStrings": {
+                "default": true,
+                "description": "Ignore sequences of characters that look like random strings.",
+                "markdownDescription": "Ignore sequences of characters that look like random strings.",
+                "type": "boolean"
+              },
+              "ignoreRegExpList": {
+                "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "description": "This matches the name in a pattern definition.",
+                      "markdownDescription": "This matches the name in a pattern definition.",
+                      "type": "string"
+                    },
+                    {
+                      "enum": [
+                        "Base64",
+                        "Base64MultiLine",
+                        "Base64SingleLine",
+                        "CStyleComment",
+                        "CStyleHexValue",
+                        "CSSHexValue",
+                        "CommitHash",
+                        "CommitHashLink",
+                        "Email",
+                        "EscapeCharacters",
+                        "HexValues",
+                        "href",
+                        "PhpHereDoc",
+                        "PublicKey",
+                        "RsaCert",
+                        "SshRsa",
+                        "SHA",
+                        "HashStrings",
+                        "SpellCheckerDisable",
+                        "SpellCheckerDisableBlock",
+                        "SpellCheckerDisableLine",
+                        "SpellCheckerDisableNext",
+                        "SpellCheckerIgnoreInDocSetting",
+                        "string",
+                        "UnicodeRef",
+                        "Urls",
+                        "UUID",
+                        "Everything"
                       ],
-                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                      "type": "string"
+                    }
+                  ],
+                  "description": "A PatternRef is a Pattern or PatternId.",
+                  "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                },
+                "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "type": "array"
+              },
+              "ignoreWords": {
+                "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                "type": "array"
+              },
+              "includeRegExpList": {
+                "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "string"
                     },
-                    "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
-                    "type": "array"
+                    {
+                      "description": "This matches the name in a pattern definition.",
+                      "markdownDescription": "This matches the name in a pattern definition.",
+                      "type": "string"
+                    },
+                    {
+                      "enum": [
+                        "Base64",
+                        "Base64MultiLine",
+                        "Base64SingleLine",
+                        "CStyleComment",
+                        "CStyleHexValue",
+                        "CSSHexValue",
+                        "CommitHash",
+                        "CommitHashLink",
+                        "Email",
+                        "EscapeCharacters",
+                        "HexValues",
+                        "href",
+                        "PhpHereDoc",
+                        "PublicKey",
+                        "RsaCert",
+                        "SshRsa",
+                        "SHA",
+                        "HashStrings",
+                        "SpellCheckerDisable",
+                        "SpellCheckerDisableBlock",
+                        "SpellCheckerDisableLine",
+                        "SpellCheckerDisableNext",
+                        "SpellCheckerIgnoreInDocSetting",
+                        "string",
+                        "UnicodeRef",
+                        "Urls",
+                        "UUID",
+                        "Everything"
+                      ],
+                      "type": "string"
+                    }
+                  ],
+                  "description": "A PatternRef is a Pattern or PatternId.",
+                  "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                },
+                "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                "type": "array"
+              },
+              "language": {
+                "description": "Sets the locale.",
+                "markdownDescription": "Sets the locale.",
+                "type": "string"
+              },
+              "languageId": {
+                "anyOf": [
+                  {
+                    "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                    "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                    "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                    "type": "string"
                   },
-                  "dictionaryDefinitions": {
-                    "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                  {
+                    "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                    "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                    "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                    "type": "string"
+                  },
+                  {
+                    "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                    "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                    "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                    "type": "string"
+                  },
+                  {
                     "items": {
                       "anyOf": [
                         {
-                          "additionalProperties": false,
-                          "properties": {
-                            "addWords": {
-                              "default": true,
-                              "description": "Indicate if this custom dictionary should be used to store added words.",
-                              "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                              "title": "Add Words to Dictionary",
-                              "type": "boolean"
-                            },
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional: A human readable description.",
-                              "markdownDescription": "Optional: A human readable description.",
-                              "title": "Description of the Dictionary",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                              "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                              "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                              "title": "Name of Dictionary",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                              "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                              "type": "string"
-                            },
-                            "scope": {
-                              "anyOf": [
-                                {
-                                  "description": "Specifies the scope of a dictionary.",
-                                  "enum": [
-                                    "user",
-                                    "workspace",
-                                    "folder"
-                                  ],
-                                  "markdownDescription": "Specifies the scope of a dictionary.",
-                                  "type": "string"
-                                },
-                                {
-                                  "items": {
-                                    "description": "Specifies the scope of a dictionary.",
-                                    "enum": [
-                                      "user",
-                                      "workspace",
-                                      "folder"
-                                    ],
-                                    "markdownDescription": "Specifies the scope of a dictionary.",
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              ],
-                              "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                              "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                              "title": "Scope of dictionary"
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "path"
-                          ],
-                          "type": "object"
+                          "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                          "type": "string"
                         },
                         {
-                          "additionalProperties": false,
-                          "properties": {
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional description of the contents / purpose of the dictionary.",
-                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "Path or url to the dictionary file.",
-                              "markdownDescription": "Path or url to the dictionary file.",
-                              "type": "string"
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "name"
-                          ],
-                          "type": "object"
+                          "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                          "type": "string"
                         },
                         {
-                          "additionalProperties": false,
-                          "properties": {
-                            "addWords": {
-                              "description": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                              "markdownDescription": "When `true`, let's the spell checker know that words can be added to this dictionary.",
-                              "type": "boolean"
-                            },
-                            "btrie": {
-                              "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                              "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                              "since": "9.6.0",
-                              "type": "string"
-                            },
-                            "description": {
-                              "description": "Optional description of the contents / purpose of the dictionary.",
-                              "markdownDescription": "Optional description of the contents / purpose of the dictionary.",
-                              "type": "string"
-                            },
-                            "ignoreForbiddenWords": {
-                              "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                              "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                              "type": "boolean"
-                            },
-                            "name": {
-                              "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                              "type": "string"
-                            },
-                            "noSuggest": {
-                              "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                              "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                              "type": "boolean"
-                            },
-                            "path": {
-                              "description": "A file path or url to a custom dictionary file.",
-                              "markdownDescription": "A file path or url to a custom dictionary file.",
-                              "type": "string"
-                            },
-                            "scope": {
-                              "anyOf": [
-                                {
-                                  "description": "Specifies the scope of a dictionary.",
-                                  "enum": [
-                                    "user",
-                                    "workspace",
-                                    "folder"
-                                  ],
-                                  "markdownDescription": "Specifies the scope of a dictionary.",
-                                  "type": "string"
-                                },
-                                {
-                                  "items": {
-                                    "description": "Specifies the scope of a dictionary.",
-                                    "enum": [
-                                      "user",
-                                      "workspace",
-                                      "folder"
-                                    ],
-                                    "markdownDescription": "Specifies the scope of a dictionary.",
-                                    "type": "string"
-                                  },
-                                  "type": "array"
-                                }
-                              ],
-                              "description": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`.",
-                              "markdownDescription": "Defines the scope for when words will be added to the dictionary.\n\nScope values: `user`, `workspace`, `folder`."
-                            },
-                            "supportNonStrictSearches": {
-                              "default": true,
-                              "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                              "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                              "type": "boolean"
-                            }
-                          },
-                          "required": [
-                            "path",
-                            "addWords",
-                            "name"
-                          ],
-                          "type": "object"
+                          "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                          "type": "string"
                         }
                       ]
                     },
-                    "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
-                    "scope": "resource",
-                    "title": "Dictionary Definitions",
                     "type": "array"
-                  },
-                  "enabled": {
-                    "default": true,
-                    "description": "Is the spell checker enabled.",
-                    "markdownDescription": "Is the spell checker enabled.",
-                    "type": "boolean"
-                  },
-                  "flagWords": {
-                    "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
-                    "items": {
+                  }
+                ],
+                "description": "Sets the programming language id to match file type.",
+                "markdownDescription": "Sets the programming language id to match file type."
+              },
+              "languageSettings": {
+                "description": "Additional settings for individual programming languages and locales.",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "allowCompoundWords": {
+                      "default": false,
+                      "description": "True to enable compound word checking.",
+                      "markdownDescription": "True to enable compound word checking.",
+                      "type": "boolean"
+                    },
+                    "caseSensitive": {
+                      "default": false,
+                      "description": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                      "markdownDescription": "Determines if words must match case and accent rules.\n\nSee [Case Sensitivity](https://cspell.org/docs/case-sensitive/) for more details.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n- `true` - Case and accents are enforced.",
+                      "type": "boolean"
+                    },
+                    "description": {
+                      "description": "Optional description of configuration.",
+                      "markdownDescription": "Optional description of configuration.",
                       "type": "string"
                     },
-                    "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
-                    "type": "array"
-                  },
-                  "id": {
-                    "description": "Optional identifier.",
-                    "markdownDescription": "Optional identifier.",
-                    "type": "string"
-                  },
-                  "ignoreRegExpList": {
-                    "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "description": "This matches the name in a pattern definition.",
-                          "markdownDescription": "This matches the name in a pattern definition.",
-                          "type": "string"
-                        },
-                        {
-                          "enum": [
-                            "Base64",
-                            "Base64MultiLine",
-                            "Base64SingleLine",
-                            "CStyleComment",
-                            "CStyleHexValue",
-                            "CSSHexValue",
-                            "CommitHash",
-                            "CommitHashLink",
-                            "Email",
-                            "EscapeCharacters",
-                            "HexValues",
-                            "href",
-                            "PhpHereDoc",
-                            "PublicKey",
-                            "RsaCert",
-                            "SshRsa",
-                            "SHA",
-                            "HashStrings",
-                            "SpellCheckerDisable",
-                            "SpellCheckerDisableBlock",
-                            "SpellCheckerDisableLine",
-                            "SpellCheckerDisableNext",
-                            "SpellCheckerIgnoreInDocSetting",
-                            "string",
-                            "UnicodeRef",
-                            "Urls",
-                            "UUID",
-                            "Everything"
-                          ],
-                          "type": "string"
-                        }
-                      ],
-                      "description": "A PatternRef is a Pattern or PatternId.",
-                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                    "dictionaries": {
+                      "description": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/) and [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                            "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                            "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                            "type": "string"
+                          },
+                          {
+                            "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                            "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                            "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                        "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                      },
+                      "markdownDescription": "Optional list of dictionaries to use. Each entry should match the name of the dictionary.\n\nTo remove a dictionary from the list, add `!` before the name.\n\nFor example, `!typescript` will turn off the dictionary with the name `typescript`.\n\nSee the [Dictionaries](https://cspell.org/docs/dictionaries/)\nand [Custom Dictionaries](https://cspell.org/docs/dictionaries/custom-dictionaries/) for more details.",
+                      "type": "array"
                     },
-                    "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "type": "array"
-                  },
-                  "ignoreWords": {
-                    "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
-                    "items": {
+                    "dictionaryDefinitions": {
+                      "description": "Define custom dictionaries. If `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js \"cSpell.dictionaryDefinitions\": [   {     \"name\": \"project-words\",     \"path\": \"${workspaceRoot}/project-words.txt\",     \"description\": \"Words used in this project\",     \"addWords\": true   } ] ```",
+                      "items": {
+                        "$ref": "#/definitions/DictionaryDef"
+                      },
+                      "markdownDescription": "Define custom dictionaries.\nIf `addWords` is `true` words will be added to this dictionary.\n\nThis setting is subject to User/Workspace settings precedence rules: [Visual Studio Code User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings#_settings-precedence).\n\nIt is better to use `#cSpell.customDictionaries#`\n\n**Example:**\n\n```js\n\"cSpell.dictionaryDefinitions\": [\n  {\n    \"name\": \"project-words\",\n    \"path\": \"${workspaceRoot}/project-words.txt\",\n    \"description\": \"Words used in this project\",\n    \"addWords\": true\n  }\n]\n```",
+                      "scope": "resource",
+                      "title": "Dictionary Definitions",
+                      "type": "array"
+                    },
+                    "enabled": {
+                      "default": true,
+                      "description": "Is the spell checker enabled.",
+                      "markdownDescription": "Is the spell checker enabled.",
+                      "type": "boolean"
+                    },
+                    "flagWords": {
+                      "description": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample: ```ts \"flagWords\": [   \"color: colour\",   \"incase: in case, encase\",   \"canot->cannot\",   \"cancelled->canceled\" ] ```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry. In practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the   document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —   `avocado` and `AVOCADO` are not flagged.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "markdownDescription": "List of words to always be considered incorrect. Words found in `flagWords` override `words`.\n\nFormat of `flagWords`\n- single word entry - `word`\n- with suggestions - `word:suggestion` or `word->suggestion, suggestions`\n\nExample:\n```ts\n\"flagWords\": [\n  \"color: colour\",\n  \"incase: in case, encase\",\n  \"canot->cannot\",\n  \"cancelled->canceled\"\n]\n```\n\nCase Sensitivity:\n\nA word is flagged if it exactly matches an entry, or if its lowercased form exactly matches an entry.\nIn practice this means:\n- An entry written in **all lowercase** (e.g. `avocado`) flags that word in any casing found in the\n  document — `avocado`, `Avocado`, and `AVOCADO` are all flagged.\n- An entry containing **any uppercase letter** (e.g. `Avocado`) only flags that exact casing —\n  `avocado` and `AVOCADO` are not flagged.",
+                      "type": "array"
+                    },
+                    "id": {
+                      "description": "Optional identifier.",
+                      "markdownDescription": "Optional identifier.",
                       "type": "string"
                     },
-                    "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
-                    "type": "array"
-                  },
-                  "includeRegExpList": {
-                    "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "items": {
+                    "ignoreRegExpList": {
+                      "description": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON ```json \"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"] ```\n\nYAML ```yaml ignoreRegExpList:   - >-    /\\b[A-Z]+\\b/g ```\n\nBy default, several patterns are excluded. See [Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "description": "This matches the name in a pattern definition.",
+                            "markdownDescription": "This matches the name in a pattern definition.",
+                            "type": "string"
+                          },
+                          {
+                            "enum": [
+                              "Base64",
+                              "Base64MultiLine",
+                              "Base64SingleLine",
+                              "CStyleComment",
+                              "CStyleHexValue",
+                              "CSSHexValue",
+                              "CommitHash",
+                              "CommitHashLink",
+                              "Email",
+                              "EscapeCharacters",
+                              "HexValues",
+                              "href",
+                              "PhpHereDoc",
+                              "PublicKey",
+                              "RsaCert",
+                              "SshRsa",
+                              "SHA",
+                              "HashStrings",
+                              "SpellCheckerDisable",
+                              "SpellCheckerDisableBlock",
+                              "SpellCheckerDisableLine",
+                              "SpellCheckerDisableNext",
+                              "SpellCheckerIgnoreInDocSetting",
+                              "string",
+                              "UnicodeRef",
+                              "Urls",
+                              "UUID",
+                              "Everything"
+                            ],
+                            "type": "string"
+                          }
+                        ],
+                        "description": "A PatternRef is a Pattern or PatternId.",
+                        "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                      },
+                      "markdownDescription": "List of regular expression patterns or pattern names to exclude from spell checking.\n\nExample: `[\"href\"]` - to exclude html href pattern.\n\nRegular expressions use JavaScript regular expression syntax.\n\nExample: to ignore ALL-CAPS words\n\nJSON\n```json\n\"ignoreRegExpList\": [\"/\\\\b[A-Z]+\\\\b/g\"]\n```\n\nYAML\n```yaml\nignoreRegExpList:\n  - >-\n   /\\b[A-Z]+\\b/g\n```\n\nBy default, several patterns are excluded. See\n[Configuration](https://cspell.org/configuration/patterns) for more details.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                      "type": "array"
+                    },
+                    "ignoreWords": {
+                      "description": "List of words to be ignored. An ignored word will not show up as an error, even if it is also in the `flagWords`.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "markdownDescription": "List of words to be ignored. An ignored word will not show up as an error, even if it is\nalso in the `flagWords`.",
+                      "type": "array"
+                    },
+                    "includeRegExpList": {
+                      "description": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are [built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "description": "This matches the name in a pattern definition.",
+                            "markdownDescription": "This matches the name in a pattern definition.",
+                            "type": "string"
+                          },
+                          {
+                            "enum": [
+                              "Base64",
+                              "Base64MultiLine",
+                              "Base64SingleLine",
+                              "CStyleComment",
+                              "CStyleHexValue",
+                              "CSSHexValue",
+                              "CommitHash",
+                              "CommitHashLink",
+                              "Email",
+                              "EscapeCharacters",
+                              "HexValues",
+                              "href",
+                              "PhpHereDoc",
+                              "PublicKey",
+                              "RsaCert",
+                              "SshRsa",
+                              "SHA",
+                              "HashStrings",
+                              "SpellCheckerDisable",
+                              "SpellCheckerDisableBlock",
+                              "SpellCheckerDisableLine",
+                              "SpellCheckerDisableNext",
+                              "SpellCheckerIgnoreInDocSetting",
+                              "string",
+                              "UnicodeRef",
+                              "Urls",
+                              "UUID",
+                              "Everything"
+                            ],
+                            "type": "string"
+                          }
+                        ],
+                        "description": "A PatternRef is a Pattern or PatternId.",
+                        "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                      },
+                      "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
+                      "type": "array"
+                    },
+                    "languageId": {
                       "anyOf": [
                         {
+                          "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                          "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
                           "type": "string"
                         },
                         {
-                          "description": "This matches the name in a pattern definition.",
-                          "markdownDescription": "This matches the name in a pattern definition.",
+                          "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                          "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
                           "type": "string"
                         },
                         {
-                          "enum": [
-                            "Base64",
-                            "Base64MultiLine",
-                            "Base64SingleLine",
-                            "CStyleComment",
-                            "CStyleHexValue",
-                            "CSSHexValue",
-                            "CommitHash",
-                            "CommitHashLink",
-                            "Email",
-                            "EscapeCharacters",
-                            "HexValues",
-                            "href",
-                            "PhpHereDoc",
-                            "PublicKey",
-                            "RsaCert",
-                            "SshRsa",
-                            "SHA",
-                            "HashStrings",
-                            "SpellCheckerDisable",
-                            "SpellCheckerDisableBlock",
-                            "SpellCheckerDisableLine",
-                            "SpellCheckerDisableNext",
-                            "SpellCheckerIgnoreInDocSetting",
-                            "string",
-                            "UnicodeRef",
-                            "Urls",
-                            "UUID",
-                            "Everything"
-                          ],
+                          "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                          "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
                           "type": "string"
+                        },
+                        {
+                          "items": {
+                            "anyOf": [
+                              {
+                                "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                                "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+                                "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+                                "type": "string"
+                              },
+                              {
+                                "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                                "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
+                                "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
+                                "type": "string"
+                              },
+                              {
+                                "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                                "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
+                                "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
+                                "type": "string"
+                              }
+                            ]
+                          },
+                          "type": "array"
                         }
                       ],
-                      "description": "A PatternRef is a Pattern or PatternId.",
-                      "markdownDescription": "A PatternRef is a Pattern or PatternId."
+                      "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
+                      "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
                     },
-                    "markdownDescription": "List of regular expression patterns or defined pattern names to match for spell checking.\n\nIf this property is defined, only text matching the included patterns will be checked.\n\nWhile you can create your own patterns, you can also leverage several patterns that are\n[built-in to CSpell](https://cspell.org/types/cspell-types/types/PredefinedPatterns.html).",
-                    "type": "array"
-                  },
-                  "languageId": {
-                    "anyOf": [
-                      {
-                        "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                        "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                        "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                        "type": "string"
-                      },
-                      {
-                        "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                        "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                        "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                        "type": "string"
-                      },
-                      {
-                        "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                        "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                        "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                        "type": "string"
-                      },
-                      {
-                        "items": {
-                          "anyOf": [
-                            {
-                              "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                              "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "markdownDescription": "A single string with a comma separated list of file types:\n- `typescript,cpp`\n- `json,jsonc,yaml`\n- etc.",
-                              "pattern": "^([-\\w_\\s]+)(,[-\\w_\\s]+)*$",
-                              "type": "string"
-                            },
-                            {
-                              "description": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "markdownDescription": "A Negative File Type used to exclude files of that type.\n- `!typescript` - will exclude typescript files.\n- `!cpp,!json` - will exclude cpp and json files.\n- `!typescript,javascript` - will exclude typescript files and include javascript files.",
-                              "pattern": "^(![-\\w_\\s]+)(,!?[-\\w_\\s]+)*$",
-                              "type": "string"
-                            }
-                          ]
-                        },
-                        "type": "array"
-                      }
-                    ],
-                    "description": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages.",
-                    "markdownDescription": "The language id.  Ex: `typescript`, `html`, or `php`.  `*` -- will match all languages."
-                  },
-                  "locale": {
-                    "anyOf": [
-                      {
-                        "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                        "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
-                        "type": "string"
-                      },
-                      {
-                        "items": {
+                    "locale": {
+                      "anyOf": [
+                        {
                           "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
                           "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
                           "type": "string"
                         },
-                        "type": "array"
-                      }
-                    ],
-                    "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
-                    "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
-                  },
-                  "name": {
-                    "description": "Optional name of configuration.",
-                    "markdownDescription": "Optional name of configuration.",
-                    "type": "string"
-                  },
-                  "noSuggestDictionaries": {
-                    "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
-                    "items": {
-                      "anyOf": [
                         {
-                          "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
-                          "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
-                          "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
-                        },
-                        {
-                          "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
-                          "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
-                          "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                          "type": "string"
+                          "items": {
+                            "description": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                            "markdownDescription": "This is a written language locale like: `en`, `en-GB`, `fr`, `es`, `de` or `en,fr` for both English and French",
+                            "type": "string"
+                          },
+                          "type": "array"
                         }
                       ],
-                      "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
-                      "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                      "description": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales.",
+                      "markdownDescription": "The locale filter, matches against the language. This can be a comma separated list. `*` will match all locales."
                     },
-                    "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
-                    "type": "array"
-                  },
-                  "patterns": {
-                    "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
-                    "items": {
-                      "additionalProperties": false,
-                      "properties": {
-                        "description": {
-                          "description": "Description of the pattern.",
-                          "markdownDescription": "Description of the pattern.",
-                          "type": "string"
-                        },
-                        "name": {
-                          "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
-                          "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
-                          "type": "string"
-                        },
-                        "pattern": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "items": {
+                    "name": {
+                      "description": "Optional name of configuration.",
+                      "markdownDescription": "Optional name of configuration.",
+                      "type": "string"
+                    },
+                    "noSuggestDictionaries": {
+                      "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                            "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                            "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                            "type": "string"
+                          },
+                          {
+                            "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                            "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                            "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                            "type": "string"
+                          }
+                        ],
+                        "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                        "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                      },
+                      "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                      "type": "array"
+                    },
+                    "patterns": {
+                      "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "description": {
+                            "description": "Description of the pattern.",
+                            "markdownDescription": "Description of the pattern.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                            "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "anyOf": [
+                              {
                                 "type": "string"
                               },
-                              "type": "array"
-                            }
-                          ],
-                          "description": "RegExp pattern or array of RegExp patterns.",
-                          "markdownDescription": "RegExp pattern or array of RegExp patterns."
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "pattern"
-                      ],
-                      "type": "object"
-                    },
-                    "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
-                    "type": "array"
-                  },
-                  "substitutionDefinitions": {
-                    "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                    "items": {
-                      "additionalProperties": false,
-                      "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
-                      "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
-                      "properties": {
-                        "description": {
-                          "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
-                          "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
-                          "type": "string"
+                              {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "RegExp pattern or array of RegExp patterns.",
+                            "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                          }
                         },
-                        "entries": {
-                          "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
-                          "items": {
+                        "required": [
+                          "name",
+                          "pattern"
+                        ],
+                        "type": "object"
+                      },
+                      "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                      "type": "array"
+                    },
+                    "substitutionDefinitions": {
+                      "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                      "items": {
+                        "additionalProperties": false,
+                        "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                        "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                        "properties": {
+                          "description": {
+                            "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                            "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                            "type": "string"
+                          },
+                          "entries": {
+                            "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                            "items": {
+                              "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                              "items": [
+                                {
+                                  "title": "find",
+                                  "type": "string"
+                                },
+                                {
+                                  "title": "replacement",
+                                  "type": "string"
+                                }
+                              ],
+                              "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                              "maxItems": 2,
+                              "minItems": 2,
+                              "since": "9.7.0",
+                              "type": "array"
+                            },
+                            "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                            "type": "array"
+                          },
+                          "name": {
+                            "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                            "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                            "since": "9.7.0",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "name",
+                          "entries"
+                        ],
+                        "since": "9.7.0",
+                        "type": "object"
+                      },
+                      "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                      "since": "9.7.0",
+                      "type": "array"
+                    },
+                    "substitutions": {
+                      "description": "The set of substitutions to apply to a document before spell checking.",
+                      "items": {
+                        "anyOf": [
+                          {
                             "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
                             "items": [
                               {
@@ -3183,345 +2191,748 @@
                             "since": "9.7.0",
                             "type": "array"
                           },
-                          "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
-                          "type": "array"
-                        },
-                        "name": {
-                          "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "since": "9.7.0",
-                          "type": "string"
-                        }
+                          {
+                            "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                            "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                            "since": "9.7.0",
+                            "type": "string"
+                          }
+                        ]
                       },
-                      "required": [
-                        "name",
-                        "entries"
-                      ],
+                      "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
                       "since": "9.7.0",
-                      "type": "object"
+                      "type": "array"
                     },
-                    "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
-                    "since": "9.7.0",
-                    "type": "array"
-                  },
-                  "substitutions": {
-                    "description": "The set of substitutions to apply to a document before spell checking.",
-                    "items": {
-                      "anyOf": [
-                        {
-                          "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
-                          "items": [
-                            {
-                              "title": "find",
-                              "type": "string"
-                            },
-                            {
-                              "title": "replacement",
-                              "type": "string"
-                            }
-                          ],
-                          "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
-                          "maxItems": 2,
-                          "minItems": 2,
-                          "since": "9.7.0",
-                          "type": "array"
-                        },
-                        {
-                          "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
-                          "since": "9.7.0",
-                          "type": "string"
-                        }
-                      ]
+                    "suggestWords": {
+                      "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                      "items": {
+                        "type": "string"
+                      },
+                      "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                      "type": "array"
                     },
-                    "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
-                    "since": "9.7.0",
-                    "type": "array"
-                  },
-                  "suggestWords": {
-                    "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
-                    "items": {
+                    "unknownWords": {
+                      "default": "report-all",
+                      "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                      "enum": [
+                        "report-all",
+                        "report-simple",
+                        "report-common-typos",
+                        "report-flagged"
+                      ],
+                      "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                      "since": "9.1.0",
                       "type": "string"
                     },
-                    "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-                    "type": "array"
-                  },
-                  "unknownWords": {
-                    "default": "report-all",
-                    "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                    "enum": [
-                      "report-all",
-                      "report-simple",
-                      "report-common-typos",
-                      "report-flagged"
-                    ],
-                    "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
-                    "since": "9.1.0",
-                    "type": "string"
-                  },
-                  "useIntlWordSegmentation": {
-                    "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
-                    "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
-                    "since": "10.2.0",
-                    "type": "boolean"
-                  },
-                  "words": {
-                    "description": "List of words to be considered correct.",
-                    "items": {
-                      "type": "string"
+                    "useIntlWordSegmentation": {
+                      "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                      "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                      "since": "10.2.0",
+                      "type": "boolean"
                     },
-                    "markdownDescription": "List of words to be considered correct.",
-                    "type": "array"
-                  }
-                },
-                "required": [
-                  "languageId"
-                ],
-                "type": "object"
-              },
-              "markdownDescription": "Additional settings for individual programming languages and locales.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.noSuggestDictionaries": {
-              "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.suggestWords": {
-              "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
-              "type": "array"
-            },
-            "cSpell.useLocallyInstalledCSpellDictionaries": {
-              "default": true,
-              "description": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
-              "markdownDescription": "Search for `@cspell/cspell-bundled-dicts` in the workspace folder and use it if found.",
-              "scope": "resource",
-              "sinceVersion": "4.0.0",
-              "type": "boolean"
-            },
-            "cSpell.userWords": {
-              "description": "Words to add to global dictionary -- should only be in the user config file.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "Words to add to global dictionary -- should only be in the user config file.",
-              "scope": "resource",
-              "type": "array"
-            },
-            "cSpell.words": {
-              "description": "List of words to be considered correct.",
-              "items": {
-                "type": "string"
-              },
-              "markdownDescription": "List of words to be considered correct.",
-              "scope": "resource",
-              "type": "array"
-            }
-          },
-          "title": "Languages and Dictionaries",
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Settings that control the appearance of the spell checker.",
-          "order": 6,
-          "properties": {
-            "cSpell.dark": {
-              "additionalProperties": false,
-              "description": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
-              "markdownDescription": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
-              "properties": {
-                "overviewRulerColor": {
-                  "default": "#348feb80",
-                  "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                  "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecoration": {
-                  "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
-                  "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColor": {
-                  "default": "#348feb",
-                  "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColorFlagged": {
-                  "default": "#f44",
-                  "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColorSuggestion": {
-                  "default": "#cf88",
-                  "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.2",
-                  "type": "string"
-                },
-                "textDecorationLine": {
-                  "default": "underline",
-                  "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                  "enum": [
-                    "underline",
-                    "overline",
-                    "line-through"
+                    "words": {
+                      "description": "List of words to be considered correct.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "markdownDescription": "List of words to be considered correct.",
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "languageId"
                   ],
-                  "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
+                  "type": "object"
                 },
-                "textDecorationStyle": {
-                  "default": "dashed",
-                  "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                  "enum": [
-                    "solid",
-                    "wavy",
-                    "dotted",
-                    "dashed",
-                    "double"
-                  ],
-                  "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationThickness": {
-                  "default": "auto",
-                  "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                  "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                }
+                "markdownDescription": "Additional settings for individual programming languages and locales.",
+                "scope": "resource",
+                "type": "array"
               },
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "type": "object"
-            },
-            "cSpell.doNotUseCustomDecorationForScheme": {
-              "additionalProperties": {
+              "loadDefaultConfiguration": {
+                "default": true,
+                "description": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false` will prevent ALL default configuration from being loaded.",
+                "markdownDescription": "By default, the bundled dictionary configurations are loaded. Explicitly setting this to `false`\nwill prevent ALL default configuration from being loaded.",
                 "type": "boolean"
               },
-              "default": {
-                "chatSessionInput": true,
-                "comment": true,
-                "vscode-scm": true
+              "maxDuplicateProblems": {
+                "default": 5,
+                "description": "The maximum number of times the same word can be flagged as an error in a file.",
+                "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
+                "type": "number"
               },
-              "description": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up. This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
-              "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "title": "Use VS Code to Render Spelling Issues",
-              "type": "object"
-            },
-            "cSpell.light": {
-              "additionalProperties": false,
-              "description": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
-              "markdownDescription": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
-              "properties": {
-                "overviewRulerColor": {
-                  "default": "#348feb80",
-                  "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                  "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecoration": {
-                  "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
-                  "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColor": {
-                  "default": "#348feb",
-                  "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColorFlagged": {
-                  "default": "#f44",
-                  "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationColorSuggestion": {
-                  "default": "#cf88",
-                  "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.2",
-                  "type": "string"
-                },
-                "textDecorationLine": {
-                  "default": "underline",
-                  "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                  "enum": [
-                    "underline",
-                    "overline",
-                    "line-through"
-                  ],
-                  "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationStyle": {
-                  "default": "dashed",
-                  "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                  "enum": [
-                    "solid",
-                    "wavy",
-                    "dotted",
-                    "dashed",
-                    "double"
-                  ],
-                  "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                },
-                "textDecorationThickness": {
-                  "default": "auto",
-                  "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                  "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
-                  "scope": "application",
-                  "sinceVersion": "4.0.0",
-                  "type": "string"
-                }
+              "maxFileSize": {
+                "description": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+                "markdownDescription": "The Maximum size of a file to spell check. This is used to prevent spell checking very large files.\n\nThe value can be number or a string formatted `<number>[units]`, number with optional units.\n\nSupported units:\n\n- K, KB - value * 1024\n- M, MB - value * 2^20\n- G, GB - value * 2^30\n\nSpecial values:\n- `0` - has the effect of removing the limit.\n\nExamples:\n- `1000000` - 1 million bytes\n- `1000K` or `1000KB` - 1 thousand kilobytes\n- `0.5M` or `0.5MB` - 0.5 megabytes\n\ndefault: no limit",
+                "since": "9.4.0",
+                "type": [
+                  "number",
+                  "string"
+                ]
               },
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "type": "object"
+              "maxNumberOfProblems": {
+                "default": 10000,
+                "description": "The maximum number of problems to report in a file.",
+                "markdownDescription": "The maximum number of problems to report in a file.",
+                "type": "number"
+              },
+              "minRandomLength": {
+                "default": 40,
+                "description": "The minimum length of a random string to be ignored.",
+                "markdownDescription": "The minimum length of a random string to be ignored.",
+                "type": "number"
+              },
+              "minWordLength": {
+                "default": 4,
+                "description": "The minimum length of a word before checking it against a dictionary.",
+                "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
+                "type": "number"
+              },
+              "name": {
+                "description": "Optional name of configuration.",
+                "markdownDescription": "Optional name of configuration.",
+                "type": "string"
+              },
+              "noSuggestDictionaries": {
+                "description": "Optional list of dictionaries that will not be used for suggestions. Words in these dictionaries are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in one of these dictionaries, it will be removed from the set of possible suggestions.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "description": "This a reference to a named dictionary. It is expected to match the name of a dictionary.",
+                      "markdownDescription": "This a reference to a named dictionary.\nIt is expected to match the name of a dictionary.",
+                      "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    },
+                    {
+                      "description": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.    Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.    Overrides `!!<dictionary_name>`.",
+                      "markdownDescription": "This a negative reference to a named dictionary.\n\nIt is used to exclude or include a dictionary by name.\n\nThe reference starts with 1 or more `!`.\n- `!<dictionary_name>` - Used to exclude the dictionary matching `<dictionary_name>`.\n- `!!<dictionary_name>` - Used to re-include a dictionary matching `<dictionary_name>`.\n   Overrides `!<dictionary_name>`.\n- `!!!<dictionary_name>` - Used to exclude a dictionary matching `<dictionary_name>`.\n   Overrides `!!<dictionary_name>`.",
+                      "pattern": "^(?=!+[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
+                      "type": "string"
+                    }
+                  ],
+                  "description": "Reference to a dictionary by name. One of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }",
+                  "markdownDescription": "Reference to a dictionary by name.\nOne of:\n-  {@link  DictionaryRef } \n-  {@link  DictionaryNegRef }"
+                },
+                "markdownDescription": "Optional list of dictionaries that will not be used for suggestions.\nWords in these dictionaries are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\none of these dictionaries, it will be removed from the set of\npossible suggestions.",
+                "type": "array"
+              },
+              "numSuggestions": {
+                "default": 10,
+                "description": "Number of suggestions to make.",
+                "markdownDescription": "Number of suggestions to make.",
+                "type": "number"
+              },
+              "patterns": {
+                "description": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and  {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript \"ignoreRegExpList\": [\"comments\"], \"patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   },   // You can also combine multiple named patterns into one single named pattern   {     \"name\": \"comments\",     \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]   } ] ```",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "Description of the pattern.",
+                      "markdownDescription": "Description of the pattern.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                      "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      ],
+                      "description": "RegExp pattern or array of RegExp patterns.",
+                      "markdownDescription": "RegExp pattern or array of RegExp patterns."
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "pattern"
+                  ],
+                  "type": "object"
+                },
+                "markdownDescription": "Defines a list of patterns that can be used with the  {@link  ignoreRegExpList }  and\n {@link  includeRegExpList }  options.\n\nFor example:\n\n```javascript\n\"ignoreRegExpList\": [\"comments\"],\n\"patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  },\n  // You can also combine multiple named patterns into one single named pattern\n  {\n    \"name\": \"comments\",\n    \"pattern\": [\"comment-single-line\", \"comment-multi-line\"]\n  }\n]\n```",
+                "type": "array"
+              },
+              "pnpFiles": {
+                "default": [
+                  ".pnp.js",
+                  ".pnp.cjs"
+                ],
+                "description": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "The PnP files to search for. Note: `.mjs` files are not currently supported.",
+                "type": "array"
+              },
+              "substitutionDefinitions": {
+                "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                "items": {
+                  "additionalProperties": false,
+                  "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+                  "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+                  "properties": {
+                    "description": {
+                      "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                      "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                      "type": "string"
+                    },
+                    "entries": {
+                      "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                      "items": {
+                        "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                        "items": [
+                          {
+                            "title": "find",
+                            "type": "string"
+                          },
+                          {
+                            "title": "replacement",
+                            "type": "string"
+                          }
+                        ],
+                        "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                        "maxItems": 2,
+                        "minItems": 2,
+                        "since": "9.7.0",
+                        "type": "array"
+                      },
+                      "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "since": "9.7.0",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "entries"
+                  ],
+                  "since": "9.7.0",
+                  "type": "object"
+                },
+                "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+                "since": "9.7.0",
+                "type": "array"
+              },
+              "substitutions": {
+                "description": "The set of substitutions to apply to a document before spell checking.",
+                "items": {
+                  "anyOf": [
+                    {
+                      "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                      "items": [
+                        {
+                          "title": "find",
+                          "type": "string"
+                        },
+                        {
+                          "title": "replacement",
+                          "type": "string"
+                        }
+                      ],
+                      "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                      "maxItems": 2,
+                      "minItems": 2,
+                      "since": "9.7.0",
+                      "type": "array"
+                    },
+                    {
+                      "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                      "since": "9.7.0",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+                "since": "9.7.0",
+                "type": "array"
+              },
+              "suggestWords": {
+                "description": "A list of suggested replacements for words. Suggested words provide a way to make preferred suggestions on word replacements. To hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)     - `word: suggestion`     - `word->suggestion`\n- Multiple suggestions (not auto fixable)    - `word: first, second, third`    - `word->first, second, third`",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "A list of suggested replacements for words.\nSuggested words provide a way to make preferred suggestions on word replacements.\nTo hint at a preferred change, but not to require it.\n\nFormat of `suggestWords`\n- Single suggestion (possible auto fix)\n    - `word: suggestion`\n    - `word->suggestion`\n- Multiple suggestions (not auto fixable)\n   - `word: first, second, third`\n   - `word->first, second, third`",
+                "type": "array"
+              },
+              "suggestionNumChanges": {
+                "default": 3,
+                "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+                "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
+                "type": "number"
+              },
+              "suggestionsTimeout": {
+                "default": 500,
+                "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+                "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
+                "type": "number"
+              },
+              "unknownWords": {
+                "default": "report-all",
+                "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                "enum": [
+                  "report-all",
+                  "report-simple",
+                  "report-common-typos",
+                  "report-flagged"
+                ],
+                "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+                "since": "9.1.0",
+                "type": "string"
+              },
+              "useIntlWordSegmentation": {
+                "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+                "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+                "since": "10.2.0",
+                "type": "boolean"
+              },
+              "usePnP": {
+                "default": false,
+                "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
+                "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
+                "type": "boolean"
+              },
+              "words": {
+                "description": "List of words to be considered correct.",
+                "items": {
+                  "type": "string"
+                },
+                "markdownDescription": "List of words to be considered correct.",
+                "type": "array"
+              }
             },
-            "cSpell.overviewRulerColor": {
+            "required": [
+              "filename"
+            ],
+            "type": "object"
+          },
+          "markdownDescription": "Overrides are used to apply settings for specific files in your project.\n\n**Example:**\n\n```jsonc\n\"cSpell.overrides\": [\n  // Force `*.hrr` and `*.crr` files to be treated as `cpp` files:\n  {\n    \"filename\": \"**/{*.hrr,*.crr}\",\n    \"languageId\": \"cpp\"\n  },\n  // Force `dutch/**/*.txt` to be treated as Dutch (dictionary needs to be installed separately):\n  {\n    \"filename\": \"**/dutch/**/*.txt\",\n    \"language\": \"nl\"\n  }\n]\n```",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.patterns": {
+          "description": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and `#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc \"cSpell.patterns\": [   {     \"name\": \"comment-single-line\",     \"pattern\": \"/#.*/g\"   },   {     \"name\": \"comment-multi-line\",     \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"   } ] ```",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "description": {
+                "description": "Description of the pattern.",
+                "markdownDescription": "Description of the pattern.",
+                "type": "string"
+              },
+              "name": {
+                "description": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList. It is possible to redefine one of the predefined patterns to override its value.",
+                "markdownDescription": "Pattern name, used as an identifier in ignoreRegExpList and includeRegExpList.\nIt is possible to redefine one of the predefined patterns to override its value.",
+                "type": "string"
+              },
+              "pattern": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                ],
+                "description": "RegExp pattern or array of RegExp patterns.",
+                "markdownDescription": "RegExp pattern or array of RegExp patterns."
+              }
+            },
+            "required": [
+              "name",
+              "pattern"
+            ],
+            "type": "object"
+          },
+          "markdownDescription": "Defines a list of patterns that can be used with the `#cSpell.ignoreRegExpList#` and\n`#cSpell.includeRegExpList#` options.\n\n**Example:**\n\n```jsonc\n\"cSpell.patterns\": [\n  {\n    \"name\": \"comment-single-line\",\n    \"pattern\": \"/#.*/g\"\n  },\n  {\n    \"name\": \"comment-multi-line\",\n    \"pattern\": \"/(?:\\\\/\\\\*[\\\\s\\\\S]*?\\\\*\\\\/)/g\"\n  }\n]\n```",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.substitutionDefinitions": {
+          "description": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+          "items": {
+            "additionalProperties": false,
+            "description": "Allows for the definition of a substitution set. A substitution set is a collection of substitution entries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings, or other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`, the last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution for `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`, and the `&` substitution will be used for the string `&`.",
+            "markdownDescription": "Allows for the definition of a substitution set. A substitution set is a collection of substitution\nentries that can be applied to a document before spell checking. This is useful for converting html entities, url encodings,\nor other transformations that may be necessary to get the correct text for spell checking.\n\nSubstitutions are applied based upon the longest matching find string. If there are multiple matches of the same `find`,\nthe last one in the list is used. This allows for the overriding of substitutions. For example, if you have a substitution\nfor `&` to `and`, and then a substitution for `&amp;` to `&`, the `&amp;` substitution will be used for the string `&amp;`,\nand the `&` substitution will be used for the string `&`.",
+            "properties": {
+              "description": {
+                "description": "An optional description of the substitution definition. This is not used for anything, but can be useful for documentation purposes.",
+                "markdownDescription": "An optional description of the substitution definition. This is not used for anything, but can be useful for\ndocumentation purposes.",
+                "type": "string"
+              },
+              "entries": {
+                "description": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a document before spell checking.",
+                "items": {
+                  "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                  "items": [
+                    {
+                      "title": "find",
+                      "type": "string"
+                    },
+                    {
+                      "title": "replacement",
+                      "type": "string"
+                    }
+                  ],
+                  "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                  "maxItems": 2,
+                  "minItems": 2,
+                  "since": "9.7.0",
+                  "type": "array"
+                },
+                "markdownDescription": "The entries for the substitution definition. This is a collection of substitution entries that can be applied to a\ndocument before spell checking.",
+                "type": "array"
+              },
+              "name": {
+                "description": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                "markdownDescription": "The name of the substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                "since": "9.7.0",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "entries"
+            ],
+            "since": "9.7.0",
+            "type": "object"
+          },
+          "markdownDescription": "The set of available substitutions. This is a collection of substitution definitions that can be applied to a document before spell checking.",
+          "since": "9.7.0",
+          "type": "array"
+        },
+        "cSpell.substitutions": {
+          "description": "The set of substitutions to apply to a document before spell checking.",
+          "items": {
+            "anyOf": [
+              {
+                "description": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find, and the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.   The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`   string in the text.",
+                "items": [
+                  {
+                    "title": "find",
+                    "type": "string"
+                  },
+                  {
+                    "title": "replacement",
+                    "type": "string"
+                  }
+                ],
+                "markdownDescription": "A substitution entry is a tuple of the form `[find, replacement]`. The find string is the string to find,\nand the replacement string is the string to replace it with.\n\n- `find` - The string to find. This is the string that will be replaced in the text. Only an exact match will be replaced.\n  The find string is not treated as a regular expression.\n- `replacement` - The string to replace the `find` string with. This is the string that will be used to replace the `find`\n  string in the text.",
+                "maxItems": 2,
+                "minItems": 2,
+                "since": "9.7.0",
+                "type": "array"
+              },
+              {
+                "description": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                "markdownDescription": "The ID for a substitution definition. This is used to reference the substitution definition in the substitutions array.",
+                "since": "9.7.0",
+                "type": "string"
+              }
+            ]
+          },
+          "markdownDescription": "The set of substitutions to apply to a document before spell checking.",
+          "since": "9.7.0",
+          "type": "array"
+        },
+        "cSpell.unknownWords": {
+          "default": "report-all",
+          "description": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+          "enum": [
+            "report-all",
+            "report-simple",
+            "report-common-typos",
+            "report-flagged"
+          ],
+          "markdownDescription": "Controls how unknown words are handled.\n\n- `report-all` - Report all unknown words (default behavior)\n- `report-simple` - Report unknown words that have simple spelling errors, typos, and flagged words.\n- `report-common-typos` - Report unknown words that are common typos and flagged words.\n- `report-flagged` - Report unknown words that are flagged.",
+          "since": "9.1.0",
+          "type": "string"
+        },
+        "cSpell.useIntlWordSegmentation": {
+          "description": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc. The locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "markdownDescription": "Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.\nThe locale used for the segmentation is based on the  {@link  language  }  setting.",
+          "since": "10.2.0",
+          "type": "boolean"
+        },
+        "cSpell.vfs": {
+          "additionalProperties": {
+            "additionalProperties": false,
+            "description": "An entry in the CSpell Virtual File System. It may or may not have a URL.",
+            "markdownDescription": "An entry in the CSpell Virtual File System.\nIt may or may not have a URL.",
+            "properties": {
+              "data": {
+                "description": "The content data of the file.",
+                "markdownDescription": "The content data of the file.",
+                "type": "string"
+              },
+              "encoding": {
+                "description": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
+                "enum": [
+                  "base64",
+                  "plaintext",
+                  "utf8"
+                ],
+                "markdownDescription": "The encoding of the data. In most cases the encoding is determined from the data type and filename url.",
+                "type": "string"
+              },
+              "url": {
+                "description": "The optional file vfs url. It is already part of the CSpellVFS key.",
+                "markdownDescription": "The optional file vfs url. It is already part of the CSpellVFS key.",
+                "since": "9.7.0",
+                "type": "string"
+              }
+            },
+            "required": [
+              "data"
+            ],
+            "since": "9.7.0",
+            "type": "object"
+          },
+          "description": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
+          "markdownDescription": "Files to add to the CSpell Virtual File System.\n\nThey can be referenced using `cspell-vfs:///<module>/<path-to-file>/<file-name>` URLs.\n\nThey can be referenced in the `path` field of dictionary definitions.",
+          "since": "9.7.0",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-6966-7444-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.allowedSchemas": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.enabledSchemes#` instead.",
+          "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.",
+          "scope": "window",
+          "title": "Define Allowed Schemes",
+          "type": "array"
+        },
+        "cSpell.checkOnlyEnabledFileTypes": {
+          "default": true,
+          "description": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#` to turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`. See `#cSpell.enabledFileTypes#` on how to disable a file type.",
+          "markdownDescription": "By default, the spell checker checks only enabled file types. Use `#cSpell.enabledFileTypes#`\nto turn on / off various file types.\n\nWhen this setting is `false`, all file types are checked except for the ones disabled by `#cSpell.enabledFileTypes#`.\nSee `#cSpell.enabledFileTypes#` on how to disable a file type.",
+          "scope": "resource",
+          "title": "Check Only Enabled File Types",
+          "type": "boolean"
+        },
+        "cSpell.checkVSCodeSystemFiles": {
+          "default": false,
+          "description": "Spell check VS Code system files. These include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+          "markdownDescription": "Spell check VS Code system files.\nThese include:\n- `vscode-userdata:/**/settings.json`\n- `vscode-userdata:/**/keybindings.json`",
+          "scope": "application",
+          "type": "boolean"
+        },
+        "cSpell.enableFiletypes": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
+          "description": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`. To disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n``` jsonc       // enable checking for jsonc !json       // disable checking for json kotlin      // enable checking for kotlin ```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types !json       // except for json ```",
+          "items": {
+            "$ref": "#/definitions/EnableFileTypeId"
+          },
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThese are in additional to the file types specified by `#cSpell.enabledLanguageIds#`.\nTo disable a language, prefix with `!` as in `!json`,\n\n\n**Example: individual file types**\n\n```\njsonc       // enable checking for jsonc\n!json       // disable checking for json\nkotlin      // enable checking for kotlin\n```\n\n**Example: enable all file types**\n\n```\n*           // enable checking for all file types\n!json       // except for json\n```",
+          "scope": "resource",
+          "title": "Enable File Types",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "cSpell.enabledFileTypes": {
+          "$ref": "#/definitions/EnabledFileTypes",
+          "default": {
+            "*": true,
+            "markdown": true
+          },
+          "description": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment | | --------- | ------- | ------- | | `*`       | `true`  | Enable all file types. | | `json`    | `false` | Disable checking for json files. |",
+          "markdownDescription": "Enable / Disable checking file types (languageIds).\n\nThis setting replaces: `#cSpell.enabledLanguageIds#` and `#cSpell.enableFiletypes#`.\n\nA Value of:\n- `true` - enable checking for the file type\n- `false` - disable checking for the file type\n\nA file type of `*` is a wildcard that enables all file types.\n\n**Example: enable all file types**\n\n| File Type | Enabled | Comment |\n| --------- | ------- | ------- |\n| `*`       | `true`  | Enable all file types. |\n| `json`    | `false` | Disable checking for json files. |",
+          "scope": "resource",
+          "title": "Enabled File Types to Check"
+        },
+        "cSpell.enabledSchemes": {
+          "$ref": "#/definitions/EnabledSchemes",
+          "default": {
+            "chatSessionInput": true,
+            "comment": true,
+            "file": true,
+            "gist": true,
+            "repo": true,
+            "sftp": true,
+            "untitled": true,
+            "vscode-notebook-cell": true,
+            "vscode-scm": true,
+            "vscode-userdata": true,
+            "vscode-vfs": true,
+            "vsls": true
+          },
+          "description": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry. This is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment | | ------ | ------- | ------- | | `*`    | `true`  | Enable all schemes. | | `git`  | `false` | Do not check documents provided by the `git` file system. |",
+          "markdownDescription": "Control which file schemes will be checked for spelling (VS Code must be restarted for this setting to take effect).\n\n\nSome schemes have special meaning like:\n- `untitled` - Used for new documents that have not yet been saved\n- `vscode-notebook-cell` - Used for validating segments of a Notebook.\n- `vscode-userdata` - Needed to spell check `.code-snippets`\n- `vscode-scm` - Needed to spell check Source Control commit messages.\n- `comment` - Used for new comment editors.\n\nA scheme of `*` is a wildcard that enables all schemes without an explicit entry.\nThis is useful for virtual file systems provided by other extensions.\n\n**Example: enable all schemes**\n\n| Scheme | Enabled | Comment |\n| ------ | ------- | ------- |\n| `*`    | `true`  | Enable all schemes. |\n| `git`  | `false` | Do not check documents provided by the `git` file system. |",
+          "scope": "window",
+          "title": "Specify Allowed Schemes"
+        },
+        "cSpell.files": {
+          "description": "Glob patterns of files to be checked. Glob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+          "items": {
+            "description": "These are glob expressions.",
+            "markdownDescription": "These are glob expressions.",
+            "type": "string"
+          },
+          "markdownDescription": "Glob patterns of files to be checked.\nGlob patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+          "scope": "resource",
+          "title": "Glob patterns of files to be checked",
+          "type": "array"
+        },
+        "cSpell.globRoot": {
+          "description": "The root to use for glob patterns found in this configuration. Default: The current workspace folder. Use `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file. Defining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
+          "markdownDescription": "The root to use for glob patterns found in this configuration.\nDefault: The current workspace folder.\nUse `globRoot` to define a different location. `globRoot` can be relative to the location of this configuration file.\nDefining globRoot, does not impact imported configurations.\n\nSpecial Values:\n\n- `${workspaceFolder}` - Default - globs will be relative to the current workspace folder\n- `${workspaceFolder:<name>}` - Where `<name>` is the name of the workspace folder.",
+          "scope": "resource",
+          "type": "string"
+        },
+        "cSpell.ignorePaths": {
+          "default": [
+            "package-lock.json",
+            "node_modules",
+            "vscode-extension",
+            ".git/{info,lfs,logs,refs,objects}/**",
+            ".git/{index,*refs,*HEAD}",
+            ".vscode",
+            ".vscode-insiders"
+          ],
+          "description": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+          "items": {
+            "description": "Simple Glob string, the root will be globRoot.",
+            "markdownDescription": "Simple Glob string, the root will be globRoot.",
+            "type": "string"
+          },
+          "markdownDescription": "Glob patterns of files to be ignored. The patterns are relative to the `#cSpell.globRoot#` of the configuration file that defines them.",
+          "scope": "resource",
+          "title": "Glob patterns of files to be ignored",
+          "type": "array"
+        },
+        "cSpell.import": {
+          "description": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
+          "items": {
+            "description": "A File System Path. Relative paths are relative to the configuration file.",
+            "markdownDescription": "A File System Path. Relative paths are relative to the configuration file.",
+            "type": "string"
+          },
+          "markdownDescription": "Allows this configuration to inherit configuration for one or more other files.\n\nSee [Importing / Extending Configuration](https://cspell.org/configuration/imports/) for more details.",
+          "scope": "resource",
+          "type": "array"
+        },
+        "cSpell.mergeCSpellSettings": {
+          "default": true,
+          "description": "Specify if fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the CSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
+          "markdownDescription": "Specify if fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace.\n\nThe purpose of this setting to help provide a consistent result compared to the\nCSpell spell checker command line tool.\n\nValues:\n- `true` - all settings will be merged based upon `#cSpell.mergeCSpellSettingsFields#`.\n- `false` - only use `.vscode/settings.json` if a CSpell configuration is not found.\n\nNote: this setting is used in conjunction with `#cSpell.mergeCSpellSettingsFields#`.",
+          "scope": "resource",
+          "sinceVersion": "4.0.0",
+          "type": "boolean"
+        },
+        "cSpell.mergeCSpellSettingsFields": {
+          "$ref": "#/definitions/CSpellMergeFields",
+          "default": {
+            "allowCompoundWords": true,
+            "caseSensitive": true,
+            "dictionaries": true,
+            "dictionaryDefinitions": true,
+            "enableGlobDot": true,
+            "features": true,
+            "files": true,
+            "flagWords": true,
+            "gitignoreRoot": true,
+            "globRoot": true,
+            "ignorePaths": true,
+            "ignoreRegExpList": true,
+            "ignoreWords": true,
+            "import": true,
+            "includeRegExpList": true,
+            "language": true,
+            "languageId": true,
+            "languageSettings": true,
+            "loadDefaultConfiguration": true,
+            "minWordLength": true,
+            "noConfigSearch": true,
+            "noSuggestDictionaries": true,
+            "numSuggestions": true,
+            "overrides": true,
+            "patterns": true,
+            "pnpFiles": true,
+            "reporters": true,
+            "suggestWords": true,
+            "useGitignore": true,
+            "usePnP": true,
+            "userWords": true,
+            "validateDirectives": true,
+            "words": true
+          },
+          "description": "Specify which fields from `.vscode/settings.json` are passed to the spell checker. This only applies when there is a CSpell configuration file in the workspace and `#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample: ```jsonc \"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false } ```",
+          "markdownDescription": "Specify which fields from `.vscode/settings.json` are passed to the spell checker.\nThis only applies when there is a CSpell configuration file in the workspace and\n`#cSpell.mergeCSpellSettings#` is `true`.\n\nValues:\n- `{ flagWords: true, userWords: false }` - Always allow `flagWords`, but never allow `userWords`.\n\nExample:\n```jsonc\n\"cSpell.mergeCSpellSettingsFields\": { \"userWords\": false }\n```",
+          "scope": "resource",
+          "sinceVersion": "4.0.0"
+        },
+        "cSpell.noConfigSearch": {
+          "description": "Prevents searching for local configuration when checking individual documents.",
+          "markdownDescription": "Prevents searching for local configuration when checking individual documents.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.spellCheckOnlyWorkspaceFiles": {
+          "default": false,
+          "description": "Only spell check files that are in the currently open workspace. This same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js \"cSpell.files\": [\"/**\"] ```",
+          "markdownDescription": "Only spell check files that are in the currently open workspace.\nThis same effect can be achieved using the `#cSpell.files#` setting.\n\n\n```js\n\"cSpell.files\": [\"/**\"]\n```",
+          "scope": "window",
+          "title": "Spell Check Only Workspace Files",
+          "type": "boolean"
+        },
+        "cSpell.useGitignore": {
+          "default": true,
+          "description": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
+          "markdownDescription": "Tells the spell checker to load `.gitignore` files and skip files that match the globs in the `.gitignore` files found.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.usePnP": {
+          "description": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading packages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence of a PnP file and load it.",
+          "markdownDescription": "Packages managers like Yarn 2 use a `.pnp.cjs` file to assist in loading\npackages stored in the repository.\n\nWhen true, the spell checker will search up the directory structure for the existence\nof a PnP file and load it.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.workspaceRootPath": {
+          "description": "Define the path to the workspace root folder in a multi-root workspace. By default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder** ``` ${workspaceFolder:client} ```",
+          "markdownDescription": "Define the path to the workspace root folder in a multi-root workspace.\nBy default it is the first folder.\n\nThis is used to find the `cspell.json` file for the workspace.\n\n\n**Example: use the `client` folder**\n```\n${workspaceFolder:client}\n```",
+          "scope": "resource",
+          "title": "Workspace Root Folder Path",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-7626-7717-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.dark": {
+          "additionalProperties": false,
+          "description": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "markdownDescription": "Decoration for dark themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "properties": {
+            "overviewRulerColor": {
               "default": "#348feb80",
               "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
               "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
@@ -3529,22 +2940,14 @@
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.showInRuler": {
-              "default": true,
-              "description": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
-              "markdownDescription": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
-              "scope": "application",
-              "sinceVersion": "4.0.35",
-              "type": "boolean"
-            },
-            "cSpell.textDecoration": {
+            "textDecoration": {
               "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
               "scope": "application",
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.textDecorationColor": {
+            "textDecorationColor": {
               "default": "#348feb",
               "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
@@ -3552,7 +2955,7 @@
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.textDecorationColorFlagged": {
+            "textDecorationColorFlagged": {
               "default": "#f44",
               "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
@@ -3560,7 +2963,7 @@
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.textDecorationColorSuggestion": {
+            "textDecorationColorSuggestion": {
               "default": "#cf88",
               "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
               "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
@@ -3568,7 +2971,7 @@
               "sinceVersion": "4.0.2",
               "type": "string"
             },
-            "cSpell.textDecorationLine": {
+            "textDecorationLine": {
               "default": "underline",
               "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
               "enum": [
@@ -3581,7 +2984,7 @@
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.textDecorationStyle": {
+            "textDecorationStyle": {
               "default": "dashed",
               "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
               "enum": [
@@ -3596,876 +2999,512 @@
               "sinceVersion": "4.0.0",
               "type": "string"
             },
-            "cSpell.textDecorationThickness": {
+            "textDecorationThickness": {
               "default": "auto",
               "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
               "scope": "application",
               "sinceVersion": "4.0.0",
               "type": "string"
-            },
-            "cSpell.useCustomDecorations": {
-              "default": false,
-              "description": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
-              "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "type": "boolean"
             }
           },
-          "title": "Appearance",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
           "type": "object"
         },
-        {
+        "cSpell.doNotUseCustomDecorationForScheme": {
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "default": {
+            "chatSessionInput": true,
+            "comment": true,
+            "vscode-scm": true
+          },
+          "description": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up. This setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
+          "markdownDescription": "Use the VS Code Diagnostic Collection to render spelling issues.\n\nWith some edit boxes, like the source control message box, the custom decorations do not show up.\nThis setting allows the use of the VS Code Diagnostic Collection to render spelling issues.",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "title": "Use VS Code to Render Spelling Issues",
+          "type": "object"
+        },
+        "cSpell.light": {
           "additionalProperties": false,
+          "description": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "markdownDescription": "Decoration for light themes.\n\nSee:\n- `#cSpell.overviewRulerColor#`\n- `#cSpell.textDecoration#`",
+          "properties": {
+            "overviewRulerColor": {
+              "default": "#348feb80",
+              "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecoration": {
+              "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+              "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecorationColor": {
+              "default": "#348feb",
+              "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecorationColorFlagged": {
+              "default": "#f44",
+              "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecorationColorSuggestion": {
+              "default": "#cf88",
+              "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+              "scope": "application",
+              "sinceVersion": "4.0.2",
+              "type": "string"
+            },
+            "textDecorationLine": {
+              "default": "underline",
+              "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+              "enum": [
+                "underline",
+                "overline",
+                "line-through"
+              ],
+              "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecorationStyle": {
+              "default": "dashed",
+              "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+              "enum": [
+                "solid",
+                "wavy",
+                "dotted",
+                "dashed",
+                "double"
+              ],
+              "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            },
+            "textDecorationThickness": {
+              "default": "auto",
+              "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+              "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+              "scope": "application",
+              "sinceVersion": "4.0.0",
+              "type": "string"
+            }
+          },
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "object"
+        },
+        "cSpell.overviewRulerColor": {
+          "default": "#348feb80",
+          "description": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`. Disable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+          "markdownDescription": "The CSS color used to show issues in the ruler.\n\nDepends upon `#cSpell.useCustomDecorations#`.\nDisable the ruler by setting `#cSpell.showInRuler#` to `false`.\n\nSee:\n- [`<color>` CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value)\n- [CSS Colors, W3C Schools](https://www.w3schools.com/cssref/css_colors.php)\n- Hex colors\n\nExamples:\n- `green`\n- `DarkYellow`\n- `#ffff0080` - semi-transparent yellow.\n- `rgb(255 153 0 / 80%)`",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.showInRuler": {
+          "default": true,
+          "description": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
+          "markdownDescription": "Show spelling issues in the editor ruler.\n\nNote: This setting is only used when `#cSpell.useCustomDecorations#` is `true`.\n\nNote: To set the color of the ruler, use `#cSpell.overviewRulerColor#`.",
+          "scope": "application",
+          "sinceVersion": "4.0.35",
+          "type": "boolean"
+        },
+        "cSpell.textDecoration": {
+          "description": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+          "markdownDescription": "The CSS Style used to decorate spelling issues. Depends upon `#cSpell.useCustomDecorations#`.\n\nThis setting is used to manually configure the text decoration. If it is not set, the following settings are used:\n- `#cSpell.textDecorationLine#` to pick the line type\n- `#cSpell.textDecorationStyle#` to pick the style\n- `#cSpell.textDecorationColor#` to set the color\n- `#cSpell.textDecorationThickness#` to set the thickness.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n\nFormat:  `<line> [style] <color> [thickness]`\n\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `underline green`\n- `underline dotted yellow 0.2rem`\n- `underline wavy #ff0c 1.5px` - Wavy underline with 1.5px thickness in semi-transparent yellow.\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.textDecorationColor": {
+          "default": "#348feb",
+          "description": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "markdownDescription": "The decoration color for normal spelling issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nTo change the ruler color, use `#cSpell.overviewRulerColor#`.\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.textDecorationColorFlagged": {
+          "default": "#f44",
+          "description": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "markdownDescription": "The decoration color for flagged issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.textDecorationColorSuggestion": {
+          "default": "#cf88",
+          "description": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "markdownDescription": "The decoration color for spelling suggestions.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- color - see: [text-decoration-color, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)\n\nCommon Format: `#RGBA` or `#RRGGBBAA` or `#RGB` or `#RRGGBB`\n\nExamples:\n- `green`\n- `yellow`\n- `#ff0c`",
+          "scope": "application",
+          "sinceVersion": "4.0.2",
+          "type": "string"
+        },
+        "cSpell.textDecorationLine": {
+          "default": "underline",
+          "description": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+          "enum": [
+            "underline",
+            "overline",
+            "line-through"
+          ],
+          "markdownDescription": "The CSS line type used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- line - `underline`, `overline`, see: [text-decoration-line, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.textDecorationStyle": {
+          "default": "dashed",
+          "description": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+          "enum": [
+            "solid",
+            "wavy",
+            "dotted",
+            "dashed",
+            "double"
+          ],
+          "markdownDescription": "The CSS line style used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- style - `solid`, `wavy`, `dotted`, see: [text-decoration-style, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.textDecorationThickness": {
+          "default": "auto",
+          "description": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+          "markdownDescription": "The CSS line thickness used to decorate issues.\n\nSee: [text-decoration - CSS: Cascading Style Sheets, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)\n- thickness - see: [text-decoration-thickness, MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness)\n\nExamples:\n- `auto`\n- `from-font`\n- `0.2rem`\n- `1.5px`\n- `10%`",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "string"
+        },
+        "cSpell.useCustomDecorations": {
+          "default": false,
+          "description": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
+          "markdownDescription": "Draw custom decorations on Spelling Issues.\n- `true` - Use custom decorations. - VS Code Diagnostic Severity Levels are not used.\n- `false` - Use the VS Code Diagnostic Collection to render spelling issues.\n\nNote: This setting overrides the VS Code Diagnostics setting: `#cSpell.diagnosticLevel#`.",
+          "scope": "application",
+          "sinceVersion": "4.0.0",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-7897-8166-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.allowCompoundWords": {
+          "default": false,
+          "description": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
+          "markdownDescription": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
+          "scope": "resource",
+          "type": "boolean"
+        },
+        "cSpell.customFolderDictionaries": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+          "description": "Define custom dictionaries to be included by default for the folder. If `addWords` is `true` words will be added to this dictionary.",
+          "items": {
+            "$ref": "#/definitions/CustomDictionaryEntry"
+          },
+          "markdownDescription": "Define custom dictionaries to be included by default for the folder.\nIf `addWords` is `true` words will be added to this dictionary.",
+          "scope": "resource",
+          "title": "Custom Folder Dictionaries",
+          "type": "array"
+        },
+        "cSpell.customUserDictionaries": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+          "description": "Define custom dictionaries to be included by default for the user. If `addWords` is `true` words will be added to this dictionary.",
+          "items": {
+            "$ref": "#/definitions/CustomDictionaryEntry"
+          },
+          "markdownDescription": "Define custom dictionaries to be included by default for the user.\nIf `addWords` is `true` words will be added to this dictionary.",
+          "scope": "application",
+          "title": "Custom User Dictionaries",
+          "type": "array"
+        },
+        "cSpell.customWorkspaceDictionaries": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
+          "description": "Define custom dictionaries to be included by default for the workspace. If `addWords` is `true` words will be added to this dictionary.",
+          "items": {
+            "$ref": "#/definitions/CustomDictionaryEntry"
+          },
+          "markdownDescription": "Define custom dictionaries to be included by default for the workspace.\nIf `addWords` is `true` words will be added to this dictionary.",
+          "scope": "resource",
+          "title": "Custom Workspace Dictionaries",
+          "type": "array"
+        },
+        "cSpell.enabledLanguageIds": {
+          "deprecated": true,
+          "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
+          "description": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
+          "items": {
+            "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+            "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
+            "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
+            "type": "string"
+          },
+          "markdownDescription": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
+          "scope": "resource",
+          "title": "Enabled Language Ids",
+          "type": "array",
+          "uniqueItems": true
+        },
+        "cSpell.showStatus": {
+          "default": true,
+          "deprecationMessage": "No longer used.",
+          "description": "Display the spell checker status on the status bar.",
+          "markdownDescription": "Display the spell checker status on the status bar.",
+          "scope": "application",
+          "type": "boolean"
+        },
+        "cSpell.showStatusAlignment": {
+          "default": "Right",
+          "deprecated": true,
+          "deprecationMessage": "No longer supported.",
+          "description": "The side of the status bar to display the spell checker status.",
+          "enum": [
+            "Left",
+            "Right"
+          ],
+          "enumDescriptions": [
+            "Left Side of Statusbar",
+            "Right Side of Statusbar"
+          ],
+          "markdownDescription": "The side of the status bar to display the spell checker status.",
+          "scope": "application",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-8337-8640-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.advanced.feature.useReferenceProviderRemove": {
+          "$ref": "#/definitions/RegExpString",
+          "description": "Used to work around bugs in Reference Providers and Rename Providers. Anything matching the provided Regular Expression will be removed from the text before sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at [Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
+          "markdownDescription": "Used to work around bugs in Reference Providers and Rename Providers.\nAnything matching the provided Regular Expression will be removed from the text\nbefore sending it to the Rename Provider.\n\nSee: [Markdown: Fixing spelling issues in Header sections changes the entire line · Issue #1987](https://github.com/streetsidesoftware/vscode-spell-checker/issues/1987)\n\nIt is unlikely that you would need to edit this setting. If you need to, please open an issue at\n[Spell Checker Issues](https://github.com/streetsidesoftware/vscode-spell-checker/issues)\n\nThis feature is used in connection with `#cSpell.advanced.feature.useReferenceProviderWithRename#`",
+          "scope": "language-overridable",
+          "title": "Remove Matching Characters Before Rename"
+        },
+        "cSpell.advanced.feature.useReferenceProviderWithRename": {
+          "default": false,
+          "description": "Use the Reference Provider when fixing spelling issues with the Rename Provider. This feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
+          "markdownDescription": "Use the Reference Provider when fixing spelling issues with the Rename Provider.\nThis feature is used in connection with `#cSpell.fixSpellingWithRenameProvider#`",
+          "scope": "language-overridable",
+          "title": "Use Reference Provider During Rename",
+          "type": "boolean"
+        },
+        "cSpell.fixSpellingWithRenameProvider": {
+          "default": true,
+          "description": "Use Rename Provider when fixing spelling issues.",
+          "markdownDescription": "Use Rename Provider when fixing spelling issues.",
+          "scope": "language-overridable",
+          "type": "boolean"
+        },
+        "cSpell.logFile": {
+          "description": "Have the logs written to a file instead of to VS Code.",
+          "markdownDescription": "Have the logs written to a file instead of to VS Code.",
+          "scope": "window",
+          "title": "Write Logs to a File",
+          "type": "string"
+        },
+        "cSpell.logLevel": {
+          "default": "Error",
+          "description": "Set the Debug Level for logging messages.",
+          "enum": [
+            "None",
+            "Error",
+            "Warning",
+            "Information",
+            "Debug"
+          ],
+          "enumDescriptions": [
+            "Do not log",
+            "Log only errors",
+            "Log errors and warnings",
+            "Log errors, warnings, and info",
+            "Log everything (noisy)"
+          ],
+          "markdownDescription": "Set the Debug Level for logging messages.",
+          "scope": "window",
+          "title": "Set Logging Level",
+          "type": "string"
+        },
+        "cSpell.trustedWorkspace": {
+          "default": true,
+          "description": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace, but a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
+          "markdownDescription": "Enable loading JavaScript CSpell configuration files.\n\nThis setting is automatically set to `true` in a trusted workspace. It is possible to override the setting to `false` in a trusted workspace,\nbut a setting of `true` in an untrusted workspace will be ignored.\n\nSee:\n- [Visual Studio Code Workspace Trust security](https://code.visualstudio.com/docs/editor/workspace-trust)\n- [Workspace Trust Extension Guide -- Visual Studio Code Extension API](https://code.visualstudio.com/api/extension-guides/workspace-trust)",
+          "scope": "window",
+          "sinceVersion": "4.0.0",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Prefix<alias-653189051-8837-9045-653189051-0-9330,\"cSpell.\">": {
+      "additionalProperties": false,
+      "properties": {
+        "cSpell.experimental.enableRegexpView": {
+          "default": false,
+          "description": "Show Regular Expression Explorer",
+          "markdownDescription": "Show Regular Expression Explorer",
+          "scope": "application",
+          "type": "boolean"
+        },
+        "cSpell.experimental.symbols": {
+          "default": false,
+          "description": "Experiment with executeDocumentSymbolProvider. This feature is experimental and will be removed in the future.",
+          "markdownDescription": "Experiment with executeDocumentSymbolProvider.\nThis feature is experimental and will be removed in the future.",
+          "scope": "application",
+          "title": "Experiment with `executeDocumentSymbolProvider`",
+          "type": "boolean"
+        },
+        "cSpell.reportUnknownWords": {
+          "$ref": "#/definitions/UnknownWordsReportingLevel",
+          "deprecated": true,
+          "deprecationMessage": "Use Unknown Words settings instead.",
+          "description": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only reporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
+          "markdownDescription": "By default, the spell checker reports all unknown words as misspelled. This setting allows for a more relaxed spell checking, by only\nreporting unknown words as suggestions. Common spelling errors are still flagged as misspelled.\n\n- `all` - report all unknown words as misspelled\n- `simple` - report unknown words with simple fixes and the rest as suggestions\n- `typos` - report on known typo words and the rest as suggestions\n- `flagged` - report only flagged words as misspelled\n\n**Note:** This setting is deprecated. Use `#cSpell.unknownWords#` instead.",
+          "scope": "language-overridable",
+          "title": "Strict Spell Checking"
+        }
+      },
+      "type": "object"
+    },
+    "PrefixWithCspell<alias-653189051-4207-4277-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-4207-4277-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-4503-4919-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-4503-4919-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-5124-5774-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-5124-5774-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-5946-6234-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-5946-6234-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-6391-6748-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-6391-6748-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-6966-7444-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-6966-7444-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-7626-7717-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-7626-7717-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-7897-8166-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-7897-8166-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-8337-8640-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-8337-8640-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "PrefixWithCspell<alias-653189051-8837-9045-653189051-0-9330>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-8837-9045-653189051-0-9330%2C%22cSpell.%22%3E"
+    },
+    "RegExpString": {
+      "description": "A string representation of a Regular Expression.",
+      "markdownDescription": "A string representation of a Regular Expression.",
+      "type": "string"
+    },
+    "SpellCheckerSettingsVSCode": {
+      "items": [
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-4207-4277-653189051-0-9330%3E",
+          "description": "Settings that control the behavior of the spell checker.",
+          "order": 0,
+          "title": "Code Spell Checker"
+        },
+        {
+          "$ref": "#/definitions/VSConfigAdvanced"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-6391-6748-653189051-0-9330%3E",
+          "description": "Settings related to CSpell Command Line Tool.",
+          "order": 5,
+          "title": "CSpell"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8837-9045-653189051-0-9330%3E",
+          "description": "Experimental settings that may change or be removed in the future.",
+          "order": 19,
+          "title": "Experimental"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-6966-7444-653189051-0-9330%3E",
+          "description": "Settings that control which files and folders are spell checked.",
+          "order": 3,
+          "title": "Files, Folders, and Workspaces"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-4503-4919-653189051-0-9330%3E",
+          "description": "Settings that control dictionaries and language preferences.",
+          "order": 1,
+          "title": "Languages and Dictionaries"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7626-7717-653189051-0-9330%3E",
+          "description": "Settings that control the appearance of the spell checker.",
+          "order": 6,
+          "title": "Appearance"
+        },
+        {
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7897-8166-653189051-0-9330%3E",
           "description": "Legacy settings that have been deprecated or are not commonly used.",
           "order": 20,
-          "properties": {
-            "cSpell.allowCompoundWords": {
-              "default": false,
-              "description": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
-              "markdownDescription": "Enable / Disable allowing word compounds.\n- `true` means `arraylength` would be ok\n- `false` means it would not pass.\n\nNote: this can also cause many misspelled words to seem correct.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.customFolderDictionaries": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
-              "description": "Define custom dictionaries to be included by default for the folder. If `addWords` is `true` words will be added to this dictionary.",
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "title": "Path to Dictionary Text File",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "path"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                    "type": "string"
-                  }
-                ]
-              },
-              "markdownDescription": "Define custom dictionaries to be included by default for the folder.\nIf `addWords` is `true` words will be added to this dictionary.",
-              "scope": "resource",
-              "title": "Custom Folder Dictionaries",
-              "type": "array"
-            },
-            "cSpell.customUserDictionaries": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
-              "description": "Define custom dictionaries to be included by default for the user. If `addWords` is `true` words will be added to this dictionary.",
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "title": "Path to Dictionary Text File",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "path"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                    "type": "string"
-                  }
-                ]
-              },
-              "markdownDescription": "Define custom dictionaries to be included by default for the user.\nIf `addWords` is `true` words will be added to this dictionary.",
-              "scope": "application",
-              "title": "Custom User Dictionaries",
-              "type": "array"
-            },
-            "cSpell.customWorkspaceDictionaries": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.customDictionaries#` instead.",
-              "description": "Define custom dictionaries to be included by default for the workspace. If `addWords` is `true` words will be added to this dictionary.",
-              "items": {
-                "anyOf": [
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "title": "Path to Dictionary Text File",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      }
-                    },
-                    "required": [
-                      "name"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "additionalProperties": false,
-                    "properties": {
-                      "addWords": {
-                        "default": true,
-                        "description": "Indicate if this custom dictionary should be used to store added words.",
-                        "markdownDescription": "Indicate if this custom dictionary should be used to store added words.",
-                        "title": "Add Words to Dictionary",
-                        "type": "boolean"
-                      },
-                      "btrie": {
-                        "description": "An alternative path to a bTrie dictionary file. It will be used in place of `path` if the version of CSpell being used supports btrie files.",
-                        "markdownDescription": "An alternative path to a bTrie dictionary file.\nIt will be used in place of `path` if the version of CSpell being used\nsupports btrie files.",
-                        "since": "9.6.0",
-                        "type": "string"
-                      },
-                      "description": {
-                        "description": "Optional: A human readable description.",
-                        "markdownDescription": "Optional: A human readable description.",
-                        "title": "Description of the Dictionary",
-                        "type": "string"
-                      },
-                      "ignoreForbiddenWords": {
-                        "description": "Some dictionaries may contain forbidden words to prevent compounding from generating words that are not valid in the language. These are often words that are used in other languages or might be generated through compounding. This setting allows flagged words to be ignored when checking the dictionary. The effect is similar to the word not being in the dictionary.",
-                        "markdownDescription": "Some dictionaries may contain forbidden words to prevent compounding from generating\nwords that are not valid in the language. These are often\nwords that are used in other languages or might be generated through compounding.\nThis setting allows flagged words to be ignored when checking the dictionary.\nThe effect is similar to the word not being in the dictionary.",
-                        "type": "boolean"
-                      },
-                      "name": {
-                        "description": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary. If you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "markdownDescription": "The reference name of the dictionary.\n\n\nExample: `My Words` or `custom`\n\n\nIf the name matches a pre-defined dictionary, it will override the pre-defined dictionary.\nIf you use: `typescript` it will replace the built-in TypeScript dictionary.",
-                        "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                        "title": "Name of Dictionary",
-                        "type": "string"
-                      },
-                      "noSuggest": {
-                        "description": "Indicate that suggestions should not come from this dictionary. Words in this dictionary are considered correct, but will not be used when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in this dictionary, it will be removed from the set of possible suggestions.",
-                        "markdownDescription": "Indicate that suggestions should not come from this dictionary.\nWords in this dictionary are considered correct, but will not be\nused when making spell correction suggestions.\n\nNote: if a word is suggested by another dictionary, but found in\nthis dictionary, it will be removed from the set of\npossible suggestions.",
-                        "type": "boolean"
-                      },
-                      "path": {
-                        "description": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found in the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json \"path\": \"~/dictionaries/custom_dictionary.txt\" ```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json \"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative workspace for the currently open file.\n\n```json \"path\": \"${workspaceFolder}/build/custom_dictionary.txt\" ```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in a multi-root workspace\n\n```json \"path\": \"./build/custom_dictionary.txt\" ```",
-                        "markdownDescription": "Define the path to the dictionary text file.\n\n**Note:** if path is `undefined` the `name`d dictionary is expected to be found\nin the `dictionaryDefinitions`.\n\nFile Format: Each line in the file is considered a dictionary entry.\n\nCase is preserved while leading and trailing space is removed.\n\nThe path should be absolute, or relative to the workspace.\n\n**Example:** relative to User's folder\n\n```json\n\"path\": \"~/dictionaries/custom_dictionary.txt\"\n```\n\n**Example:** relative to the `client` folder in a multi-root workspace\n\n```json\n\"path\": \"${workspaceFolder:client}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the current workspace folder in a single-root workspace\n\n**Note:** this might not work as expected in a multi-root workspace since it is based upon the relative\nworkspace for the currently open file.\n\n```json\n\"path\": \"${workspaceFolder}/build/custom_dictionary.txt\"\n```\n\n**Example:** relative to the workspace folder in a single-root workspace or the first folder in\na multi-root workspace\n\n```json\n\"path\": \"./build/custom_dictionary.txt\"\n```",
-                        "type": "string"
-                      },
-                      "scope": {
-                        "anyOf": [
-                          {
-                            "description": "Specifies the scope of a dictionary.",
-                            "enum": [
-                              "user",
-                              "workspace",
-                              "folder"
-                            ],
-                            "markdownDescription": "Specifies the scope of a dictionary.",
-                            "type": "string"
-                          },
-                          {
-                            "items": {
-                              "description": "Specifies the scope of a dictionary.",
-                              "enum": [
-                                "user",
-                                "workspace",
-                                "folder"
-                              ],
-                              "markdownDescription": "Specifies the scope of a dictionary.",
-                              "type": "string"
-                            },
-                            "type": "array"
-                          }
-                        ],
-                        "description": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "markdownDescription": "Options are\n- `user` - words that apply to all projects and workspaces\n- `workspace` - words that apply to the entire workspace\n- `folder` - words that apply to only a workspace folder",
-                        "title": "Scope of dictionary"
-                      },
-                      "supportNonStrictSearches": {
-                        "default": true,
-                        "description": "Strip case and accents to allow for case insensitive searches and words without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie dictionaries.",
-                        "markdownDescription": "Strip case and accents to allow for case insensitive searches and\nwords without accents.\n\nNote: this setting only applies to word lists. It has no-impact on trie\ndictionaries.",
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "name",
-                      "path"
-                    ],
-                    "type": "object"
-                  },
-                  {
-                    "description": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "markdownDescription": "This is the name of a dictionary.\n\nName Format:\n- Must contain at least 1 number or letter.\n- Spaces are allowed.\n- Leading and trailing space will be removed.\n- Names ARE case-sensitive.\n- Must not contain `*`, `!`, `;`, `,`, `{`, `}`, `[`, `]`, `~`.",
-                    "pattern": "^(?=[^!*,;{}[\\]~\\n]+$)(?=(.*\\w)).+$",
-                    "type": "string"
-                  }
-                ]
-              },
-              "markdownDescription": "Define custom dictionaries to be included by default for the workspace.\nIf `addWords` is `true` words will be added to this dictionary.",
-              "scope": "resource",
-              "title": "Custom Workspace Dictionaries",
-              "type": "array"
-            },
-            "cSpell.enabledLanguageIds": {
-              "deprecated": true,
-              "deprecationMessage": "- Use `#cSpell.enabledFileTypes#` instead.",
-              "description": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
-              "items": {
-                "description": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                "markdownDescription": "A file type:\n- `*` - will match ALL file types.\n- `typescript`, `cpp`, `json`, etc.",
-                "pattern": "^(!?[-\\w_\\s]+)|(\\*)$",
-                "type": "string"
-              },
-              "markdownDescription": "Specify a list of file types to spell check. It is better to use `#cSpell.enabledFileTypes#` to Enable / Disable checking files types.",
-              "scope": "resource",
-              "title": "Enabled Language Ids",
-              "type": "array",
-              "uniqueItems": true
-            },
-            "cSpell.showStatus": {
-              "default": true,
-              "deprecationMessage": "No longer used.",
-              "description": "Display the spell checker status on the status bar.",
-              "markdownDescription": "Display the spell checker status on the status bar.",
-              "scope": "application",
-              "type": "boolean"
-            },
-            "cSpell.showStatusAlignment": {
-              "default": "Right",
-              "deprecated": true,
-              "deprecationMessage": "No longer supported.",
-              "description": "The side of the status bar to display the spell checker status.",
-              "enum": [
-                "Left",
-                "Right"
-              ],
-              "enumDescriptions": [
-                "Left Side of Statusbar",
-                "Right Side of Statusbar"
-              ],
-              "markdownDescription": "The side of the status bar to display the spell checker status.",
-              "scope": "application",
-              "type": "string"
-            }
-          },
-          "title": "Legacy",
-          "type": "object"
+          "title": "Legacy"
         },
         {
-          "additionalProperties": false,
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5946-6234-653189051-0-9330%3E",
           "description": "Settings that control the performance of the spell checker.",
           "order": 4,
-          "properties": {
-            "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
-              "default": 200,
-              "description": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "markdownDescription": "The maximum average length of chunks of text without word breaks.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`\n\n\n**Error Message:** _Average word length is too long._\n\n\nIf you are seeing this message, it means that the file contains mostly long lines\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "scope": "language-overridable",
-              "type": "number"
-            },
-            "cSpell.blockCheckingWhenLineLengthGreaterThan": {
-              "default": 20000,
-              "description": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given. This is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "markdownDescription": "The maximum line length.\n\n\nBlock spell checking if lines are longer than the value given.\nThis is used to prevent spell checking generated files.\n\n\n**Error Message:** _Lines are too long._\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "scope": "language-overridable",
-              "type": "number"
-            },
-            "cSpell.blockCheckingWhenTextChunkSizeGreaterThan": {
-              "default": 1000,
-              "description": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks. Absolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line without many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "markdownDescription": "The maximum length of a chunk of text without word breaks.\n\n\nIt is used to prevent spell checking of generated files.\n\n\nA chunk is the characters between absolute word breaks.\nAbsolute word breaks match: `/[\\s,{}[\\]]/`, i.e. spaces or braces.\n\n\n**Error Message:** _Maximum word length exceeded._\n\n\nIf you are seeing this message, it means that the file contains a very long line\nwithout many word breaks.\n\n\nHide this message using `#cSpell.enabledNotifications#`",
-              "scope": "language-overridable",
-              "type": "number"
-            },
-            "cSpell.checkLimit": {
-              "default": 500,
-              "description": "Set the maximum number of blocks of text to check. Each block is 1024 characters.",
-              "markdownDescription": "Set the maximum number of blocks of text to check.\nEach block is 1024 characters.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.spellCheckDelayMs": {
-              "default": 50,
-              "description": "Delay in ms after a document has changed before checking it for spelling errors.",
-              "markdownDescription": "Delay in ms after a document has changed before checking it for spelling errors.",
-              "scope": "application",
-              "type": "number"
-            },
-            "cSpell.suggestionsTimeout": {
-              "default": 400,
-              "description": "The maximum amount of time in milliseconds to generate suggestions for a word.",
-              "markdownDescription": "The maximum amount of time in milliseconds to generate suggestions for a word.",
-              "scope": "resource",
-              "type": "number"
-            }
-          },
-          "title": "Performance",
-          "type": "object"
+          "title": "Performance"
         },
         {
-          "additionalProperties": false,
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5124-5774-653189051-0-9330%3E",
           "description": "Settings that control how the spell checker reports and displays errors.",
           "order": 2,
-          "properties": {
-            "cSpell.autoFormatConfigFile": {
-              "default": false,
-              "description": "If a `cspell` configuration file is updated, format the configuration file using the VS Code Format Document Provider. This will cause the configuration file to be saved prior to being updated.",
-              "markdownDescription": "If a `cspell` configuration file is updated, format the configuration file\nusing the VS Code Format Document Provider. This will cause the configuration\nfile to be saved prior to being updated.",
-              "scope": "window",
-              "title": "Auto Format Configuration File",
-              "type": "boolean"
-            },
-            "cSpell.autocorrect": {
-              "default": false,
-              "description": "Enable / Disable autocorrect while typing.",
-              "markdownDescription": "Enable / Disable autocorrect while typing.",
-              "scope": "resource",
-              "title": "Autocorrect",
-              "type": "boolean"
-            },
-            "cSpell.diagnosticLevel": {
-              "default": "Information",
-              "description": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document. Set the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-              "enum": [
-                "Error",
-                "Warning",
-                "Information",
-                "Hint"
-              ],
-              "enumDescriptions": [
-                "Report Spelling Issues as Errors",
-                "Report Spelling Issues as Warnings",
-                "Report Spelling Issues as Information",
-                "Report Spelling Issues as Hints, will not show up in Problems"
-              ],
-              "markdownDescription": "The Diagnostic Severity Level determines how issues are shown in the Problems Pane and within the document.\nSet the level to `Hint` to hide the issues from the Problems Pane.\n\nNote: `#cSpell.useCustomDecorations#` must be `false` to use VS Code Diagnostic Severity Levels.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-              "scope": "resource",
-              "title": "Set Diagnostic Reporting Level",
-              "type": "string"
-            },
-            "cSpell.diagnosticLevelFlaggedWords": {
-              "description": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle. By default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-              "enum": [
-                "Error",
-                "Warning",
-                "Information",
-                "Hint"
-              ],
-              "enumDescriptions": [
-                "Report Spelling Issues as Errors",
-                "Report Spelling Issues as Warnings",
-                "Report Spelling Issues as Information",
-                "Report Spelling Issues as Hints, will not show up in Problems"
-              ],
-              "markdownDescription": "Flagged word issues found by the spell checker are marked with a Diagnostic Severity Level. This affects the color of the squiggle.\nBy default, flagged words will use the same diagnostic level as general issues. Use this setting to customize them.\n\nSee: [VS Code Diagnostic Severity Level](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)",
-              "scope": "resource",
-              "sinceVersion": "4.0.0",
-              "title": "Set Diagnostic Reporting Level for Flagged Words",
-              "type": "string"
-            },
-            "cSpell.enabledNotifications": {
-              "additionalProperties": false,
-              "default": {
-                "Average Word Length too Long": true,
-                "Lines too Long": true,
-                "Maximum Word Length Exceeded": true
-              },
-              "description": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
-              "markdownDescription": "Control which notifications are displayed.\n\nSee:\n- `#cSpell.blockCheckingWhenLineLengthGreaterThan#`\n- `#cSpell.blockCheckingWhenTextChunkSizeGreaterThan#`\n- `#cSpell.blockCheckingWhenAverageChunkSizeGreaterThan#`",
-              "properties": {
-                "Average Word Length too Long": {
-                  "description": "Enable notifications if the average word size is too high.",
-                  "markdownDescription": "Enable notifications if the average word size is too high.",
-                  "type": "boolean"
-                },
-                "Lines too Long": {
-                  "description": "Enable notifications if the line is too long.",
-                  "markdownDescription": "Enable notifications if the line is too long.",
-                  "type": "boolean"
-                },
-                "Maximum Word Length Exceeded": {
-                  "description": "Enable notifications if the maximum word length is exceeded.",
-                  "markdownDescription": "Enable notifications if the maximum word length is exceeded.",
-                  "type": "boolean"
-                }
-              },
-              "scope": "resource",
-              "sinceVersion": "4.0.41",
-              "title": "Enabled Notifications",
-              "type": "object"
-            },
-            "cSpell.hideAddToDictionaryCodeActions": {
-              "default": false,
-              "description": "Hide the options to add words to dictionaries or settings.",
-              "markdownDescription": "Hide the options to add words to dictionaries or settings.",
-              "scope": "resource",
-              "type": "boolean"
-            },
-            "cSpell.hideIssuesWhileTyping": {
-              "default": "Word",
-              "description": "Control how spelling issues are displayed while typing. See: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
-              "enum": [
-                "Off",
-                "Word",
-                "Line",
-                "Document"
-              ],
-              "enumDescriptions": [
-                "Show issues while typing",
-                "Hide issues while typing in the current word",
-                "Hide issues while typing on the line",
-                "Hide all issues while typing in the document"
-              ],
-              "markdownDescription": "Control how spelling issues are displayed while typing.\nSee: `#cSpell.revealIssuesAfterDelayMS#` to control when issues are revealed.",
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "title": "Hide Issues While Typing",
-              "type": "string"
-            },
-            "cSpell.maxDuplicateProblems": {
-              "default": 20,
-              "description": "The maximum number of times the same word can be flagged as an error in a file.",
-              "markdownDescription": "The maximum number of times the same word can be flagged as an error in a file.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.maxNumberOfProblems": {
-              "default": 100,
-              "description": "Controls the maximum number of spelling errors per document.",
-              "markdownDescription": "Controls the maximum number of spelling errors per document.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.minWordLength": {
-              "default": 4,
-              "description": "The minimum length of a word before checking it against a dictionary.",
-              "markdownDescription": "The minimum length of a word before checking it against a dictionary.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.numSuggestions": {
-              "default": 8,
-              "description": "Controls the number of suggestions shown.",
-              "markdownDescription": "Controls the number of suggestions shown.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.revealIssuesAfterDelayMS": {
-              "default": 1500,
-              "description": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
-              "markdownDescription": "Reveal hidden issues related to `#cSpell.hideIssuesWhileTyping#` after a delay in milliseconds.",
-              "scope": "application",
-              "sinceVersion": "4.0.0",
-              "title": "Reveal Issues After a Delay in Milliseconds",
-              "type": "number"
-            },
-            "cSpell.showAutocompleteDirectiveSuggestions": {
-              "default": true,
-              "description": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
-              "markdownDescription": "Show CSpell in-document directives as you type.\n\n**Note:** VS Code must be restarted for this setting to take effect.",
-              "scope": "language-overridable",
-              "type": "boolean"
-            },
-            "cSpell.showCommandsInEditorContextMenu": {
-              "default": true,
-              "description": "Show Spell Checker actions in Editor Context Menu",
-              "markdownDescription": "Show Spell Checker actions in Editor Context Menu",
-              "scope": "application",
-              "type": "boolean"
-            },
-            "cSpell.showSuggestionsLinkInEditorContextMenu": {
-              "default": true,
-              "description": "Show Spelling Suggestions link in the top level context menu.",
-              "markdownDescription": "Show Spelling Suggestions link in the top level context menu.",
-              "scope": "application",
-              "type": "boolean"
-            },
-            "cSpell.suggestionMenuType": {
-              "default": "quickPick",
-              "description": "The type of menu used to display spelling suggestions.",
-              "enum": [
-                "quickPick",
-                "quickFix"
-              ],
-              "enumDescriptions": [
-                "Suggestions will appear as a drop down at the top of the IDE. (Best choice for Vim Key Bindings)",
-                "Suggestions will appear inline near the word, inside the text editor."
-              ],
-              "markdownDescription": "The type of menu used to display spelling suggestions.",
-              "scope": "resource",
-              "type": "string"
-            },
-            "cSpell.suggestionNumChanges": {
-              "default": 3,
-              "description": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
-              "markdownDescription": "The maximum number of changes allowed on a word to be considered a suggestions.\n\nFor example, appending an `s` onto `example` -> `examples` is considered 1 change.\n\nRange: between 1 and 5.",
-              "scope": "resource",
-              "type": "number"
-            },
-            "cSpell.validateDirectives": {
-              "description": "Verify that the in-document directives are correct.",
-              "markdownDescription": "Verify that the in-document directives are correct.",
-              "scope": "window",
-              "type": "boolean"
-            }
-          },
-          "title": "Reporting and Display",
-          "type": "object"
+          "title": "Reporting and Display"
         }
       ],
       "maxItems": 10,
       "minItems": 10,
       "type": "array"
+    },
+    "UnknownWordsReportingLevel": {
+      "enum": [
+        "all",
+        "simple",
+        "typos",
+        "flagged"
+      ],
+      "type": "string"
+    },
+    "VSConfigAdvanced": {
+      "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8337-8640-653189051-0-9330%3E",
+      "description": "Advanced settings that are not commonly used.",
+      "order": 18,
+      "title": "Advanced"
     }
   }
 }

--- a/website/_scripts/extract-config.mts
+++ b/website/_scripts/extract-config.mts
@@ -7,7 +7,7 @@ type TypeSlugRefs = { [key: string]: string };
 /**
  * The Schema File URL
  */
-const schemaFile = new URL('../../packages/_server/spell-checker-config.schema.json', import.meta.url);
+const schemaFile = new URL('../../packages/_server/spell-checker-config-web.schema.json', import.meta.url);
 const descriptionWidth = 90;
 const compare = new Intl.Collator().compare;
 
@@ -334,10 +334,28 @@ function shorten(text: string, len: number): string {
 async function loadSchema(): Promise<JSONSchema4['items'] | Pick<JSONSchema4, 'properties'>> {
     const schema: JSONSchema4 = JSON.parse(await fs.readFile(schemaFile, 'utf8'));
 
-    if (schema.items) return schema.items;
+    const resolved = resolveRef(schema, schema);
+
+    if (resolved.items) return resolved.items;
     return {
-        properties: schema.properties,
+        properties: resolved.properties,
     };
+}
+
+/**
+ * Resolve a top-level `$ref` (e.g. `#/definitions/Foo`) against the root schema document.
+ */
+function resolveRef(root: JSONSchema4, ref: JSONSchema4): JSONSchema4 {
+    if (!ref.$ref) return ref;
+
+    const path = ref.$ref.replace(/^#\//, '').split('/');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const resolved = path.reduce<any>((node, key) => node?.[key], root);
+    if (!resolved) {
+        throw new Error(`Unable to resolve $ref: ${ref.$ref}`);
+    }
+
+    return resolveRef(root, resolved);
 }
 
 function beautifyJSON(json: string, width: number): string {

--- a/website/_scripts/extract-config.mts
+++ b/website/_scripts/extract-config.mts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import type { JSONSchema4, JSONSchema4Type } from 'json-schema';
 import { unindent } from './lib/utils.mts';
+import { resolve } from 'node:path';
 
 type TypeSlugRefs = { [key: string]: string };
 
@@ -10,29 +11,43 @@ type TypeSlugRefs = { [key: string]: string };
 const schemaFile = new URL('../../packages/_server/spell-checker-config-web.schema.json', import.meta.url);
 const descriptionWidth = 90;
 const compare = new Intl.Collator().compare;
-
-async function run(): Promise<void> {
-    const configSections = await loadSchema();
-
-    if (!Array.isArray(configSections)) {
-        return;
-    }
-
-    configSections.sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || compare(a.title || '', b.title || ''));
-
-    const refs = extractTypeRefs(configSections);
-
-    await fs.mkdir(targetDir, { recursive: true });
-    await fs.writeFile(new URL('index.md', targetDir), genIndex(configSections));
-    for (const section of formatSections(configSections, refs)) {
-        await fs.writeFile(new URL(`auto_${section.slug}.md`, targetDir), section.content);
-    }
-}
-
 const targetDir = new URL('../docs/configuration/', import.meta.url);
 
-function genIndex(configSections: JSONSchema4[]): string {
-    return unindent`\
+class ConfigExtractor {
+    private root: JSONSchema4;
+    private configSections: JSONSchema4[];
+    private refs: TypeSlugRefs;
+    constructor(root: JSONSchema4) {
+        this.root = root;
+        const configSections = this.#resolve(this.root).items;
+        this.configSections = Array.isArray(configSections) ? configSections : [];
+        this.configSections.sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || compare(a.title || '', b.title || ''));
+        this.refs = this.#extractTypeRefs(this.configSections);
+    }
+
+    #extractTypeRefs(configSections: JSONSchema4[]): TypeSlugRefs {
+        const refs: TypeSlugRefs = {};
+        for (const section of configSections) {
+            for (const key of Object.keys(section.properties || {})) {
+                refs[key] ??= slugifyTitle(section.title || '') + hashRef(key);
+            }
+        }
+        return refs;
+    }
+
+    #resolve($ref: JSONSchema4 | string): JSONSchema4 {
+        if (typeof $ref === 'string') {
+            return resolveRef(this.root, { $ref });
+        }
+        return resolveRef(this.root, $ref);
+    }
+
+    genIndex(): string {
+        return this.#genIndex(this.configSections);
+    }
+
+    #genIndex(configSections: JSONSchema4[]): string {
+        return unindent`\
         ---
         # AUTO-GENERATED ALL CHANGES WILL BE LOST
         # See \`_scripts/extract-config.mts\`
@@ -42,32 +57,50 @@ function genIndex(configSections: JSONSchema4[]): string {
 
         # Configuration Settings
 
-        ${sectionTOC(configSections)}
+        ${this.#sectionTOC(configSections)}
     `;
-}
+    }
 
-function sectionTOC(sections: JSONSchema4[]): string {
-    function tocEntry(value: JSONSchema4): string {
+    #tocEntry(value: JSONSchema4): string {
+        value = this.#resolve(value);
         if (!value.title) return '';
         const title = value.title;
         const description = value.description ? ` - ${value.description}` : '';
         return `- [${title}](configuration/${slugifyTitle(title)}) ${description}`.trim();
     }
 
-    return `\n${sections
-        .map(tocEntry)
-        .filter((a) => !!a)
-        .join('\n')}\n`;
+    #sectionTOC(sections: JSONSchema4[]): string {
+        return `\n${sections
+            .map((v) => this.#tocEntry(v))
+            .filter((a) => !!a)
+            .join('\n')}\n`;
+    }
+
+    #formatSections(sections: JSONSchema4[], refs: TypeSlugRefs): FormattedSection[] {
+        return sections.map((s) => formatSectionContent(s, refs));
+    }
+
+    formatSections(): FormattedSection[] {
+        return this.#formatSections(this.configSections, this.refs);
+    }
+}
+
+async function run(): Promise<void> {
+    const root = await loadSchema();
+
+    const extractor = new ConfigExtractor(root);
+
+    const configSections = await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(new URL('index.md', targetDir), extractor.genIndex());
+    for (const section of extractor.formatSections()) {
+        await fs.writeFile(new URL(`auto_${section.slug}.md`, targetDir), section.content);
+    }
 }
 
 interface FormattedSection {
     title: string;
     content: string;
     slug: string;
-}
-
-function formatSections(sections: JSONSchema4[], refs: TypeSlugRefs): FormattedSection[] {
-    return sections.map((s) => formatSectionContent(s, refs));
 }
 
 function formatSectionContent(section: JSONSchema4, refs: TypeSlugRefs): FormattedSection {
@@ -98,16 +131,6 @@ function formatSectionContent(section: JSONSchema4, refs: TypeSlugRefs): Formatt
     `;
 
     return { title, content, slug };
-}
-
-function extractTypeRefs(configSections: JSONSchema4[]): TypeSlugRefs {
-    const refs: TypeSlugRefs = {};
-    for (const section of configSections) {
-        for (const key of Object.keys(section.properties || {})) {
-            refs[key] ??= slugifyTitle(section.title || '') + hashRef(key);
-        }
-    }
-    return refs;
 }
 
 /**
@@ -331,15 +354,9 @@ function shorten(text: string, len: number): string {
     return text.length <= len ? text : text.slice(0, len - 1) + '…';
 }
 
-async function loadSchema(): Promise<JSONSchema4['items'] | Pick<JSONSchema4, 'properties'>> {
+async function loadSchema(): Promise<JSONSchema4> {
     const schema: JSONSchema4 = JSON.parse(await fs.readFile(schemaFile, 'utf8'));
-
-    const resolved = resolveRef(schema, schema);
-
-    if (resolved.items) return resolved.items;
-    return {
-        properties: resolved.properties,
-    };
+    return schema;
 }
 
 /**

--- a/website/_scripts/extract-config.mts
+++ b/website/_scripts/extract-config.mts
@@ -19,27 +19,37 @@ class ConfigExtractor {
     private refs: TypeSlugRefs;
     constructor(root: JSONSchema4) {
         this.root = root;
-        const configSections = this.#resolve(this.root).items;
-        this.configSections = Array.isArray(configSections) ? configSections : [];
-        this.configSections.sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || compare(a.title || '', b.title || ''));
+        this.configSections = this.#extractConfigSections();
         this.refs = this.#extractTypeRefs(this.configSections);
+    }
+
+    #extractConfigSections(): JSONSchema4[] {
+        const root = this.root;
+        const configSections = this.#resolve(this.root).items;
+        if (!Array.isArray(configSections)) return [];
+        const resolved = configSections.map((s) => this.#resolve(s, hasTitle));
+        resolved.sort((a, b) => (a.order || 0) - (b.order || 0) || compare(a.title || '', b.title || ''));
+        return resolved;
     }
 
     #extractTypeRefs(configSections: JSONSchema4[]): TypeSlugRefs {
         const refs: TypeSlugRefs = {};
         for (const section of configSections) {
-            for (const key of Object.keys(section.properties || {})) {
-                refs[key] ??= slugifyTitle(section.title || '') + hashRef(key);
+            const title = section.title || '';
+            const props = this.#resolve(section, hasProperties).properties || {};
+            for (const key of Object.keys(props)) {
+                refs[key] ??= slugifyTitle(title) + hashRef(key);
             }
         }
         return refs;
     }
 
-    #resolve($ref: JSONSchema4 | string): JSONSchema4 {
-        if (typeof $ref === 'string') {
-            return resolveRef(this.root, { $ref });
+    #resolve($ref: JSONSchema4 | string, stopPredicate?: (schema: JSONSchema4) => boolean): JSONSchema4 {
+        let ref = typeof $ref === 'string' ? { $ref } : $ref;
+        while (ref.$ref && !stopPredicate?.(ref)) {
+            ref = resolveRef(this.root, ref);
         }
-        return resolveRef(this.root, $ref);
+        return ref;
     }
 
     genIndex(): string {
@@ -48,21 +58,20 @@ class ConfigExtractor {
 
     #genIndex(configSections: JSONSchema4[]): string {
         return unindent`\
-        ---
-        # AUTO-GENERATED ALL CHANGES WILL BE LOST
-        # See \`_scripts/extract-config.mts\`
-        title: Configuration
-        id: configuration
-        ---
+            ---
+            # AUTO-GENERATED ALL CHANGES WILL BE LOST
+            # See \`_scripts/extract-config.mts\`
+            title: Configuration
+            id: configuration
+            ---
 
-        # Configuration Settings
+            # Configuration Settings
 
-        ${this.#sectionTOC(configSections)}
-    `;
+            ${this.#sectionTOC(configSections)}
+        `;
     }
 
     #tocEntry(value: JSONSchema4): string {
-        value = this.#resolve(value);
         if (!value.title) return '';
         const title = value.title;
         const description = value.description ? ` - ${value.description}` : '';
@@ -77,11 +86,184 @@ class ConfigExtractor {
     }
 
     #formatSections(sections: JSONSchema4[], refs: TypeSlugRefs): FormattedSection[] {
-        return sections.map((s) => formatSectionContent(s, refs));
+        return sections.map((s) => this.#formatSectionContent(s, refs));
+    }
+
+    #formatSectionContent(section: JSONSchema4, refs: TypeSlugRefs): FormattedSection {
+        const resolvedSection = this.#resolve(section, hasProperties);
+        const entries = Object.entries(resolvedSection.properties || {});
+        entries.sort((a, b) => this.#compareProperties(a, b));
+        const activeEntries = entries.filter(([, value]) => !value.deprecationMessage);
+
+        const title = section.title || '';
+        const slug = slugifyTitle(title);
+        const content = unindent`\
+            ---
+            # AUTO-GENERATED ALL CHANGES WILL BE LOST
+            # See \`_scripts/extract-config.mts\`
+            title: ${title}
+            id: ${slugify(title)}
+            ---
+
+            # ${title}
+
+            ${section.description || ''}
+
+            ${this.#configTable(activeEntries, refs)}
+
+            ## Settings
+
+            ${this.#configDefinitions(entries, refs)}
+
+        `;
+
+        return { title, content, slug };
+    }
+
+    #configDefinitions(entries: [string, JSONSchema4][], refs: TypeSlugRefs): string {
+        return entries.map((def) => this.#definition(def, refs)).join('\n');
+    }
+
+    #definition(entry: [string, JSONSchema4], refs: TypeSlugRefs): string {
+        const [key, value] = entry;
+        const description = value.markdownDescription || value.description || value.title || '';
+        const since = value.sinceVersion || '';
+        const sinceCSpellVersion = value.since || '';
+        const defaultValue = this.#formatDefaultValue(value.default);
+
+        const title = value.title ? `-- ${value.title}` : '';
+        let name = '`' + key + '`';
+        if (value.deprecationMessage) {
+            name = '~~' + name + '~~';
+        }
+
+        const deprecationMessage = value.deprecationMessage ? singleDef('Deprecation Message', value.deprecationMessage) : '';
+
+        return unindent`
+            ### ${name}
+
+            <dl>
+
+            ${singleDef('Name', `${name} ${title}`)}
+
+            ${singleDef('Description', fixVSCodeRefs(description, refs))}
+
+            ${singleDef('Type', this.#formatType(value), true)}
+
+            ${singleDef('Scope', scopeDef(value.scope) || '_- none -_')}
+
+            ${deprecationMessage}
+
+            ${singleDef('Default', defaultValue, true)}
+
+            ${since ? singleDef('Since Extension Version', since) : ''}
+
+            ${sinceCSpellVersion ? singleDef('CSpell Version', sinceCSpellVersion) : ''}
+
+            </dl>
+
+            ---
+        `.replace(/\n{3,}/g, '\n\n'); // Remove extra blank lines
     }
 
     formatSections(): FormattedSection[] {
         return this.#formatSections(this.configSections, this.refs);
+    }
+
+    #innerFormatDefaultValue(value: JSONSchema4Type | undefined): string {
+        if (value === undefined) return '';
+
+        if (Array.isArray(value)) {
+            return '[ ' + value.map((v) => this.#innerFormatDefaultValue(v)).join(', ') + ' ]';
+        }
+
+        return JSON.stringify(value);
+    }
+
+    #formatDefaultValue(value: JSONSchema4Type | undefined): string {
+        if (value === undefined) return '_- none -_';
+
+        const text = beautifyJSON(this.#innerFormatDefaultValue(value), 80);
+        const lines = text.split('\n');
+        if (lines.length > 1) {
+            // console.error('%o', lines);
+            return '\n```json5\n' + text + '\n```\n';
+        }
+
+        return '_`' + text + '`_';
+    }
+
+    #formatType(def: JSONSchema4): string {
+        const typeLines = beautifyType(this.#extractTypeAndFormat(def), 80);
+        const types = typeLines.length > 1 ? 'definition\n```\n' + typeLines.join('\n') + '\n```\n' : '`' + typeLines[0] + '`';
+        const enumDefs = this.#extractEnumDescriptions(def);
+        return types + enumDefs;
+    }
+
+    #extractEnumDescriptions(def: JSONSchema4): string {
+        const enumDef = this.#resolve(def);
+        if (!def.enumDescriptions || !enumDef.enum) return '';
+
+        const defs = enumDef.enum
+            .map((e, i) => [e, def.enumDescriptions?.[i] || '_No description_'])
+            .map(([e, d]) => `| \`${e}\` | ${(d as string).replace(/\n/g, '<br>')} |`)
+            .join('\n');
+
+        return unindent`
+            | Value | Description |
+            | ----- | ----------- |
+            ${defs}
+        `;
+    }
+
+    #extractTypeAndFormat(def: JSONSchema4 | undefined): string {
+        return formatExtractedType(this.#extractType(def));
+    }
+
+    #extractType(def: JSONSchema4 | undefined): string | string[] {
+        def = def && this.#resolve(def);
+        if (!def) return '';
+        if (def.type === 'array') return this.#extractTypeAndFormat(def.items) + '[]';
+
+        if (def.enum) {
+            return def.enum.map((v) => JSON.stringify(v));
+        }
+
+        if (def.type) return def.type;
+
+        if (Array.isArray(def.anyOf)) {
+            const types = [...new Set(def.anyOf.map((t) => this.#extractType(t)).flat())];
+            if (types.length === 1) return types[0];
+            return types;
+        }
+
+        return '';
+    }
+
+    /**
+     * Sort properties by name, with deprecated properties last.
+     */
+    #compareProperties(a: [string, JSONSchema4], b: [string, JSONSchema4]): number {
+        const dA = a[1].deprecationMessage || a[1].deprecated ? 1 : 0;
+        const dB = b[1].deprecationMessage || b[1].deprecated ? 1 : 0;
+        return dA - dB || compare(a[0], b[0]);
+    }
+
+    #configTable(entries: [string, JSONSchema4][], refs: TypeSlugRefs): string {
+        function tableEntryConfig([key, value]: [string, JSONSchema4]): string {
+            const description = fixVSCodeRefs(
+                value.title || value.description?.replace(/\n/g, '<br>') || value.markdownDescription?.replace(/\n[\s\S]*/g, ' ') || '',
+                refs,
+            );
+            const scope = value.scope || '';
+            return `| [\`${shorten(key, 60)}\`](${hashRef(key)}) | ${scope} | ${shortenLine(description, descriptionWidth)} |`;
+        }
+
+        return unindent`
+            | Setting | Scope | Description |
+            | ------- | ----- | ----------- |
+            ${entries.map(tableEntryConfig).join('\n')}
+        `;
     }
 }
 
@@ -97,66 +279,18 @@ async function run(): Promise<void> {
     }
 }
 
+function hasTitle(schema: JSONSchema4): boolean {
+    return schema.title !== undefined;
+}
+
+function hasProperties(schema: JSONSchema4): boolean {
+    return !!schema.properties;
+}
+
 interface FormattedSection {
     title: string;
     content: string;
     slug: string;
-}
-
-function formatSectionContent(section: JSONSchema4, refs: TypeSlugRefs): FormattedSection {
-    const entries = Object.entries(section.properties || {});
-    entries.sort(compareProperties);
-    const activeEntries = entries.filter(([, value]) => !value.deprecationMessage);
-
-    const title = section.title || '';
-    const slug = slugifyTitle(title);
-    const content = unindent`\
-        ---
-        # AUTO-GENERATED ALL CHANGES WILL BE LOST
-        # See \`_scripts/extract-config.mts\`
-        title: ${title}
-        id: ${slugify(title)}
-        ---
-
-        # ${title}
-
-        ${section.description || ''}
-
-        ${configTable(activeEntries, refs)}
-
-        ## Settings
-
-        ${configDefinitions(entries, refs)}
-
-    `;
-
-    return { title, content, slug };
-}
-
-/**
- * Sort properties by name, with deprecated properties last.
- */
-function compareProperties(a: [string, JSONSchema4], b: [string, JSONSchema4]): number {
-    const dA = a[1].deprecationMessage || a[1].deprecated ? 1 : 0;
-    const dB = b[1].deprecationMessage || b[1].deprecated ? 1 : 0;
-    return dA - dB || compare(a[0], b[0]);
-}
-
-function configTable(entries: [string, JSONSchema4][], refs: TypeSlugRefs): string {
-    function tableEntryConfig([key, value]: [string, JSONSchema4]): string {
-        const description = fixVSCodeRefs(
-            value.title || value.description?.replace(/\n/g, '<br>') || value.markdownDescription?.replace(/\n[\s\S]*/g, ' ') || '',
-            refs,
-        );
-        const scope = value.scope || '';
-        return `| [\`${shorten(key, 60)}\`](${hashRef(key)}) | ${scope} | ${shortenLine(description, descriptionWidth)} |`;
-    }
-
-    return unindent`
-        | Setting | Scope | Description |
-        | ------- | ----- | ----------- |
-        ${entries.map(tableEntryConfig).join('\n')}
-    `;
 }
 
 function shortenLine(line: string, len: number): string {
@@ -171,52 +305,6 @@ function shortenLine(line: string, len: number): string {
         ++i;
     }
     return i < line.length ? line.slice(0, i) + '…' : line;
-}
-
-function configDefinitions(entries: [string, JSONSchema4][], refs: TypeSlugRefs): string {
-    return entries.map((def) => definition(def, refs)).join('\n');
-}
-
-function definition(entry: [string, JSONSchema4], refs: TypeSlugRefs): string {
-    const [key, value] = entry;
-    const description = value.markdownDescription || value.description || value.title || '';
-    const since = value.sinceVersion || '';
-    const sinceCSpellVersion = value.since || '';
-    const defaultValue = formatDefaultValue(value.default);
-
-    const title = value.title ? `-- ${value.title}` : '';
-    let name = '`' + key + '`';
-    if (value.deprecationMessage) {
-        name = '~~' + name + '~~';
-    }
-
-    const deprecationMessage = value.deprecationMessage ? singleDef('Deprecation Message', value.deprecationMessage) : '';
-
-    return unindent`
-        ### ${name}
-
-        <dl>
-
-        ${singleDef('Name', `${name} ${title}`)}
-
-        ${singleDef('Description', fixVSCodeRefs(description, refs))}
-
-        ${singleDef('Type', formatType(value), true)}
-
-        ${singleDef('Scope', scopeDef(value.scope) || '_- none -_')}
-
-        ${deprecationMessage}
-
-        ${singleDef('Default', defaultValue, true)}
-
-        ${since ? singleDef('Since Extension Version', since) : ''}
-
-        ${sinceCSpellVersion ? singleDef('CSpell Version', sinceCSpellVersion) : ''}
-
-        </dl>
-
-        ---
-    `.replace(/\n{3,}/g, '\n\n'); // Remove extra blank lines
 }
 
 function scopeDef(scope: string | undefined): string | undefined {
@@ -264,29 +352,6 @@ function singleDef(term: string, def: string, _addIgnore = false): string {
     return lines.join('\n');
 }
 
-function _formatDefaultValue(value: JSONSchema4Type | undefined): string {
-    if (value === undefined) return '';
-
-    if (Array.isArray(value)) {
-        return '[ ' + value.map(_formatDefaultValue).join(', ') + ' ]';
-    }
-
-    return JSON.stringify(value);
-}
-
-function formatDefaultValue(value: JSONSchema4Type | undefined): string {
-    if (value === undefined) return '_- none -_';
-
-    const text = beautifyJSON(_formatDefaultValue(value), 80);
-    const lines = text.split('\n');
-    if (lines.length > 1) {
-        // console.error('%o', lines);
-        return '\n```json5\n' + text + '\n```\n';
-    }
-
-    return '_`' + text + '`_';
-}
-
 function slugifyTitle(sectionTitle: string): string {
     return slugify(sectionTitle);
 }
@@ -299,55 +364,10 @@ function hashRef(heading: string): string {
     return '#' + slugify(heading);
 }
 
-function extractTypeAndFormat(def: JSONSchema4 | undefined): string {
-    return formatExtractedType(extractType(def));
-}
-
 function formatExtractedType(types: string | string[]): string {
     if (!Array.isArray(types)) return types;
     if (types.length === 1) return types[0];
     return '( ' + types.join(' | ') + ' )';
-}
-
-function extractType(def: JSONSchema4 | undefined): string | string[] {
-    if (!def) return '';
-    if (def.type === 'array') return extractTypeAndFormat(def.items) + '[]';
-
-    if (def.enum) {
-        return def.enum.map((v) => JSON.stringify(v));
-    }
-
-    if (def.type) return def.type;
-
-    if (Array.isArray(def.anyOf)) {
-        const types = [...new Set(def.anyOf.map(extractType).flat())];
-        if (types.length === 1) return types[0];
-        return types;
-    }
-
-    return '';
-}
-
-function extractEnumDescriptions(def: JSONSchema4): string {
-    if (!def.enumDescriptions || !def.enum) return '';
-
-    const defs = def.enum
-        .map((e, i) => [e, def.enumDescriptions?.[i] || '_No description_'])
-        .map(([e, d]) => `| \`${e}\` | ${(d as string).replace(/\n/g, '<br>')} |`)
-        .join('\n');
-
-    return unindent`
-        | Value | Description |
-        | ----- | ----------- |
-        ${defs}
-    `;
-}
-
-function formatType(def: JSONSchema4): string {
-    const typeLines = beautifyType(extractTypeAndFormat(def), 80);
-    const types = typeLines.length > 1 ? 'definition\n```\n' + typeLines.join('\n') + '\n```\n' : '`' + typeLines[0] + '`';
-    const enumDefs = extractEnumDescriptions(def);
-    return types + enumDefs;
 }
 
 function shorten(text: string, len: number): string {
@@ -365,14 +385,14 @@ async function loadSchema(): Promise<JSONSchema4> {
 function resolveRef(root: JSONSchema4, ref: JSONSchema4): JSONSchema4 {
     if (!ref.$ref) return ref;
 
-    const path = ref.$ref.replace(/^#\//, '').split('/');
+    const path = ref.$ref.replace(/^#\//, '').split('/').map(decodeURIComponent);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const resolved = path.reduce<any>((node, key) => node?.[key], root);
     if (!resolved) {
         throw new Error(`Unable to resolve $ref: ${ref.$ref}`);
     }
 
-    return resolveRef(root, resolved);
+    return resolved;
 }
 
 function beautifyJSON(json: string, width: number): string {

--- a/website/_scripts/extract-config.mts
+++ b/website/_scripts/extract-config.mts
@@ -1,7 +1,6 @@
 import { promises as fs } from 'node:fs';
 import type { JSONSchema4, JSONSchema4Type } from 'json-schema';
 import { unindent } from './lib/utils.mts';
-import { resolve } from 'node:path';
 
 type TypeSlugRefs = { [key: string]: string };
 


### PR DESCRIPTION
## Summary

- Adds a second, web-friendly config schema (`spell-checker-config-web.schema.json`), generated with `topRef: true` and `expose: 'export'` so definitions are resolvable via top-level `$ref`s instead of being inlined.
- `build-schema.mts` now generates both `spell-checker-config.schema.json` (existing, used by VS Code) and the new web schema from a shared base config, via a small `genSchema` helper.
- `website/_scripts/extract-config.mts` is reworked into a `ConfigExtractor` class that reads from the new web schema and resolves `$ref`s against the root document (`resolveRef`) instead of expecting schema definitions to already be inlined.
- `cspell.config.yaml`: ignore generated `*.schema.json` files by pattern, replacing the now-redundant explicit ignore for `spell-checker-config.schema.json`.

## Why

`$ref`s are needed to render the types for nested objects. In a later PR, all `object` and `object[]` show on the website will get actual types.

