### PR TITLE
chore: make when clauses easier to read

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,7 @@
 **/yarn.lock
 CHANGELOG.md
 coverage
+graphify-out
 node_modules
 package-lock.json
 packages/_integrationTests/out/

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -25,6 +25,7 @@ ignorePaths:
   - .cspell*.{json,yaml}
   - dist
   - fixtures/workspaces/**
+  - graphify-out
   - languageCodes.ts
   - package-lock.json
   - fixtures/_server/sampleSourceFiles/**
@@ -63,3 +64,4 @@ useGitignore: true
 words:
   - dbaeumer
   - esbenp
+  - graphify

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,7 @@ export default defineConfig(
             '**/scripts/ts-json-schema-generator.cjs',
             '**/temp/**',
             '**/webpack*.js',
+            'graphify-out',
             'package-lock.json',
             'packages/*/dist/**',
             'packages/*/out/**',

--- a/packages/client/src/contributes/commands.ts
+++ b/packages/client/src/contributes/commands.ts
@@ -1,4 +1,7 @@
 import type { ICommand } from '../vscode/types.ts';
+import { whenClause } from './whenClause.ts';
+
+const ts = whenClause;
 
 export const commands: ICommand[] = [
     {
@@ -55,13 +58,17 @@ export const commands: ICommand[] = [
         command: 'cSpell.enableCurrentLanguage',
         category: 'Spell',
         title: 'Enable Spell Checking Document Type',
-        enablement: 'cSpell.showLegacyCommands.enableCurrentLanguage',
+        enablement: ts`
+            cSpell.showLegacyCommands.enableCurrentLanguage
+        `,
     },
     {
         command: 'cSpell.disableCurrentLanguage',
         category: 'Spell',
         title: 'Disable Spell Checking Document Type',
-        enablement: 'cSpell.showLegacyCommands.disableCurrentLanguage',
+        enablement: ts`
+            cSpell.showLegacyCommands.disableCurrentLanguage
+        `,
     },
     {
         command: 'cSpell.enableCurrentFileType',
@@ -168,7 +175,9 @@ export const commands: ICommand[] = [
     },
     {
         command: 'cSpell.suggestSpellingCorrections',
-        enablement: 'editorTextFocus && cSpell.editorMenuContext.showSuggestions',
+        enablement: ts`
+            editorTextFocus && cSpell.editorMenuContext.showSuggestions
+        `,
         category: 'Spell',
         title: 'Spelling Suggestions...',
     },
@@ -195,19 +204,25 @@ export const commands: ICommand[] = [
     {
         command: 'cSpellRegExpTester.testRegExp',
         title: 'Test a Regular Expression on the current document.',
-        enablement: 'config.cSpell.experimental.enableRegexpView',
+        enablement: ts`
+            config.cSpell.experimental.enableRegexpView
+        `,
     },
     {
         command: 'cSpellRegExpTester.editRegExp',
         title: 'Edit',
         icon: '$(edit)',
-        enablement: 'config.cSpell.experimental.enableRegexpView',
+        enablement: ts`
+            config.cSpell.experimental.enableRegexpView
+        `,
     },
     {
         command: 'cSpell.experimental.executeDocumentSymbolProvider',
         title: 'Execute Document Symbol Provider on the current document.',
         icon: '$(code)',
-        enablement: 'config.cSpell.experimental.symbols',
+        enablement: ts`
+            config.cSpell.experimental.symbols
+        `,
     },
     {
         command: 'cSpell.autoFixSpellingIssues',
@@ -218,33 +233,43 @@ export const commands: ICommand[] = [
         command: 'cSpell.issueViewer.item.openSuggestionsForIssue',
         title: 'Show Suggestions',
         icon: '$(list-unordered)',
-        enablement: 'view == cSpellIssuesViewByIssue',
+        enablement: ts`
+            view == cSpellIssuesViewByIssue
+        `,
     },
     {
         command: 'cSpell.issueViewer.item.autoFixSpellingIssues',
         title: 'Fix issue with preferred suggestion in the current document.',
         icon: '$(lightbulb-autofix)',
-        enablement: 'view == cSpellIssuesViewByIssue',
+        enablement: ts`
+            view == cSpellIssuesViewByIssue
+        `,
     },
     {
         command: 'cSpell.issueViewer.item.addWordToDictionary',
         category: 'Spell',
         title: 'Add Word to Dictionary',
         icon: '$(book)',
-        enablement: 'view == cSpellIssuesViewByIssue',
+        enablement: ts`
+            view == cSpellIssuesViewByIssue
+        `,
     },
     {
         command: 'cSpell.issuesViewByFile.item.autoFixSpellingIssues',
         title: 'Fix issue with preferred suggestion in the current document.',
         icon: '$(lightbulb-autofix)',
-        enablement: 'view == cSpellIssuesViewByFile',
+        enablement: ts`
+            view == cSpellIssuesViewByFile
+        `,
     },
     {
         command: 'cSpell.issuesViewByFile.item.addWordToDictionary',
         category: 'Spell',
         title: 'Add Word to Dictionary',
         icon: '$(book)',
-        enablement: 'view == cSpellIssuesViewByFile',
+        enablement: ts`
+            view == cSpellIssuesViewByFile
+        `,
     },
     {
         command: 'cSpell.insertDisableNextLineDirective',
@@ -340,35 +365,45 @@ export const commands: ICommand[] = [
     },
     {
         command: 'cSpell.supportRequest',
-        enablement: 'config.cSpell.command.enableSupportRequest',
+        enablement: ts`
+            config.cSpell.command.enableSupportRequest
+        `,
         category: 'Spell',
         title: 'Request Support with the Spell Checker',
         icon: '$(github)',
     },
     {
         command: 'cSpell.reportIssue',
-        enablement: 'config.cSpell.command.reportIssue',
+        enablement: ts`
+            config.cSpell.command.reportIssue
+        `,
         category: 'Spell',
         title: 'Report an Issue with the Spell Checker',
         icon: '$(github)',
     },
     {
         command: 'cSpell.about',
-        enablement: 'config.cSpell.command.about',
+        enablement: ts`
+            config.cSpell.command.about
+        `,
         category: 'Spell',
         title: 'About the Spell Checker',
         icon: '$(home)',
     },
     {
         command: 'cSpell.releaseNotes',
-        enablement: 'config.cSpell.command.releaseNotes',
+        enablement: ts`
+            config.cSpell.command.releaseNotes
+        `,
         category: 'Spell',
         title: 'Show Spell Checker Release Notes',
         icon: '$(heart)',
     },
     {
         command: 'cSpell.sponsor',
-        enablement: 'config.cSpell.command.sponsor',
+        enablement: ts`
+            config.cSpell.command.sponsor
+        `,
         category: 'Spell',
         title: 'Sponsor the Spell Checker',
         icon: '$(heart)',

--- a/packages/client/src/contributes/menus.ts
+++ b/packages/client/src/contributes/menus.ts
@@ -1,153 +1,230 @@
 import type { ISubmenu, Menus } from '../vscode/types.ts';
+import { whenClause } from './whenClause.ts';
+
+const ts = whenClause;
 
 export const menus: Menus = {
     'editor/context': [
         {
             command: 'cSpell.suggestSpellingCorrections',
-            when: '!editorReadonly && editorTextFocus && config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions && cSpell.context.showDecorations',
+            when: ts`
+                !editorReadonly
+                && editorTextFocus
+                && config.cSpell.showSuggestionsLinkInEditorContextMenu
+                && cSpell.editorMenuContext.showSuggestions
+                && cSpell.context.showDecorations
+            `,
             group: 'A_cspell@000',
         },
         {
             submenu: 'cSpell.spelling',
             group: 'A_cspell@001',
-            when: '!editorReadonly && editorTextFocus && config.cSpell.showCommandsInEditorContextMenu',
+            when: ts`
+                !editorReadonly
+                && editorTextFocus
+                && config.cSpell.showCommandsInEditorContextMenu
+            `,
         },
         {
             command: 'cSpell.show',
-            when: 'editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && !cSpell.context.showDecorations',
+            when: ts`
+                editorTextFocus
+                && config.cSpell.showCommandsInEditorContextMenu
+                && cSpell.editorMenuContext.hasIssues
+                && !cSpell.context.showDecorations
+            `,
             group: 'A_cspell@002',
         },
         {
             command: 'cSpell.hide',
-            when: 'editorTextFocus && config.cSpell.showCommandsInEditorContextMenu && cSpell.editorMenuContext.hasIssues && cSpell.context.showDecorations',
+            when: ts`
+                editorTextFocus
+                && config.cSpell.showCommandsInEditorContextMenu
+                && cSpell.editorMenuContext.hasIssues
+                && cSpell.context.showDecorations
+            `,
             group: 'A_cspell@002',
         },
     ],
     'cSpell.spelling': [
         {
             command: 'cSpell.suggestSpellingCorrections',
-            when: 'editorTextFocus && !config.cSpell.showSuggestionsLinkInEditorContextMenu && cSpell.editorMenuContext.showSuggestions',
+            when: ts`
+                editorTextFocus
+                && !config.cSpell.showSuggestionsLinkInEditorContextMenu
+                && cSpell.editorMenuContext.showSuggestions
+            `,
             group: 'A_cspell@001',
         },
         {
             command: 'cSpell.addWordToDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToDictionary',
+            when: ts`
+                editorTextFocus
+                && cSpell.editorMenuContext.addWordToDictionary
+            `,
             group: 'A_cspell@010',
         },
         {
             command: 'cSpell.addWordToFolderDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToFolderDictionary',
+            when: ts`
+                editorTextFocus
+                && cSpell.editorMenuContext.addWordToFolderDictionary
+            `,
             group: 'A_cspell@020',
         },
         {
             command: 'cSpell.addWordToWorkspaceDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToWorkspaceDictionary',
+            when: ts`
+                editorTextFocus
+                && cSpell.editorMenuContext.addWordToWorkspaceDictionary
+            `,
             group: 'A_cspell@030',
         },
         {
             command: 'cSpell.addWordToCSpellConfig',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToCSpellConfig',
+            when: ts`
+                editorTextFocus
+                && cSpell.editorMenuContext.addWordToCSpellConfig
+            `,
             group: 'A_cspell@050',
         },
         {
             command: 'cSpell.addWordToFolderSettings',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToFolderSettings',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addWordToFolderSettings
+            `,
             group: 'A_cspell@051',
         },
         {
             command: 'cSpell.addWordToWorkspaceSettings',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToWorkspaceSettings',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addWordToWorkspaceSettings
+            `,
             group: 'A_cspell@052',
         },
         {
             command: 'cSpell.addWordToUserDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToUserDictionary',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addWordToUserDictionary
+            `,
             group: 'A_cspell@055',
         },
         {
             command: 'cSpell.addWordToUserSettings',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addWordToUserSettings',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addWordToUserSettings
+            `,
             group: 'A_cspell@056',
         },
         {
             command: 'cSpell.addIssuesToDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addIssuesToDictionary',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addIssuesToDictionary
+            `,
             group: 'A_cspell@060',
         },
         {
             command: 'cSpell.addIgnoreWord',
-            when: 'editorTextFocus && cSpell.editorMenuContext.addIgnoreWord',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.addIgnoreWord
+            `,
             group: 'A_cspell@090',
         },
         {
             command: 'cSpell.createCSpellConfig',
-            when: 'editorTextFocus && cSpell.editorMenuContext.createCSpellConfig',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.createCSpellConfig
+            `,
             group: 'B_cspell@010',
         },
         {
             command: 'cSpell.createCustomDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.createCustomDictionary',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.createCustomDictionary
+            `,
             group: 'B_cspell@020',
         },
     ],
     'cSpell.configMenu': [
         {
             command: 'cSpell.createCSpellConfig',
-            when: 'editorTextFocus && cSpell.editorMenuContext.createCSpellConfig',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.createCSpellConfig
+            `,
             group: 'A_cspell@010',
         },
         {
             command: 'cSpell.createCustomDictionary',
-            when: 'editorTextFocus && cSpell.editorMenuContext.createCustomDictionary',
+            when: ts`
+                editorTextFocus && cSpell.editorMenuContext.createCustomDictionary
+            `,
             group: 'A_cspell@070',
         },
     ],
     commandPalette: [
         {
             command: 'cSpellRegExpTester.testRegExp',
-            when: 'config.cSpell.experimental.enableRegexpView',
+            when: ts`
+                config.cSpell.experimental.enableRegexpView
+            `,
         },
         {
             command: 'cSpellRegExpTester.editRegExp',
-            when: 'view == cSpellRegExpView',
+            when: ts`
+                view == cSpellRegExpView
+            `,
         },
     ],
     'view/title': [
         {
             command: 'cSpell.show',
-            when: '!cSpell.context.showDecorations && view == cSpellIssuesViewByFile',
+            when: ts`
+                !cSpell.context.showDecorations && view == cSpellIssuesViewByFile
+            `,
             group: 'navigation',
         },
         {
             command: 'cSpell.hide',
-            when: 'cSpell.context.showDecorations && view == cSpellIssuesViewByFile',
+            when: ts`
+                cSpell.context.showDecorations && view == cSpellIssuesViewByFile
+            `,
             group: 'navigation',
         },
     ],
     'view/item/context': [
         {
             command: 'cSpellRegExpTester.editRegExp',
-            when: 'view == cSpellRegExpView && viewItem == regexp',
+            when: ts`
+                view == cSpellRegExpView && viewItem == regexp
+            `,
             group: 'inline',
         },
         {
             command: 'cSpell.issueViewer.item.autoFixSpellingIssues',
-            when: 'view == cSpellIssuesViewByIssue && viewItem == issue.hasPreferred',
+            when: ts`
+                view == cSpellIssuesViewByIssue && viewItem == issue.hasPreferred
+            `,
             group: 'inline',
         },
         {
             command: 'cSpell.issueViewer.item.addWordToDictionary',
-            when: 'view == cSpellIssuesViewByIssue && viewItem == issue',
+            when: ts`
+                view == cSpellIssuesViewByIssue && viewItem == issue
+            `,
             group: 'inline',
         },
         {
             command: 'cSpell.issuesViewByFile.item.autoFixSpellingIssues',
-            when: 'view == cSpellIssuesViewByFile && viewItem == issue.FileWithIssuesTreeItem.hasPreferred',
+            when: ts`
+                view == cSpellIssuesViewByFile && viewItem == issue.FileWithIssuesTreeItem.hasPreferred
+            `,
             group: 'inline',
         },
         {
             command: 'cSpell.issuesViewByFile.item.addWordToDictionary',
-            when: 'view == cSpellIssuesViewByFile && viewItem == issue.FileIssueTreeItem',
+            when: ts`
+                view == cSpellIssuesViewByFile && viewItem == issue.FileIssueTreeItem
+            `,
             group: 'inline',
         },
     ],

--- a/packages/client/src/contributes/whenClause.ts
+++ b/packages/client/src/contributes/whenClause.ts
@@ -1,0 +1,5 @@
+export function whenClause(template: TemplateStringsArray | string, ...values: unknown[]): string {
+    const str = typeof template === 'string' ? template : String.raw(template, ...values);
+
+    return str.replaceAll(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
This pull request introduces a utility function to improve the handling of enablement and visibility conditions for commands and menus in the VS Code client. It refactors the way these conditions are written, making them more readable and maintainable by allowing multi-line template strings that are normalized to single-line expressions. Additionally, it updates configuration and ignore files to account for a new `graphify-out` directory.

**Refactoring of command and menu condition definitions:**

* Introduced a new `whenClause` utility function in `whenClause.ts` that allows writing enablement and `when` conditions as multi-line template strings, automatically normalizing whitespace.
* Refactored all command `enablement` and menu `when` properties in `commands.ts` and `menus.ts` to use the new `whenClause` function, improving readability and maintainability. [[1]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bR2-R4) [[2]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bL58-R71) [[3]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bL171-R180) [[4]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bL198-R225) [[5]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bL221-R272) [[6]](diffhunk://#diff-6add91b5782e4877f7a3a617e416e7190416d4f76ba88146b0c57bc42360f96bL343-R406) [[7]](diffhunk://#diff-30eb58baf305fc4e519b880f76ecd3a3e3fd4079a8323e3cfc4464496158349bR2-R227)

**Configuration and ignore file updates:**

* Added `graphify-out` to `.prettierignore`, `cspell.config.yaml` ignore paths, and ESLint ignore patterns to prevent this output directory from being linted, spell-checked, or formatted. [[1]](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R18) [[2]](diffhunk://#diff-ba28c8d282ca58005aabe5a8d32713d35c2710f00219765dceae9b9895ab8277R28) [[3]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839R38)
* Added `graphify` to the custom words list in `cspell.config.yaml` to avoid false spelling errors.