### PR TITLE
chore: Update set-prerelease configuration

### DIFF
--- a/.github/workflows/set-prerelease.yml
+++ b/.github/workflows/set-prerelease.yml
@@ -44,7 +44,9 @@ jobs:
           commit-message: 'chore: Set Prerelease Mode to `${{ inputs.prerelease }}`'
           branch: ${{ env.BRANCH_NAME }}
           base: main
-          title: 'chore: Set Prerelease Mode to `${{ inputs.prerelease }}`'
+          title: "${{ inputs.prerelease == 'true' && 'chore: Set Prerelease Mode to true' || 'fix: Prepare for Release' }}"
           body: |
+            # Prerelease Mode
+
             Set Prerelease Mode to `${{ inputs.prerelease }}`
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the pull request title logic in the `.github/workflows/set-prerelease.yml` workflow to make it clearer whether the repository is being set to prerelease mode or prepared for a release. It also adds a heading to the pull request body for better readability.

Workflow improvements:

* Updated the `title` field in the workflow to dynamically set the pull request title to either "chore: Set Prerelease Mode to true" or "fix: Prepare for Release" based on the value of the `prerelease` input, making the intent of the PR clearer.
* Added a `# Prerelease Mode` heading to the pull request body for improved clarity and structure.