### PR TITLE
chore: Update set-prerelease.yml

### DIFF
--- a/.github/workflows/set-prerelease.yml
+++ b/.github/workflows/set-prerelease.yml
@@ -44,7 +44,7 @@ jobs:
           commit-message: 'chore: Set Prerelease Mode to `${{ inputs.prerelease }}`'
           branch: ${{ env.BRANCH_NAME }}
           base: main
-          title: "${{ inputs.prerelease == 'true' && 'chore: Set Prerelease Mode to true' || 'fix: Prepare for Release' }}"
+          title: "${{ (inputs.prerelease == 'false' || inputs.prerelease == false) && 'fix: Prepare for Release' || 'chore: Set Prerelease Mode to true'  }}"
           body: |
             # Prerelease Mode
 


### PR DESCRIPTION
This pull request makes a small update to the workflow file `.github/workflows/set-prerelease.yml`, specifically improving the logic that sets the pull request title based on the `prerelease` input.

* Updated the conditional expression for the pull request title to correctly handle both string and boolean `false` values for the `prerelease` input, ensuring that the title is set to "fix: Prepare for Release" when `prerelease` is false, and "chore: Set Prerelease Mode to true" otherwise.