### PR TITLE
fix: Use allowWordsToBeAddTo to filter Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2936,46 +2936,6 @@
         "markdownDescription": "Settings that control dictionaries and language preferences.",
         "order": 1,
         "properties": {
-          "cSpell.allowWordsToBeAddTo": {
-            "additionalProperties": false,
-            "default": {
-              "cspell": true,
-              "dictionaries": true,
-              "folder": true,
-              "user": true,
-              "workspace": true
-            },
-            "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
-            "properties": {
-              "cspell": {
-                "default": true,
-                "markdownDescription": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-                "type": "boolean"
-              },
-              "dictionaries": {
-                "default": true,
-                "markdownDescription": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-                "type": "boolean"
-              },
-              "folder": {
-                "default": true,
-                "markdownDescription": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
-                "type": "boolean"
-              },
-              "user": {
-                "default": true,
-                "markdownDescription": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
-                "type": "boolean"
-              },
-              "workspace": {
-                "default": true,
-                "markdownDescription": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
-                "type": "boolean"
-              }
-            },
-            "scope": "resource",
-            "type": "object"
-          },
           "cSpell.caseSensitive": {
             "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
             "scope": "resource",
@@ -4545,6 +4505,46 @@
         "markdownDescription": "Settings that control the menu items and actions available in the spell checker.",
         "order": 7,
         "properties": {
+          "cSpell.allowWordsToBeAddTo": {
+            "additionalProperties": false,
+            "default": {
+              "cspell": true,
+              "dictionaries": true,
+              "folder": true,
+              "user": true,
+              "workspace": true
+            },
+            "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
+            "properties": {
+              "cspell": {
+                "default": true,
+                "markdownDescription": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+                "type": "boolean"
+              },
+              "dictionaries": {
+                "default": true,
+                "markdownDescription": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+                "type": "boolean"
+              },
+              "folder": {
+                "default": true,
+                "markdownDescription": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
+                "type": "boolean"
+              },
+              "user": {
+                "default": true,
+                "markdownDescription": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
+                "type": "boolean"
+              },
+              "workspace": {
+                "default": true,
+                "markdownDescription": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
+                "type": "boolean"
+              }
+            },
+            "scope": "resource",
+            "type": "object"
+          },
           "cSpell.hideAddToDictionaryCodeActions": {
             "default": false,
             "markdownDescription": "Hide the options to add words to dictionaries or settings.",

--- a/packages/_server/spell-checker-config-web.schema.json
+++ b/packages/_server/spell-checker-config-web.schema.json
@@ -1889,7 +1889,7 @@
       ],
       "type": "object"
     },
-    "Prefix<alias-653189051-10044-10347-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-10016-10319-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.advanced.feature.useReferenceProviderRemove": {
@@ -1954,7 +1954,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-10544-10752-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-10516-10724-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.experimental.enableRegexpView": {
@@ -1984,7 +1984,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-5457-5527-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-5457-5527-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.enabled": {
@@ -1997,23 +1997,9 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-5753-6175-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-5753-6147-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
-        "cSpell.allowWordsToBeAddTo": {
-          "$ref": "#/definitions/ActionAddToTargets",
-          "default": {
-            "cspell": true,
-            "dictionaries": true,
-            "folder": true,
-            "user": true,
-            "workspace": true
-          },
-          "description": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false // Do not allow adding words to user settings } ```\n\nTo disable adding words to all VSCode settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false       // Do not allow adding words to user settings   \"workspace\": false, // Do not allow adding words to workspace settings   \"folder\": false     // Do not allow adding words to folder settings } ```",
-          "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
-          "scope": "resource",
-          "sinceVersion": "4.9.1"
-        },
         "cSpell.caseSensitive": {
           "description": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.   **Note:** Some languages like Portuguese have case sensitivity turned on by default.   You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
           "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
@@ -2126,7 +2112,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-6380-6898-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-6352-6870-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.autoFormatConfigFile": {
@@ -2279,7 +2265,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-7070-7358-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-7042-7330-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.blockCheckingWhenAverageChunkSizeGreaterThan": {
@@ -2327,9 +2313,23 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-7579-7672-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-7551-7644-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
+        "cSpell.allowWordsToBeAddTo": {
+          "$ref": "#/definitions/ActionAddToTargets",
+          "default": {
+            "cspell": true,
+            "dictionaries": true,
+            "folder": true,
+            "user": true,
+            "workspace": true
+          },
+          "description": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false // Do not allow adding words to user settings } ```\n\nTo disable adding words to all VSCode settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false       // Do not allow adding words to user settings   \"workspace\": false, // Do not allow adding words to workspace settings   \"folder\": false     // Do not allow adding words to folder settings } ```",
+          "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
+          "scope": "resource",
+          "sinceVersion": "4.9.1"
+        },
         "cSpell.hideAddToDictionaryCodeActions": {
           "default": false,
           "description": "Hide the options to add words to dictionaries or settings.",
@@ -2435,7 +2435,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-8373-8455-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-8345-8427-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.engines": {
@@ -2690,7 +2690,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-8673-9151-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-8645-9123-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.allowedSchemas": {
@@ -2902,7 +2902,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-9333-9424-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-9305-9396-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.dark": {
@@ -3185,7 +3185,7 @@
       },
       "type": "object"
     },
-    "Prefix<alias-653189051-9604-9873-653189051-0-11296,\"cSpell.\">": {
+    "Prefix<alias-653189051-9576-9845-653189051-0-11268,\"cSpell.\">": {
       "additionalProperties": false,
       "properties": {
         "cSpell.allowCompoundWords": {
@@ -3275,38 +3275,38 @@
       },
       "type": "object"
     },
-    "PrefixWithCspell<alias-653189051-10044-10347-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-10044-10347-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-10016-10319-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-10016-10319-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-10544-10752-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-10544-10752-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-10516-10724-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-10516-10724-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-5457-5527-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-5457-5527-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-5457-5527-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-5457-5527-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-5753-6175-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-5753-6175-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-5753-6147-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-5753-6147-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-6380-6898-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-6380-6898-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-6352-6870-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-6352-6870-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-7070-7358-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-7070-7358-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-7042-7330-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-7042-7330-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-7579-7672-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-7579-7672-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-7551-7644-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-7551-7644-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-8373-8455-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-8373-8455-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-8345-8427-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-8345-8427-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-8673-9151-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-8673-9151-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-8645-9123-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-8645-9123-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-9333-9424-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-9333-9424-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-9305-9396-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-9305-9396-653189051-0-11268%2C%22cSpell.%22%3E"
     },
-    "PrefixWithCspell<alias-653189051-9604-9873-653189051-0-11296>": {
-      "$ref": "#/definitions/Prefix%3Calias-653189051-9604-9873-653189051-0-11296%2C%22cSpell.%22%3E"
+    "PrefixWithCspell<alias-653189051-9576-9845-653189051-0-11268>": {
+      "$ref": "#/definitions/Prefix%3Calias-653189051-9576-9845-653189051-0-11268%2C%22cSpell.%22%3E"
     },
     "RegExpList": {
       "items": {
@@ -3325,61 +3325,61 @@
           "$ref": "#/definitions/VSConfigAdvanced"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-9333-9424-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-9305-9396-653189051-0-11268%3E",
           "description": "Settings that control the appearance of the spell checker.",
           "order": 6,
           "title": "Appearance"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8373-8455-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8345-8427-653189051-0-11268%3E",
           "description": "Settings related to CSpell Command Line Tool.",
           "order": 5,
           "title": "CSpell"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-10544-10752-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-10516-10724-653189051-0-11268%3E",
           "description": "Experimental settings that may change or be removed in the future.",
           "order": 19,
           "title": "Experimental"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8673-9151-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-8645-9123-653189051-0-11268%3E",
           "description": "Settings that control which files and folders are spell checked.",
           "order": 3,
           "title": "Files, Folders, and Workspaces"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5753-6175-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5753-6147-653189051-0-11268%3E",
           "description": "Settings that control dictionaries and language preferences.",
           "order": 1,
           "title": "Languages and Dictionaries"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-9604-9873-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-9576-9845-653189051-0-11268%3E",
           "description": "Legacy settings that have been deprecated or are not commonly used.",
           "order": 20,
           "title": "Legacy"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7579-7672-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7551-7644-653189051-0-11268%3E",
           "description": "Settings that control the menu items and actions available in the spell checker.",
           "order": 7,
           "title": "Menus and Actions"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7070-7358-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-7042-7330-653189051-0-11268%3E",
           "description": "Settings that control the performance of the spell checker.",
           "order": 4,
           "title": "Performance"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-6380-6898-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-6352-6870-653189051-0-11268%3E",
           "description": "Settings that control how the spell checker reports and displays errors.",
           "order": 2,
           "title": "Reporting and Display"
         },
         {
-          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5457-5527-653189051-0-11296%3E",
+          "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-5457-5527-653189051-0-11268%3E",
           "description": "Settings that control the behavior of the spell checker.",
           "order": 0,
           "title": "Code Spell Checker"
@@ -3399,7 +3399,7 @@
       "type": "string"
     },
     "VSConfigAdvanced": {
-      "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-10044-10347-653189051-0-11296%3E",
+      "$ref": "#/definitions/PrefixWithCspell%3Calias-653189051-10016-10319-653189051-0-11268%3E",
       "description": "Advanced settings that are not commonly used.",
       "order": 18,
       "title": "Advanced"

--- a/packages/_server/spell-checker-config.schema.json
+++ b/packages/_server/spell-checker-config.schema.json
@@ -2561,53 +2561,6 @@
       "description": "Settings that control dictionaries and language preferences.",
       "order": 1,
       "properties": {
-        "cSpell.allowWordsToBeAddTo": {
-          "additionalProperties": false,
-          "default": {
-            "cspell": true,
-            "dictionaries": true,
-            "folder": true,
-            "user": true,
-            "workspace": true
-          },
-          "description": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false // Do not allow adding words to user settings } ```\n\nTo disable adding words to all VSCode settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false       // Do not allow adding words to user settings   \"workspace\": false, // Do not allow adding words to workspace settings   \"folder\": false     // Do not allow adding words to folder settings } ```",
-          "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
-          "properties": {
-            "cspell": {
-              "default": true,
-              "description": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-              "markdownDescription": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-              "type": "boolean"
-            },
-            "dictionaries": {
-              "default": true,
-              "description": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-              "markdownDescription": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
-              "type": "boolean"
-            },
-            "folder": {
-              "default": true,
-              "description": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
-              "markdownDescription": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
-              "type": "boolean"
-            },
-            "user": {
-              "default": true,
-              "description": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
-              "markdownDescription": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
-              "type": "boolean"
-            },
-            "workspace": {
-              "default": true,
-              "description": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
-              "markdownDescription": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
-              "type": "boolean"
-            }
-          },
-          "scope": "resource",
-          "sinceVersion": "4.9.1",
-          "type": "object"
-        },
         "cSpell.caseSensitive": {
           "description": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.   Incorrect accents or partially missing accents will be marked as incorrect.   **Note:** Some languages like Portuguese have case sensitivity turned on by default.   You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
           "markdownDescription": "Determines if words must match case and accent rules.\n\n- `false` - Case is ignored and accents can be missing on the entire word.\n  Incorrect accents or partially missing accents will be marked as incorrect.\n  **Note:** Some languages like Portuguese have case sensitivity turned on by default.\n  You must use `#cSpell.languageSettings#` to turn it off.\n- `true` - Case and accents are enforced by default.",
@@ -4420,6 +4373,53 @@
       "description": "Settings that control the menu items and actions available in the spell checker.",
       "order": 7,
       "properties": {
+        "cSpell.allowWordsToBeAddTo": {
+          "additionalProperties": false,
+          "default": {
+            "cspell": true,
+            "dictionaries": true,
+            "folder": true,
+            "user": true,
+            "workspace": true
+          },
+          "description": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false // Do not allow adding words to user settings } ```\n\nTo disable adding words to all VSCode settings:\n\n```js \"cSpell.addWordTo\": {   \"user\": false       // Do not allow adding words to user settings   \"workspace\": false, // Do not allow adding words to workspace settings   \"folder\": false     // Do not allow adding words to folder settings } ```",
+          "markdownDescription": "Specify where words can be added to. This setting is used to control the \"Add to Dictionary\" code actions.\n\n**Examples**\n\nTo disable adding words to user settings, but allow adding words to workspace settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false // Do not allow adding words to user settings\n}\n```\n\nTo disable adding words to all VSCode settings:\n\n```js\n\"cSpell.addWordTo\": {\n  \"user\": false       // Do not allow adding words to user settings\n  \"workspace\": false, // Do not allow adding words to workspace settings\n  \"folder\": false     // Do not allow adding words to folder settings\n}\n```",
+          "properties": {
+            "cspell": {
+              "default": true,
+              "description": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+              "markdownDescription": "Allow adding words cspell configuration file settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+              "type": "boolean"
+            },
+            "dictionaries": {
+              "default": true,
+              "description": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+              "markdownDescription": "Allow adding words user defined dictionaries settings.\n- `true` - allow add to cspell settings\n- `false` - never enable add to cspell settings",
+              "type": "boolean"
+            },
+            "folder": {
+              "default": true,
+              "description": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
+              "markdownDescription": "Allow adding words to folder settings.\n- `true` - allow add to folder settings\n- `false` - never enable add to folder settings",
+              "type": "boolean"
+            },
+            "user": {
+              "default": true,
+              "description": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
+              "markdownDescription": "Allow adding words to user settings.\n- `true` - allow add to user settings\n- `false` - never enable add to user settings",
+              "type": "boolean"
+            },
+            "workspace": {
+              "default": true,
+              "description": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
+              "markdownDescription": "Allow adding words to workspace settings.\n- `true` - allow  add to workspace settings\n- `false` - never enable add to workspace settings",
+              "type": "boolean"
+            }
+          },
+          "scope": "resource",
+          "sinceVersion": "4.9.1",
+          "type": "object"
+        },
         "cSpell.hideAddToDictionaryCodeActions": {
           "default": false,
           "description": "Hide the options to add words to dictionaries or settings.",

--- a/packages/_server/src/config/configTargetsHelper.mts
+++ b/packages/_server/src/config/configTargetsHelper.mts
@@ -13,6 +13,7 @@ import type {
 } from './configTargets.mjs';
 import { ConfigKinds, ConfigScopes, weight } from './configTargets.mjs';
 import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
+import type { ActionAddToTargets } from './cspellConfig/SpellCheckerSettings.mjs';
 import type { CSpellSettingsWithFileSource } from './documentSettings.mjs';
 import { extractCSpellFileConfigurations, extractTargetDictionaries, filterExistingCSpellFileConfigurations } from './documentSettings.mjs';
 
@@ -27,6 +28,7 @@ export async function calculateConfigTargets(
         const href = toFileUri(filename).toString();
         return found.has(href);
     }
+    const allowedTargets = settings.allowWordsToBeAddTo || {};
     const targets: ConfigTarget[] = [];
     const possibleSources = extractCSpellFileConfigurations(settings).filter((cfg) => !cfg.readonly);
     const sources = configFilesFound
@@ -34,14 +36,17 @@ export async function calculateConfigTargets(
         : await filterExistingCSpellFileConfigurations(possibleSources);
     const dictionaries = extractTargetDictionaries(settings);
 
-    targets.push(...workspaceConfigToTargets(workspaceConfig));
-    targets.push(...cspellToTargets(sources));
-    targets.push(...dictionariesToTargets(dictionaries));
+    targets.push(...workspaceConfigToTargets(allowedTargets, workspaceConfig));
+    targets.push(...cspellToTargets(allowedTargets, sources));
+    targets.push(...dictionariesToTargets(allowedTargets, dictionaries));
 
     return sortTargets(targets);
 }
 
-function* workspaceConfigToTargets(workspaceConfig: WorkspaceConfigForDocument): Generator<ConfigTargetVSCode> {
+function* workspaceConfigToTargets(
+    addToTargets: ActionAddToTargets,
+    workspaceConfig: WorkspaceConfigForDocument,
+): Generator<ConfigTargetVSCode> {
     function toTarget(scope: ConfigScopeVScode): ConfigTargetVSCode {
         return {
             kind: ConfigKinds.Vscode,
@@ -56,15 +61,17 @@ function* workspaceConfigToTargets(workspaceConfig: WorkspaceConfigForDocument):
         };
     }
 
-    yield toTarget(ConfigScopes.User);
+    if (addToTargets.user) {
+        yield toTarget(ConfigScopes.User);
+    }
 
     // If it is part of a workspace folder, it is either a multi-root or single root workspace
-    if (workspaceConfig.workspaceFolder) {
+    if (addToTargets.workspace && workspaceConfig.workspaceFolder) {
         yield toTarget(ConfigScopes.Workspace);
     }
 
     // If there is a workspace file, give the folder option.
-    if (workspaceConfig.workspaceFile) {
+    if (addToTargets.folder && workspaceConfig.workspaceFile) {
         yield toTarget(ConfigScopes.Folder);
     }
 }
@@ -73,7 +80,7 @@ function basename(path: string): string {
     return path.split(/[/\\]/g).slice(-1).join('');
 }
 
-function cspellToTargets(sources: CSpellSettingsWithFileSource[]): ConfigTargetCSpell[] {
+function cspellToTargets(addToTargets: ActionAddToTargets, sources: CSpellSettingsWithFileSource[]): ConfigTargetCSpell[] {
     function toTarget(cfg: CSpellSettingsWithFileSource, index: number): ConfigTargetCSpell {
         return {
             kind: ConfigKinds.Cspell,
@@ -87,10 +94,10 @@ function cspellToTargets(sources: CSpellSettingsWithFileSource[]): ConfigTargetC
             sortKey: index,
         };
     }
-    return sources.map(toTarget);
+    return addToTargets.cspell ? sources.map(toTarget) : [];
 }
 
-function dictionariesToTargets(dicts: DictionaryDefinitionCustom[]): ConfigTargetDictionary[] {
+function dictionariesToTargets(addToTargets: ActionAddToTargets, dicts: DictionaryDefinitionCustom[]): ConfigTargetDictionary[] {
     function* dictToT(d: DictionaryDefinitionCustom): Generator<ConfigTargetDictionary> {
         const scopeMask = extractDictScopeFromCustomDictionary(d);
         const base: ConfigTargetDictionary = {
@@ -105,7 +112,7 @@ function dictionariesToTargets(dicts: DictionaryDefinitionCustom[]): ConfigTarge
         if (scopeMask & scopeMaskMap.unknown) yield { ...base, scope: ConfigScopes.Unknown };
     }
 
-    return dicts.map(dictToT).flatMap((x) => [...x]);
+    return addToTargets.dictionaries ? dicts.map(dictToT).flatMap((x) => [...x]) : [];
 }
 
 type DictScopeMapKnown = Record<ConfigScope, number>;

--- a/packages/_server/src/config/configTargetsHelper.test.mts
+++ b/packages/_server/src/config/configTargetsHelper.test.mts
@@ -1,5 +1,4 @@
 import { mustBeDefined } from '@internal/common-utils/util';
-import type { CSpellUserSettings } from 'cspell-lib';
 import { searchForConfig } from 'cspell-lib';
 import * as Path from 'path';
 import { describe, expect, test } from 'vitest';
@@ -8,6 +7,7 @@ import { URI } from 'vscode-uri';
 import type { WorkspaceConfigForDocument } from '../api.js';
 import { __testing__, calculateConfigTargets } from './configTargetsHelper.mjs';
 import type { DictionaryDef } from './cspellConfig/CustomDictionary.mjs';
+import type { CSpellUserAndExtensionSettings } from './cspellConfig/index.mjs';
 import { extractCSpellFileConfigurations, extractTargetDictionaries } from './documentSettings.mjs';
 
 const { workspaceConfigToTargets, cspellToTargets, dictionariesToTargets, sortTargets } = __testing__;
@@ -27,7 +27,7 @@ describe('Validate configTargetsHelper', () => {
             },
             ignoreWords: {},
         };
-        const r = [...workspaceConfigToTargets(wConfig)];
+        const r = [...workspaceConfigToTargets({ user: true, workspace: true, folder: true }, wConfig)];
         expect(r).toEqual([
             oc({
                 kind: 'vscode',
@@ -44,6 +44,16 @@ describe('Validate configTargetsHelper', () => {
                 has: { words: undefined, ignoreWords: undefined },
             }),
         ]);
+        expect([...workspaceConfigToTargets({ user: false, workspace: true, folder: true }, wConfig)]).toEqual([
+            oc({
+                kind: 'vscode',
+                scope: 'workspace',
+                name: 'Workspace',
+                docUri: expect.stringContaining('file:'),
+                has: { words: undefined, ignoreWords: undefined },
+            }),
+        ]);
+        expect([...workspaceConfigToTargets({ user: false, workspace: false, folder: true }, wConfig)]).toEqual([]);
     });
 
     test('workspaceConfigToTargets in multi root workspace', () => {
@@ -59,7 +69,7 @@ describe('Validate configTargetsHelper', () => {
                 folder: true,
             },
         };
-        const r = [...workspaceConfigToTargets(wConfig)];
+        const r = [...workspaceConfigToTargets({ user: true, workspace: true, folder: true }, wConfig)];
         expect(r).toEqual([
             oc({
                 kind: 'vscode',
@@ -83,6 +93,16 @@ describe('Validate configTargetsHelper', () => {
                 has: { words: true, ignoreWords: true },
             }),
         ]);
+        expect([...workspaceConfigToTargets({ workspace: true }, wConfig)]).toEqual([
+            oc({
+                kind: 'vscode',
+                scope: 'workspace',
+                name: 'Workspace',
+                docUri: wConfig.uri,
+                has: { words: undefined, ignoreWords: undefined },
+            }),
+        ]);
+        expect([...workspaceConfigToTargets({ workspace: false }, wConfig)]).toEqual([]);
     });
 
     test('workspaceConfigToTargets with no workspace', () => {
@@ -95,7 +115,7 @@ describe('Validate configTargetsHelper', () => {
             },
             ignoreWords: {},
         };
-        const r = [...workspaceConfigToTargets(wConfig)];
+        const r = [...workspaceConfigToTargets({ user: true, workspace: true, folder: true }, wConfig)];
         expect(r).toEqual([
             oc({
                 kind: 'vscode',
@@ -105,12 +125,13 @@ describe('Validate configTargetsHelper', () => {
                 has: { words: true, ignoreWords: undefined },
             }),
         ]);
+        expect([...workspaceConfigToTargets({ user: false }, wConfig)]).toEqual([]);
     });
 
     test('cspellToTargets', async () => {
         const cfg = mustBeDefined(await searchForConfig(__dirname));
         const sources = extractCSpellFileConfigurations(cfg);
-        const r = cspellToTargets(sources);
+        const r = cspellToTargets({ cspell: true }, sources);
         expect(r).toEqual([
             oc({
                 kind: 'cspell',
@@ -127,6 +148,7 @@ describe('Validate configTargetsHelper', () => {
                 has: { words: true, ignoreWords: true },
             }),
         ]);
+        expect(cspellToTargets({ cspell: false }, sources)).toEqual([]);
     });
 
     test('dictionariesToTargets', async () => {
@@ -144,7 +166,7 @@ describe('Validate configTargetsHelper', () => {
                 scope: 'user',
             },
         ]);
-        const r = sortTargets(dictionariesToTargets(dictionaries));
+        const r = sortTargets(dictionariesToTargets({ dictionaries: true }, dictionaries));
         expect(r).toEqual([
             oc({
                 kind: 'dictionary',
@@ -165,6 +187,7 @@ describe('Validate configTargetsHelper', () => {
                 dictionaryUri: expect.stringContaining('user-words.txt'),
             }),
         ]);
+        expect(sortTargets(dictionariesToTargets({ dictionaries: false }, dictionaries))).toEqual([]);
     });
 
     test('calculateConfigTargets user', async () => {
@@ -178,7 +201,14 @@ describe('Validate configTargetsHelper', () => {
             ignoreWords: {},
         };
         const cfg = mustBeDefined(await searchForConfig(__dirname));
-        const settings = { ...cfg };
+        const allowWordsToBeAddTo: CSpellUserAndExtensionSettings['allowWordsToBeAddTo'] = {
+            cspell: true,
+            user: true,
+            workspace: true,
+            dictionaries: true,
+        };
+
+        const settings = { ...cfg, allowWordsToBeAddTo };
         const r = await calculateConfigTargets(settings, wConfig);
         expect(r).toEqual([
             oc({
@@ -231,7 +261,12 @@ describe('Validate configTargetsHelper', () => {
         const cfg = mustBeDefined(await searchForConfig(__dirname));
         const defs: DictionaryDef[] = [cd('custom-words', 'path/to/custom-words.txt', false)];
         const dictionaries: string[] = (cfg.dictionaries || []).concat('custom-words');
-        const settings: CSpellUserSettings = { ...cfg, dictionaryDefinitions: defs, dictionaries };
+        const allowWordsToBeAddTo: CSpellUserAndExtensionSettings['allowWordsToBeAddTo'] = {
+            cspell: true,
+            user: true,
+            workspace: true,
+        };
+        const settings: CSpellUserAndExtensionSettings = { ...cfg, dictionaryDefinitions: defs, dictionaries, allowWordsToBeAddTo };
         const r = (await calculateConfigTargets(settings, wConfig)).sort(
             (a, b) => col.compare(a.kind, b.kind) || col.compare(a.name, b.name),
         );

--- a/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
+++ b/packages/_server/src/config/cspellConfig/SpellCheckerSettings.mts
@@ -237,42 +237,6 @@ export interface SpellCheckerUserSettings {
     spellCheckOnlyWorkspaceFiles?: boolean;
 
     /**
-     * Specify where words can be added to. This setting is used to control the "Add to Dictionary" code actions.
-     *
-     * **Examples**
-     *
-     * To disable adding words to user settings, but allow adding words to workspace settings:
-     *
-     * ```js
-     * "cSpell.addWordTo": {
-     *   "user": false // Do not allow adding words to user settings
-     * }
-     * ```
-     *
-     * To disable adding words to all VSCode settings:
-     *
-     * ```js
-     * "cSpell.addWordTo": {
-     *   "user": false       // Do not allow adding words to user settings
-     *   "workspace": false, // Do not allow adding words to workspace settings
-     *   "folder": false     // Do not allow adding words to folder settings
-     * }
-     * ```
-     *
-     * @default {
-     *   folder: true,
-     *   workspace: true,
-     *   user: true,
-     *   cspell: true,
-     *   dictionaries: true
-     * }
-     *
-     * @sinceVersion 4.9.1
-     * @scope resource
-     */
-    allowWordsToBeAddTo?: ActionAddToTargets;
-
-    /**
      * Specify if fields from `.vscode/settings.json` are passed to the spell checker.
      * This only applies when there is a CSpell configuration file in the workspace.
      *
@@ -361,6 +325,42 @@ export interface SpellCheckerUserSettings {
 }
 
 export interface MenusAndActions {
+    /**
+     * Specify where words can be added to. This setting is used to control the "Add to Dictionary" code actions.
+     *
+     * **Examples**
+     *
+     * To disable adding words to user settings, but allow adding words to workspace settings:
+     *
+     * ```js
+     * "cSpell.addWordTo": {
+     *   "user": false // Do not allow adding words to user settings
+     * }
+     * ```
+     *
+     * To disable adding words to all VSCode settings:
+     *
+     * ```js
+     * "cSpell.addWordTo": {
+     *   "user": false       // Do not allow adding words to user settings
+     *   "workspace": false, // Do not allow adding words to workspace settings
+     *   "folder": false     // Do not allow adding words to folder settings
+     * }
+     * ```
+     *
+     * @default {
+     *   folder: true,
+     *   workspace: true,
+     *   user: true,
+     *   cspell: true,
+     *   dictionaries: true
+     * }
+     *
+     * @sinceVersion 4.9.1
+     * @scope resource
+     */
+    allowWordsToBeAddTo?: ActionAddToTargets;
+
     /**
      * Hide the options to add words to dictionaries or settings.
      * @scope resource

--- a/packages/_server/src/config/cspellConfig/cspellConfig.mts
+++ b/packages/_server/src/config/cspellConfig/cspellConfig.mts
@@ -178,7 +178,6 @@ type _VSConfigRoot = Pick<SpellCheckerSettingsVSCodeBase, 'enabled'>;
 type VSConfigLanguageAndDictionaries = PrefixWithCspell<_VSConfigLanguageAndDictionaries>;
 type _VSConfigLanguageAndDictionaries = Pick<
     SpellCheckerSettingsVSCodeBase,
-    | 'allowWordsToBeAddTo'
     | 'caseSensitive'
     | 'customDictionaries'
     | 'dictionaries'


### PR DESCRIPTION
This pull request relocates the `cSpell.allowWordsToBeAddTo` configuration property within both the `package.json` and the web schema definition. The property is moved from the general dictionary and language preferences section to the menu items and actions section, making its configuration context more appropriate. Additionally, the schema references and alias names are updated throughout the web schema file to reflect this structural change.

**Configuration property relocation:**

* Moved the `cSpell.allowWordsToBeAddTo` property from the dictionary/language preferences section to the menu items and actions section in `package.json`, ensuring the setting appears in a more relevant context for users configuring menu actions. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2939-L2978) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4508-R4547)
* Updated the web schema (`spell-checker-config-web.schema.json`) to remove the property from its previous location and add it to the new section, maintaining consistency with the `package.json` changes. [[1]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2000-L2016) [[2]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2330-R2332)

**Schema maintenance:**

* Adjusted all relevant schema alias names and `$ref` pointers in `spell-checker-config-web.schema.json` to match the new structure and ensure schema integrity. [[1]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL1892-R1892) [[2]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL1957-R1957) [[3]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL1987-R1987) [[4]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2129-R2115) [[5]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2282-R2268) [[6]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2438-R2438) [[7]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2693-R2693) [[8]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL2905-R2905) [[9]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL3188-R3188) [[10]](diffhunk://#diff-dae4a6a2463147aed63ba619e9ce38297dc6382e1c1211ed4c8e6484cf78d4feL3278-R3309)