### PR TITLE
chore: improve configuration pages on the website.

### DIFF
--- a/website/_scripts/extract-config.mts
+++ b/website/_scripts/extract-config.mts
@@ -5,6 +5,31 @@ import { unindent } from './lib/utils.mts';
 type TypeSlugRefs = { [key: string]: string };
 
 /**
+ * A simplified structural representation of a JSON Schema type, built by
+ * resolving `$ref`s so that named object types can be detected and hoisted
+ * out into a separate "Type Definitions" section, while inline (unnamed)
+ * object types are expanded in place.
+ */
+type TypeNode =
+    | { kind: 'plain'; text: string }
+    | { kind: 'array'; item: TypeNode }
+    | { kind: 'tuple'; items: TypeNode[] }
+    | { kind: 'union'; options: TypeNode[] }
+    | { kind: 'ref'; name: string }
+    | { kind: 'object'; props: ObjectProp[]; indexSignature?: { keyType: string; value: TypeNode } };
+
+interface ObjectProp {
+    key: string;
+    type: TypeNode;
+    optional: boolean;
+}
+
+interface NamedType {
+    node: TypeNode;
+    description?: string;
+}
+
+/**
  * The Schema File URL
  */
 const schemaFile = new URL('../../packages/_server/spell-checker-config-web.schema.json', import.meta.url);
@@ -16,6 +41,10 @@ class ConfigExtractor {
     private root: JSONSchema4;
     private configSections: JSONSchema4[];
     private refs: TypeSlugRefs;
+    /** Named object types encountered while formatting the current section, keyed by definition name. */
+    private namedTypes: Map<string, NamedType> = new Map();
+    /** Guards against infinite recursion when resolving a named type that (indirectly) references itself. */
+    private namedTypesInProgress: Set<string> = new Set();
     constructor(root: JSONSchema4) {
         this.root = root;
         this.configSections = this.#extractConfigSections();
@@ -94,27 +123,31 @@ class ConfigExtractor {
         entries.sort((a, b) => this.#compareProperties(a, b));
         const activeEntries = entries.filter(([, value]) => !value.deprecationMessage);
 
+        this.namedTypes = new Map();
+
         const title = section.title || '';
         const slug = slugifyTitle(title);
-        const content = unindent`\
-            ---
-            # AUTO-GENERATED ALL CHANGES WILL BE LOST
-            # See \`_scripts/extract-config.mts\`
-            title: ${title}
-            id: ${slugify(title)}
-            ---
+        const definitions = this.#configDefinitions(entries, refs);
+        const namedTypeDefinitions = this.#formatNamedTypeDefinitions();
+        const content =
+            unindent`\
+                ---
+                # AUTO-GENERATED ALL CHANGES WILL BE LOST
+                # See \`_scripts/extract-config.mts\`
+                title: ${title}
+                id: ${slugify(title)}
+                ---
 
-            # ${title}
+                # ${title}
 
-            ${section.description || ''}
+                ${section.description || ''}
 
-            ${this.#configTable(activeEntries, refs)}
+                ${this.#configTable(activeEntries, refs)}
 
-            ## Settings
+                ## Settings
 
-            ${this.#configDefinitions(entries, refs)}
-
-        `;
+                ${definitions}
+            `.trimEnd() + (namedTypeDefinitions ? `\n\n${namedTypeDefinitions}\n\n\n` : '\n\n\n');
 
         return { title, content, slug };
     }
@@ -193,10 +226,28 @@ class ConfigExtractor {
     }
 
     #formatType(def: JSONSchema4): string {
-        const typeLines = beautifyType(this.#extractTypeAndFormat(def), 80);
-        const types = typeLines.length > 1 ? 'definition\n```\n' + typeLines.join('\n') + '\n```\n' : '`' + typeLines[0] + '`';
-        const enumDefs = this.#extractEnumDescriptions(def);
-        return types + enumDefs;
+        const node = this.#buildTypeNode(def);
+        return this.#renderTypeField(node) + this.#extractEnumDescriptions(def);
+    }
+
+    /**
+     * Render the value used for a "Type" field: an inline, backtick-quoted type for a plain
+     * type or a type that only involves links to named types (matching how the rest of this
+     * file formats inline code, e.g. {@link fixVSCodeRefs}), or - when an inline object literal
+     * is involved - a fenced code block, the same way {@link #formatDefaultValue} pretty-prints
+     * multi-line default values.
+     */
+    #renderTypeField(node: TypeNode): string {
+        if (containsObjectLiteral(node)) {
+            return '\n```ts\n' + this.#renderTsType(node, 0) + '\n```\n';
+        }
+
+        if (containsRef(node)) {
+            return this.#renderLinkedType(node);
+        }
+
+        const typeLines = beautifyType(this.#renderPlainType(node), 80);
+        return typeLines.length > 1 ? '\n```\n' + typeLines.join('\n') + '\n```\n' : '`' + typeLines[0] + '`';
     }
 
     #extractEnumDescriptions(def: JSONSchema4): string {
@@ -215,28 +266,200 @@ class ConfigExtractor {
         `;
     }
 
-    #extractTypeAndFormat(def: JSONSchema4 | undefined): string {
-        return formatExtractedType(this.#extractType(def));
+    /**
+     * Build a structural {@link TypeNode} for a schema, resolving `$ref`s.
+     *
+     * A `$ref` to a named definition that turns out to be an object type (or a union that
+     * involves one) is hoisted: it is registered in {@link namedTypes} and a `ref` node is
+     * returned instead of inlining it, so that it can be rendered later in a "Type Definitions"
+     * section. Inline (unnamed) object types are expanded in place as an `object` node.
+     */
+    #buildTypeNode(def: JSONSchema4 | undefined): TypeNode {
+        if (!def) return { kind: 'plain', text: '' };
+
+        if (def.$ref) {
+            const name = refName(def.$ref);
+            const known = this.namedTypes.get(name);
+            if (known) return { kind: 'ref', name };
+            if (!isHoistableName(name) || this.namedTypesInProgress.has(name)) {
+                return this.#buildTypeNodeRaw(resolveRef(this.root, def));
+            }
+
+            const resolved = resolveRef(this.root, def);
+            this.namedTypesInProgress.add(name);
+            const inner = this.#buildTypeNodeRaw(resolved);
+            this.namedTypesInProgress.delete(name);
+
+            if (!containsComplexType(inner)) return inner;
+
+            this.namedTypes.set(name, { node: inner, description: resolved.description });
+            return { kind: 'ref', name };
+        }
+
+        return this.#buildTypeNodeRaw(def);
     }
 
-    #extractType(def: JSONSchema4 | undefined): string | string[] {
-        def = def && this.#resolve(def);
-        if (!def) return '';
-        if (def.type === 'array') return this.#extractTypeAndFormat(def.items) + '[]';
+    #buildTypeNodeRaw(def: JSONSchema4): TypeNode {
+        if (def.type === 'array') {
+            if (Array.isArray(def.items)) {
+                return { kind: 'tuple', items: def.items.map((t) => this.#buildTypeNode(t)) };
+            }
+            return { kind: 'array', item: this.#buildTypeNode(def.items) };
+        }
 
         if (def.enum) {
-            return def.enum.map((v) => JSON.stringify(v));
+            return { kind: 'union', options: def.enum.map((v): TypeNode => ({ kind: 'plain', text: JSON.stringify(v) })) };
         }
 
-        if (def.type) return def.type;
+        if (def.type === 'object') {
+            return this.#buildObjectNode(def);
+        }
+
+        if (Array.isArray(def.type)) {
+            const options = def.type.map((t): TypeNode => ({ kind: 'plain', text: t }));
+            return options.length === 1 ? options[0] : { kind: 'union', options };
+        }
+
+        if (def.type) return { kind: 'plain', text: def.type };
+
+        // `{ "not": {} }` is the JSON Schema idiom for "matches nothing" (TypeScript's `never`),
+        // commonly paired with other options in an `anyOf` to widen a string-literal union
+        // without losing autocomplete (TypeScript's `SomeLiteral | (string & {})` trick).
+        if (def.not) return { kind: 'plain', text: 'never' };
 
         if (Array.isArray(def.anyOf)) {
-            const types = [...new Set(def.anyOf.map((t) => this.#extractType(t)).flat())];
-            if (types.length === 1) return types[0];
-            return types;
+            const options = dedupeTypeNodes(def.anyOf.map((t) => this.#buildTypeNode(t)));
+            // `T | never` is just `T`; drop `never` whenever another option is present.
+            const meaningful = options.filter((o) => !(o.kind === 'plain' && o.text === 'never'));
+            const result = meaningful.length ? meaningful : options;
+            return result.length === 1 ? result[0] : { kind: 'union', options: result };
         }
 
-        return '';
+        return { kind: 'plain', text: '' };
+    }
+
+    #buildObjectNode(def: JSONSchema4): TypeNode {
+        const required = new Set(Array.isArray(def.required) ? def.required : []);
+        const props: ObjectProp[] = Object.entries(def.properties || {}).map(([key, value]) => ({
+            key,
+            type: this.#buildTypeNode(value),
+            optional: !required.has(key),
+        }));
+
+        let indexSignature: { keyType: string; value: TypeNode } | undefined;
+        if (def.additionalProperties && typeof def.additionalProperties === 'object') {
+            indexSignature = { keyType: 'string', value: this.#buildTypeNode(def.additionalProperties) };
+        } else if (def.additionalProperties === true && !props.length) {
+            indexSignature = { keyType: 'string', value: { kind: 'plain', text: 'any' } };
+        }
+
+        return { kind: 'object', props, indexSignature };
+    }
+
+    /** Render a type known to contain no object/ref nodes, matching the legacy compact format. */
+    #renderPlainType(node: TypeNode): string {
+        switch (node.kind) {
+            case 'plain':
+                return node.text;
+            case 'array':
+                return this.#renderPlainType(node.item) + '[]';
+            case 'tuple':
+                return '[ ' + node.items.map((i) => this.#renderPlainType(i)).join(', ') + ' ]';
+            case 'union': {
+                const parts = node.options.map((o) => this.#renderPlainType(o));
+                return parts.length > 1 ? '( ' + parts.join(' | ') + ' )' : (parts[0] ?? '');
+            }
+            case 'ref':
+            case 'object':
+                // Unreachable: callers only use this renderer when `containsComplexType` is false.
+                return '';
+        }
+    }
+
+    /**
+     * Render a type that references a named type but involves no inline object literal, as a
+     * single line of inline code with a real markdown link for each reference - the same style
+     * {@link fixVSCodeRefs} uses for `#setting#`-style cross references in descriptions.
+     */
+    #renderLinkedType(node: TypeNode): string {
+        switch (node.kind) {
+            case 'plain':
+                return node.text ? '`' + node.text + '`' : '';
+            case 'ref':
+                return '[`' + node.name + '`](' + hashRef(node.name) + ')';
+            case 'array':
+                return this.#renderLinkedType(node.item) + '[]';
+            case 'tuple':
+                return '[ ' + node.items.map((i) => this.#renderLinkedType(i)).join(', ') + ' ]';
+            case 'union': {
+                const parts = node.options.map((o) => this.#renderLinkedType(o));
+                return parts.length > 1 ? '( ' + parts.join(' | ') + ' )' : (parts[0] ?? '');
+            }
+            case 'object':
+                // Unreachable: callers only use this renderer when `containsObjectLiteral` is false.
+                return '';
+        }
+    }
+
+    /**
+     * Pretty-print a type as a TypeScript type literal, the same way {@link #formatDefaultValue}
+     * pretty-prints a multi-line default value into a fenced ` ```json5 ` block: plain text with
+     * real indentation, meant to be placed inside a fenced ` ```ts ` block. A named-type
+     * reference is rendered as its bare name (a link would not work inside a fenced code block);
+     * see the "Type Definitions" section for its shape.
+     */
+    #renderTsType(node: TypeNode, depth: number): string {
+        switch (node.kind) {
+            case 'plain':
+                return node.text || 'any';
+            case 'ref':
+                return node.name;
+            case 'array':
+                return this.#renderTsType(node.item, depth) + '[]';
+            case 'tuple':
+                return '[' + node.items.map((i) => this.#renderTsType(i, depth)).join(', ') + ']';
+            case 'union': {
+                const parts = node.options.map((o) => this.#renderTsType(o, depth));
+                return parts.length > 1 ? '(' + parts.join(' | ') + ')' : (parts[0] ?? '');
+            }
+            case 'object':
+                return this.#renderTsObject(node, depth);
+        }
+    }
+
+    #renderTsObject(node: Extract<TypeNode, { kind: 'object' }>, depth: number): string {
+        const pad = '  '.repeat(depth + 1);
+        const propLines = node.props.map(
+            (p) => `${pad}${propKeyText(p.key)}${p.optional ? '?' : ''}: ${this.#renderTsType(p.type, depth + 1)};`,
+        );
+        if (node.indexSignature) {
+            propLines.push(`${pad}[key: string]: ${this.#renderTsType(node.indexSignature.value, depth + 1)};`);
+        }
+        if (!propLines.length) return '{}';
+
+        return '{\n' + propLines.join('\n') + '\n' + '  '.repeat(depth) + '}';
+    }
+
+    /** Render the "Type Definitions" section listing the named object types hoisted while formatting this section. */
+    #formatNamedTypeDefinitions(): string {
+        if (!this.namedTypes.size) return '';
+
+        const sections = [...this.namedTypes.entries()].map(([name, { node, description }]) =>
+            unindent`
+                ### ${name}
+
+                ${description ? description + '\n' : ''}
+                ${this.#renderTypeField(node)}
+
+                ---
+            `.replace(/\n{3,}/g, '\n\n'),
+        );
+
+        return unindent`
+            ## Type Definitions
+
+            ${sections.join('\n')}
+        `;
     }
 
     /**
@@ -336,7 +559,9 @@ function scopeDef(scope: string | undefined): string | undefined {
 }
 
 function fixVSCodeRefs(markdown: string, refs: TypeSlugRefs): string {
-    return markdown.replaceAll(/`#(.*?)#`/g, (_, p1) => `[\`${p1}\`](${refs[p1] || hashRef(p1)})`);
+    return markdown
+        .replaceAll(/`#(.*?)#`/g, (_, p1) => `[\`${p1}\`](${refs[p1] || hashRef(p1)})`)
+        .replaceAll(/\{@link (.*?)\}/g, (_, p1) => `\`${p1.trim()}\``);
 }
 
 function singleDef(term: string, def: string, _addIgnore = false): string {
@@ -363,10 +588,87 @@ function hashRef(heading: string): string {
     return '#' + slugify(heading);
 }
 
-function formatExtractedType(types: string | string[]): string {
-    if (!Array.isArray(types)) return types;
-    if (types.length === 1) return types[0];
-    return '( ' + types.join(' | ') + ' )';
+/** Extracts the definition name from a `$ref` such as `#/definitions/CustomDictionaries`. */
+function refName(ref: string): string {
+    const path = ref.replace(/^#\//, '').split('/').map(decodeURIComponent);
+    return path[path.length - 1];
+}
+
+/**
+ * `ts-json-schema-generator` emits internal helper definitions (e.g. `Prefix<alias-...>`) used to
+ * build up the config sections themselves; these are never meaningful as a named type for a
+ * property's value and should always be inlined instead of hoisted.
+ */
+function isHoistableName(name: string): boolean {
+    return !/^Prefix\b|alias-/.test(name);
+}
+
+/** True if this type is an object literal, or references/contains a named type - too complex to inline as a plain type. */
+function containsComplexType(node: TypeNode): boolean {
+    switch (node.kind) {
+        case 'object':
+        case 'ref':
+            return true;
+        case 'array':
+            return containsComplexType(node.item);
+        case 'tuple':
+            return node.items.some(containsComplexType);
+        case 'union':
+            return node.options.some(containsComplexType);
+        case 'plain':
+            return false;
+    }
+}
+
+/** True if this type contains an inline object literal anywhere, which must be rendered as a fenced code block. */
+function containsObjectLiteral(node: TypeNode): boolean {
+    switch (node.kind) {
+        case 'object':
+            return true;
+        case 'ref':
+        case 'plain':
+            return false;
+        case 'array':
+            return containsObjectLiteral(node.item);
+        case 'tuple':
+            return node.items.some(containsObjectLiteral);
+        case 'union':
+            return node.options.some(containsObjectLiteral);
+    }
+}
+
+/** True if this type references a named type anywhere, which should be rendered as a markdown link. */
+function containsRef(node: TypeNode): boolean {
+    switch (node.kind) {
+        case 'ref':
+            return true;
+        case 'plain':
+        case 'object':
+            return false;
+        case 'array':
+            return containsRef(node.item);
+        case 'tuple':
+            return node.items.some(containsRef);
+        case 'union':
+            return node.options.some(containsRef);
+    }
+}
+
+function dedupeTypeNodes(nodes: TypeNode[]): TypeNode[] {
+    const seen = new Set<string>();
+    const result: TypeNode[] = [];
+    for (const node of nodes) {
+        const key = JSON.stringify(node);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        result.push(node);
+    }
+    return result;
+}
+
+/** Quote an object-literal property key if it isn't a valid bare identifier. */
+function propKeyText(key: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
 }
 
 function shorten(text: string, len: number): string {

--- a/website/docs/configuration/auto_appearance.md
+++ b/website/docs/configuration/auto_appearance.md
@@ -61,7 +61,18 @@ Type
 </dt>
 <dd>
 
-`object`
+```ts
+{
+  overviewRulerColor?: string;
+  textDecoration?: string;
+  textDecorationColor?: string;
+  textDecorationColorFlagged?: string;
+  textDecorationColorSuggestion?: string;
+  textDecorationLine?: ("underline" | "overline" | "line-through");
+  textDecorationStyle?: ("solid" | "wavy" | "dotted" | "dashed" | "double");
+  textDecorationThickness?: string;
+}
+```
 
 </dd>
 
@@ -127,7 +138,11 @@ Type
 </dt>
 <dd>
 
-`object`
+```ts
+{
+  [key: string]: boolean;
+}
+```
 
 </dd>
 
@@ -194,7 +209,18 @@ Type
 </dt>
 <dd>
 
-`object`
+```ts
+{
+  overviewRulerColor?: string;
+  textDecoration?: string;
+  textDecorationColor?: string;
+  textDecorationColorFlagged?: string;
+  textDecorationColorSuggestion?: string;
+  textDecorationLine?: ("underline" | "overline" | "line-through");
+  textDecorationStyle?: ("solid" | "wavy" | "dotted" | "dashed" | "double");
+  textDecorationThickness?: string;
+}
+```
 
 </dd>
 

--- a/website/docs/configuration/auto_cspell.md
+++ b/website/docs/configuration/auto_cspell.md
@@ -61,7 +61,13 @@ Type
 </dt>
 <dd>
 
-`object`
+```ts
+{
+  "code-spell-checker"?: string;
+  cspell?: string;
+  [key: string]: string;
+}
+```
 
 </dd>
 
@@ -453,7 +459,92 @@ Type
 </dt>
 <dd>
 
-`object[]`
+```ts
+{
+  allowCompoundWords?: boolean;
+  caseSensitive?: boolean;
+  description?: string;
+  diagnosticLevel?: ("Error" | "Warning" | "Information" | "Hint");
+  diagnosticLevelFlaggedWords?: ("Error" | "Warning" | "Information" | "Hint");
+  dictionaries?: string[];
+  dictionaryDefinitions?: DictionaryDef[];
+  enableFiletypes?: string[];
+  enabled?: boolean;
+  enabledFileTypes?: {
+    [key: string]: boolean;
+  };
+  enabledLanguageIds?: string[];
+  filename: (string | string[]);
+  flagWords?: string[];
+  id?: string;
+  ignoreRandomStrings?: boolean;
+  ignoreRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+  ignoreWords?: string[];
+  includeRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+  language?: string;
+  languageId?: (string | string[]);
+  languageSettings?: {
+    allowCompoundWords?: boolean;
+    caseSensitive?: boolean;
+    description?: string;
+    dictionaries?: string[];
+    dictionaryDefinitions?: DictionaryDef[];
+    enabled?: boolean;
+    flagWords?: string[];
+    id?: string;
+    ignoreRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+    ignoreWords?: string[];
+    includeRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+    languageId: (string | string[]);
+    locale?: (string | string[]);
+    name?: string;
+    noSuggestDictionaries?: string[];
+    patterns?: {
+      description?: string;
+      name: string;
+      pattern: (string | string[]);
+    }[];
+    substitutionDefinitions?: {
+      description?: string;
+      entries: [string, string][];
+      name: string;
+    }[];
+    substitutions?: ([string, string] | string)[];
+    suggestWords?: string[];
+    unknownWords?: ("report-all" | "report-simple" | "report-common-typos" | "report-flagged");
+    useIntlWordSegmentation?: boolean;
+    words?: string[];
+  }[];
+  loadDefaultConfiguration?: boolean;
+  maxDuplicateProblems?: number;
+  maxFileSize?: (number | string);
+  maxNumberOfProblems?: number;
+  minRandomLength?: number;
+  minWordLength?: number;
+  name?: string;
+  noSuggestDictionaries?: string[];
+  numSuggestions?: number;
+  patterns?: {
+    description?: string;
+    name: string;
+    pattern: (string | string[]);
+  }[];
+  pnpFiles?: string[];
+  substitutionDefinitions?: {
+    description?: string;
+    entries: [string, string][];
+    name: string;
+  }[];
+  substitutions?: ([string, string] | string)[];
+  suggestWords?: string[];
+  suggestionNumChanges?: number;
+  suggestionsTimeout?: number;
+  unknownWords?: ("report-all" | "report-simple" | "report-common-typos" | "report-flagged");
+  useIntlWordSegmentation?: boolean;
+  usePnP?: boolean;
+  words?: string[];
+}[]
+```
 
 </dd>
 
@@ -523,7 +614,13 @@ Type
 </dt>
 <dd>
 
-`object[]`
+```ts
+{
+  description?: string;
+  name: string;
+  pattern: (string | string[]);
+}[]
+```
 
 </dd>
 
@@ -577,7 +674,13 @@ Type
 </dt>
 <dd>
 
-`object[]`
+```ts
+{
+  description?: string;
+  entries: [string, string][];
+  name: string;
+}[]
+```
 
 </dd>
 
@@ -640,7 +743,7 @@ Type
 </dt>
 <dd>
 
-`( [] | string )[]`
+`( [ string, string ] | string )[]`
 
 </dd>
 
@@ -763,7 +866,7 @@ Description
 <dd>
 
 Enables enables locale-sensitive text segmentation to support languages like Japanese, Chinese, Thai, Lao, Khmer, Myanmar, etc.
-The locale used for the segmentation is based on the  {@link  language  }  setting.
+The locale used for the segmentation is based on the  `language`  setting.
 
 </dd>
 
@@ -839,7 +942,15 @@ Type
 </dt>
 <dd>
 
-`object`
+```ts
+{
+  [key: string]: {
+    data: string;
+    encoding?: ("base64" | "plaintext" | "utf8");
+    url?: string;
+  };
+}
+```
 
 </dd>
 
@@ -873,5 +984,56 @@ CSpell Version
 </dl>
 
 ---
+
+
+## Type Definitions
+
+
+### CustomDictionary
+
+```ts
+{
+  addWords?: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+}
+```
+
+---
+
+
+### DictionaryDef
+
+```ts
+(CustomDictionary | {
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  supportNonStrictSearches?: boolean;
+} | {
+  addWords: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+})
+```
+
+---
+
+
 
 

--- a/website/docs/configuration/auto_files-folders-and-workspaces.md
+++ b/website/docs/configuration/auto_files-folders-and-workspaces.md
@@ -189,7 +189,7 @@ Type
 </dt>
 <dd>
 
-`object`
+[`EnabledFileTypes`](#enabledfiletypes)
 
 </dd>
 
@@ -260,7 +260,7 @@ Type
 </dt>
 <dd>
 
-`object`
+[`EnabledSchemes`](#enabledschemes)
 
 </dd>
 
@@ -636,7 +636,7 @@ Type
 </dt>
 <dd>
 
-`object`
+[`CSpellMergeFields`](#cspellmergefields)
 
 </dd>
 
@@ -1121,5 +1121,75 @@ _- none -_
 </dl>
 
 ---
+
+
+## Type Definitions
+
+
+### EnabledFileTypes
+
+```ts
+{
+  [key: string]: boolean;
+}
+```
+
+---
+
+
+### EnabledSchemes
+
+```ts
+{
+  [key: string]: boolean;
+}
+```
+
+---
+
+
+### CSpellMergeFields
+
+```ts
+{
+  allowCompoundWords?: boolean;
+  caseSensitive?: boolean;
+  dictionaries?: boolean;
+  dictionaryDefinitions?: boolean;
+  enableGlobDot?: boolean;
+  features?: boolean;
+  files?: boolean;
+  flagWords?: boolean;
+  gitignoreRoot?: boolean;
+  globRoot?: boolean;
+  ignorePaths?: boolean;
+  ignoreRegExpList?: boolean;
+  ignoreWords?: boolean;
+  import?: boolean;
+  includeRegExpList?: boolean;
+  language?: boolean;
+  languageId?: boolean;
+  languageSettings?: boolean;
+  loadDefaultConfiguration?: boolean;
+  minWordLength?: boolean;
+  noConfigSearch?: boolean;
+  noSuggestDictionaries?: boolean;
+  numSuggestions?: boolean;
+  overrides?: boolean;
+  patterns?: boolean;
+  pnpFiles?: boolean;
+  reporters?: boolean;
+  suggestWords?: boolean;
+  useGitignore?: boolean;
+  usePnP?: boolean;
+  userWords?: boolean;
+  validateDirectives?: boolean;
+  words?: boolean;
+}
+```
+
+---
+
+
 
 

--- a/website/docs/configuration/auto_languages-and-dictionaries.md
+++ b/website/docs/configuration/auto_languages-and-dictionaries.md
@@ -133,7 +133,7 @@ Type
 </dt>
 <dd>
 
-`object`
+[`CustomDictionaries`](#customdictionaries)
 
 </dd>
 
@@ -271,7 +271,7 @@ Type
 </dt>
 <dd>
 
-`object[]`
+[`DictionaryDef`](#dictionarydef)[]
 
 </dd>
 
@@ -514,7 +514,40 @@ Type
 </dt>
 <dd>
 
-`object[]`
+```ts
+{
+  allowCompoundWords?: boolean;
+  caseSensitive?: boolean;
+  description?: string;
+  dictionaries?: string[];
+  dictionaryDefinitions?: DictionaryDef[];
+  enabled?: boolean;
+  flagWords?: string[];
+  id?: string;
+  ignoreRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+  ignoreWords?: string[];
+  includeRegExpList?: (string | ("Base64" | "Base64MultiLine" | "Base64SingleLine" | "CStyleComment" | "CStyleHexValue" | "CSSHexValue" | "CommitHash" | "CommitHashLink" | "Email" | "EscapeCharacters" | "HexValues" | "href" | "PhpHereDoc" | "PublicKey" | "RsaCert" | "SshRsa" | "SHA" | "HashStrings" | "SpellCheckerDisable" | "SpellCheckerDisableBlock" | "SpellCheckerDisableLine" | "SpellCheckerDisableNext" | "SpellCheckerIgnoreInDocSetting" | "string" | "UnicodeRef" | "Urls" | "UUID" | "Everything"))[];
+  languageId: (string | string[]);
+  locale?: (string | string[]);
+  name?: string;
+  noSuggestDictionaries?: string[];
+  patterns?: {
+    description?: string;
+    name: string;
+    pattern: (string | string[]);
+  }[];
+  substitutionDefinitions?: {
+    description?: string;
+    entries: [string, string][];
+    name: string;
+  }[];
+  substitutions?: ([string, string] | string)[];
+  suggestWords?: string[];
+  unknownWords?: ("report-all" | "report-simple" | "report-common-typos" | "report-flagged");
+  useIntlWordSegmentation?: boolean;
+  words?: string[];
+}[]
+```
 
 </dd>
 
@@ -834,5 +867,88 @@ _- none -_
 </dl>
 
 ---
+
+
+## Type Definitions
+
+
+### CustomDictionariesDictionary
+
+Define a custom dictionary to be included.
+
+```ts
+{
+  addWords?: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name?: string;
+  noSuggest?: boolean;
+  path?: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+}
+```
+
+---
+
+
+### CustomDictionaries
+
+```ts
+{
+  [key: string]: (boolean | CustomDictionariesDictionary);
+}
+```
+
+---
+
+
+### CustomDictionary
+
+```ts
+{
+  addWords?: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+}
+```
+
+---
+
+
+### DictionaryDef
+
+```ts
+(CustomDictionary | {
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  supportNonStrictSearches?: boolean;
+} | {
+  addWords: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+})
+```
+
+---
+
+
 
 

--- a/website/docs/configuration/auto_legacy.md
+++ b/website/docs/configuration/auto_legacy.md
@@ -104,7 +104,7 @@ Type
 </dt>
 <dd>
 
-`( object | string )[]`
+[`CustomDictionaryEntry`](#customdictionaryentry)[]
 
 </dd>
 
@@ -168,7 +168,7 @@ Type
 </dt>
 <dd>
 
-`( object | string )[]`
+[`CustomDictionaryEntry`](#customdictionaryentry)[]
 
 </dd>
 
@@ -232,7 +232,7 @@ Type
 </dt>
 <dd>
 
-`( object | string )[]`
+[`CustomDictionaryEntry`](#customdictionaryentry)[]
 
 </dd>
 
@@ -459,5 +459,52 @@ _`"Right"`_
 </dl>
 
 ---
+
+
+## Type Definitions
+
+
+### CustomDictionaryAugmentExistingDictionary
+
+```ts
+{
+  addWords?: boolean;
+  description?: string;
+  name: string;
+  noSuggest?: boolean;
+  path?: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+}
+```
+
+---
+
+
+### CustomDictionary
+
+```ts
+{
+  addWords?: boolean;
+  btrie?: string;
+  description?: string;
+  ignoreForbiddenWords?: boolean;
+  name: string;
+  noSuggest?: boolean;
+  path: string;
+  scope?: (("user" | "workspace" | "folder") | ("user" | "workspace" | "folder")[]);
+  supportNonStrictSearches?: boolean;
+}
+```
+
+---
+
+
+### CustomDictionaryEntry
+
+( [`CustomDictionaryAugmentExistingDictionary`](#customdictionaryaugmentexistingdictionary) | [`CustomDictionary`](#customdictionary) | `string` )
+
+---
+
+
 
 

--- a/website/docs/configuration/auto_reporting-and-display.md
+++ b/website/docs/configuration/auto_reporting-and-display.md
@@ -314,7 +314,7 @@ Type
 </dt>
 <dd>
 
-`object`
+[`EnabledNotifications`](#enablednotifications)
 
 </dd>
 
@@ -1090,5 +1090,25 @@ _- none -_
 </dl>
 
 ---
+
+
+## Type Definitions
+
+
+### EnabledNotifications
+
+Control which notifications are displayed.
+
+```ts
+{
+  "Average Word Length too Long"?: boolean;
+  "Lines too Long"?: boolean;
+  "Maximum Word Length Exceeded"?: boolean;
+}
+```
+
+---
+
+
 
 


### PR DESCRIPTION
This pull request refactors the config documentation generator to improve how JSON Schema types are rendered in the generated Markdown files. Instead of displaying all types as simple inline code, it now detects complex object types and renders them as formatted TypeScript type literals in fenced code blocks. Named object types are hoisted into a new "Type Definitions" section, and type references are rendered as Markdown links. This results in much clearer and more readable documentation for complex configuration schemas.

The most important changes are:

**Type Rendering and Formatting Improvements:**

* Introduced a new `TypeNode` structure and related logic to parse, resolve, and render JSON Schema types, supporting plain types, arrays, tuples, unions, references, and objects. Complex types are now rendered as formatted TypeScript code blocks, and named types are hoisted and linked. (`website/_scripts/extract-config.mts`) [[1]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679R7-R31) [[2]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679L196-R250) [[3]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679L218-R463) [[4]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679L366-R671)
* Added logic to detect and hoist named object types into a new "Type Definitions" section in the generated docs, improving clarity and reducing duplication. (`website/_scripts/extract-config.mts`) [[1]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679R44-R47) [[2]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679R126-R133) [[3]](diffhunk://#diff-e2ca157bbd1033664599dfa1e270f9405799af4ae24bbf7b9fe987f30d5a6679L115-R150)

**Documentation Output Updates:**

* Updated the generated Markdown files for configuration documentation (e.g., `auto_appearance.md`, `auto_cspell.md`) to use fenced TypeScript code blocks for object types, and to show index signatures and unions where appropriate. [[1]](diffhunk://#diff-1a4e8083aa69259bbc0748ad551af004228d40acaf89aa046592a142ffa78506L64-R75) [[2]](diffhunk://#diff-1a4e8083aa69259bbc0748ad551af004228d40acaf89aa046592a142ffa78506L130-R145) [[3]](diffhunk://#diff-1a4e8083aa69259bbc0748ad551af004228d40acaf89aa046592a142ffa78506L197-R223) [[4]](diffhunk://#diff-004b8715a12f8c8d5e03c3fa60fd9e642e8e16a325d6dfea7827faf3806ada6fL64-R70)

**Markdown Reference Handling:**

* Improved the handling of inline references and JSDoc `{@link ...}` tags in Markdown descriptions, ensuring they are rendered as inline code or links for better readability. (`website/_scripts/extract-config.mts`)

These changes make the generated configuration documentation much easier to understand, especially for complex settings and types.